### PR TITLE
fix: API improvements, second round

### DIFF
--- a/docs-site/src/content/docs/api/index.mdx
+++ b/docs-site/src/content/docs/api/index.mdx
@@ -54,6 +54,7 @@ Creates a new SwarmIdClient instance.
 | `options.iframeOrigin` | `string` | Yes | The origin URL where the Swarm ID proxy iframe is hosted |
 | `options.iframePath` | `string` | No | The path to the proxy iframe (defaults to `"/proxy"`) |
 | `options.timeout` | `number` | No | Request timeout in milliseconds (defaults to `30000`) |
+| `options.initializationTimeout` | `number` | No | Initialization timeout in milliseconds (defaults to `30000`) |
 | `options.onAuthChange` | `(authenticated: boolean) => void` | No | Callback function invoked when authentication status changes |
 | `options.popupMode` | `"popup" \| "window"` | No | How to display the authentication popup (defaults to `"window"`) |
 | `options.metadata` | `AppMetadata` | Yes | Application metadata shown to users during authentication |
@@ -97,7 +98,7 @@ This method must be called before using any other client methods. It creates a h
 **Throws:**
 - `Error` if the client is already initialized
 - `Error` if the iframe fails to load
-- `Error` if the proxy does not respond within the timeout period (30 seconds)
+- `Error` if the proxy does not respond within the initialization timeout period (configurable via `initializationTimeout`, defaults to 30 seconds)
 - `Error` if origin validation fails on the proxy side
 
 **Example:**
@@ -379,11 +380,9 @@ if (info.canUpload) {
 
 Checks whether the Bee node is reachable.
 
-**Returns:** `Promise<boolean>` - `true` if the Bee node is reachable, `false` otherwise
+This method never throws an exception. If the client is not initialized, the request times out, or any other error occurs, it returns `false`.
 
-**Throws:**
-- `Error` if the client is not initialized
-- `Error` if the request times out
+**Returns:** `Promise<boolean>` - `true` if the Bee node is reachable, `false` otherwise
 
 **Example:**
 

--- a/lib/src/swarm-id-client.ts
+++ b/lib/src/swarm-id-client.ts
@@ -20,6 +20,9 @@ import {
 } from "./types"
 import { buildAuthUrl } from "./utils/url"
 
+const DEFAULT_TIMEOUT_MS = 30000
+const DEFAULT_INITIALIZATION_TIMEOUT_MS = 30000
+
 /**
  * Main client library for integrating Swarm ID authentication and storage capabilities
  * into web applications.
@@ -55,6 +58,7 @@ export class SwarmIdClient {
   private iframeOrigin: string
   private iframePath: string
   private timeout: number
+  private initializationTimeout: number
   private onAuthChange?: (authenticated: boolean) => void
   private popupMode: "popup" | "window"
   private metadata: AppMetadata
@@ -105,7 +109,9 @@ export class SwarmIdClient {
   constructor(options: ClientOptions) {
     this.iframeOrigin = options.iframeOrigin
     this.iframePath = options.iframePath || "/proxy"
-    this.timeout = options.timeout || 30000 // 30 seconds default
+    this.timeout = options.timeout ?? DEFAULT_TIMEOUT_MS
+    this.initializationTimeout =
+      options.initializationTimeout ?? DEFAULT_INITIALIZATION_TIMEOUT_MS
     this.onAuthChange = options.onAuthChange
     this.popupMode = options.popupMode || "window"
     this.metadata = options.metadata
@@ -124,14 +130,14 @@ export class SwarmIdClient {
       this.readyResolve = resolve
       this.readyReject = reject
 
-      // Timeout after 10 seconds if proxy doesn't respond
+      // Timeout if proxy doesn't respond
       setTimeout(() => {
         reject(
           new Error(
-            "Proxy initialization timeout - proxy did not respond within 10 seconds",
+            `Proxy initialization timeout - proxy did not respond within ${this.initializationTimeout}ms`,
           ),
         )
-      }, 30000)
+      }, this.initializationTimeout)
     })
 
     // Create promise for proxyInitialized message
@@ -139,16 +145,16 @@ export class SwarmIdClient {
       this.proxyInitializedResolve = resolve
       this.proxyInitializedReject = reject
 
-      // Timeout if proxy doesn't send proxyInitialized within 10 seconds
+      // Timeout if proxy doesn't send proxyInitialized
       setTimeout(() => {
         if (this.proxyInitializedReject) {
           this.proxyInitializedReject(
             new Error(
-              "Proxy initialization timeout - proxy did not signal readiness",
+              `Proxy initialization timeout - proxy did not signal readiness within ${this.initializationTimeout}ms`,
             ),
           )
         }
-      }, 30000)
+      }, this.initializationTimeout)
     })
 
     this.setupMessageListener()
@@ -674,9 +680,10 @@ export class SwarmIdClient {
   /**
    * Checks whether the Bee node is reachable.
    *
+   * This method never throws an exception. If the client is not initialized,
+   * the request times out, or any other error occurs, it returns `false`.
+   *
    * @returns A promise resolving to `true` if the Bee node is reachable, `false` otherwise
-   * @throws {Error} If the client is not initialized
-   * @throws {Error} If the request times out
    *
    * @example
    * ```typescript
@@ -689,19 +696,23 @@ export class SwarmIdClient {
    * ```
    */
   async isBeeConnected(): Promise<boolean> {
-    this.ensureReady()
-    const requestId = this.generateRequestId()
+    try {
+      this.ensureReady()
+      const requestId = this.generateRequestId()
 
-    const response = await this.sendRequest<{
-      type: "isConnectedResponse"
-      requestId: string
-      connected: boolean
-    }>({
-      type: "isConnected",
-      requestId,
-    })
+      const response = await this.sendRequest<{
+        type: "isConnectedResponse"
+        requestId: string
+        connected: boolean
+      }>({
+        type: "isConnected",
+        requestId,
+      })
 
-    return response.connected
+      return response.connected
+    } catch {
+      return false
+    }
   }
 
   // ============================================================================

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -592,6 +592,7 @@ export interface ClientOptions {
   iframeOrigin: string
   iframePath?: string
   timeout?: number
+  initializationTimeout?: number
   onAuthChange?: (authenticated: boolean) => void
   popupMode?: "popup" | "window" // Default: 'window'
   metadata: AppMetadata


### PR DESCRIPTION
- Updated `docs-site`
- Change `isBeeConnected` to never throw
- Added optional `initializationTimeout` to `ClientOptions`