### PR TITLE
fix: identity address in connection info

### DIFF
--- a/lib/src/swarm-id-proxy.ts
+++ b/lib/src/swarm-id-proxy.ts
@@ -1078,7 +1078,7 @@ export class SwarmIdProxy {
               identity = {
                 id: foundIdentity.id,
                 name: foundIdentity.name,
-                address: foundIdentity.accountId.toHex(),
+                address: foundIdentity.id,
               }
             }
           }


### PR DESCRIPTION
The connection info returned the address of the account, not the address of the identity. This PR fixes that.