### PR TITLE
refactor: use AddressSchema for indentity.id

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -22,6 +22,9 @@ export {
   utils,
 } from "./utils/key-derivation"
 
+// Hex address utility
+export { hexAddress } from "./utils/hex"
+
 // Batch utilization tracking
 export {
   initializeBatchUtilization,
@@ -208,9 +211,6 @@ export type {
   UploadProgress,
   RequestOptions,
   DownloadOptions,
-  Reference,
-  BatchId,
-  Address,
   ParentToIframeMessage,
   IframeToParentMessage,
   PopupToIframeMessage,
@@ -282,6 +282,29 @@ export {
   NetworkSettingsSchemaV1,
 } from "./schemas"
 
+// Base validation schemas and types
+export {
+  ReferenceSchema,
+  BatchIdSchema,
+  AddressSchema,
+  PrivateKeySchema,
+  EncryptionKeySchema,
+  IdentifierSchema,
+  SignatureSchema,
+  TimestampSchema,
+  FeedIndexSchema,
+} from "./schemas"
+export type {
+  Reference,
+  BatchId,
+  Address,
+  PrivateKey,
+  Identifier,
+  Signature,
+  Timestamp,
+  FeedIndex,
+} from "./schemas"
+
 // Batch utilization types
 export type {
   BatchUtilizationState,
@@ -310,9 +333,6 @@ export type {
 
 // Schema exports (for validation)
 export {
-  ReferenceSchema,
-  BatchIdSchema,
-  AddressSchema,
   UploadOptionsSchema,
   ActUploadOptionsSchema,
   RequestOptionsSchema,

--- a/lib/src/schemas.ts
+++ b/lib/src/schemas.ts
@@ -7,7 +7,12 @@
  */
 
 import { z } from "zod"
-import { EthAddress, BatchId, Bytes, PrivateKey } from "@ethersphere/bee-js"
+import {
+  EthAddress,
+  BatchId as BeeBatchId,
+  Bytes,
+  PrivateKey as BeePrivateKey,
+} from "@ethersphere/bee-js"
 
 // ============================================================================
 // Network Settings Constants
@@ -15,6 +20,46 @@ import { EthAddress, BatchId, Bytes, PrivateKey } from "@ethersphere/bee-js"
 
 export const DEFAULT_BEE_NODE_URL = "https://api.gateway.ethswarm.org/"
 export const DEFAULT_GNOSIS_RPC_URL = "https://xdai.fairdatasociety.org/"
+
+// ============================================================================
+// Base Validation Schemas (hex strings, no transforms)
+// ============================================================================
+
+const hexString = (length: number) =>
+  z.string().regex(new RegExp(`^[0-9a-fA-F]{${length}}$`), {
+    message: `Must be a ${length}-character hex string`,
+  })
+
+// Support both regular (32-byte = 64 hex chars) and encrypted (64-byte = 128 hex chars) references
+export const ReferenceSchema = z
+  .string()
+  .regex(/^[0-9a-fA-F]{64}$|^[0-9a-fA-F]{128}$/, {
+    message:
+      "Reference must be 64 hex chars (32 bytes) or 128 hex chars (64 bytes for encrypted)",
+  })
+export const BatchIdSchema = hexString(64) // 32 bytes
+export const AddressSchema = hexString(40) // 20 bytes
+export const PrivateKeySchema = hexString(64) // 32 bytes
+export const EncryptionKeySchema = hexString(64) // 32 bytes symmetric key
+export const IdentifierSchema = hexString(64) // 32 bytes
+export const SignatureSchema = hexString(130) // 65 bytes
+export const TimestampSchema = z.preprocess(
+  (val) => (typeof val === "bigint" ? val.toString() : val),
+  z.union([z.number(), z.string()]),
+)
+export const FeedIndexSchema = z.preprocess(
+  (val) => (typeof val === "bigint" ? val.toString() : val),
+  z.union([z.number(), z.string()]),
+)
+
+export type Reference = z.infer<typeof ReferenceSchema>
+export type BatchId = z.infer<typeof BatchIdSchema>
+export type Address = z.infer<typeof AddressSchema>
+export type PrivateKey = z.infer<typeof PrivateKeySchema>
+export type Identifier = z.infer<typeof IdentifierSchema>
+export type Signature = z.infer<typeof SignatureSchema>
+export type Timestamp = z.infer<typeof TimestampSchema>
+export type FeedIndex = z.infer<typeof FeedIndexSchema>
 
 // ============================================================================
 // Primitive → bee-js Type Transforms (internal, for entity schemas)
@@ -34,7 +79,7 @@ const StoredEthAddress = z
 const StoredBatchId = z
   .string()
   .length(64)
-  .transform((s) => new BatchId(s))
+  .transform((s) => new BeeBatchId(s))
 
 /**
  * Schema for PrivateKey - validates 64-char hex string, transforms to PrivateKey
@@ -42,7 +87,7 @@ const StoredBatchId = z
 const StoredPrivateKey = z
   .string()
   .length(64)
-  .transform((s) => new PrivateKey(s))
+  .transform((s) => new BeePrivateKey(s))
 
 /**
  * Schema for Bytes - validates number array, transforms to Bytes
@@ -115,7 +160,7 @@ export const AccountSchemaV1 = z.discriminatedUnion("type", [
  * Identity Schema V1
  */
 export const IdentitySchemaV1 = z.object({
-  id: z.string(),
+  id: AddressSchema,
   accountId: StoredEthAddress,
   name: z.string(),
   defaultPostageStampBatchID: StoredBatchId.optional(),

--- a/lib/src/swarm-id-proxy.ts
+++ b/lib/src/swarm-id-proxy.ts
@@ -1078,7 +1078,7 @@ export class SwarmIdProxy {
               identity = {
                 id: foundIdentity.id,
                 name: foundIdentity.name,
-                address: foundIdentity.accountId.toHex(),
+                address: foundIdentity.id,
               }
             }
           }

--- a/lib/src/sync/sync-account.test.ts
+++ b/lib/src/sync/sync-account.test.ts
@@ -12,6 +12,7 @@ import type { UtilizationStoreDB } from "../storage/utilization-store"
 import type { DebouncedUtilizationUploader } from "../storage/debounced-uploader"
 import {
   TEST_ETH_ADDRESS_HEX,
+  TEST_IDENTITY_ADDRESS_HEX,
   TEST_BATCH_ID_HEX,
   createPasskeyAccount,
   createIdentity,
@@ -47,7 +48,7 @@ function createMockStores() {
 
   const connectedAppsStore: ConnectedAppsStoreInterface = {
     getAppsByIdentityId: vi.fn((identityId: string) =>
-      identityId === "identity-1" ? [connectedApp] : [],
+      identityId === TEST_IDENTITY_ADDRESS_HEX ? [connectedApp] : [],
     ),
   }
 

--- a/lib/src/test-fixtures.ts
+++ b/lib/src/test-fixtures.ts
@@ -13,11 +13,13 @@ import type {
 
 export const TEST_ETH_ADDRESS_HEX = "a".repeat(40)
 export const TEST_ETH_ADDRESS_2_HEX = "b".repeat(40)
+export const TEST_IDENTITY_ADDRESS_HEX = "1".repeat(40)
+export const TEST_IDENTITY_ADDRESS_2_HEX = "2".repeat(40)
 export const TEST_BATCH_ID_HEX = "c".repeat(64)
 export const TEST_BATCH_ID_2_HEX = "e".repeat(64)
 export const TEST_PRIVATE_KEY_HEX = "d".repeat(64)
 export const TEST_ENCRYPTION_KEY_HEX = "f".repeat(64)
-export const DIFFERENT_ENCRYPTION_KEY_HEX = "1".repeat(64)
+export const DIFFERENT_ENCRYPTION_KEY_HEX = "3".repeat(64)
 
 export function createPasskeyAccount(
   overrides?: Partial<PasskeyAccount>,
@@ -65,7 +67,7 @@ export function createAgentAccount(
 
 export function createIdentity(overrides?: Partial<Identity>): Identity {
   return {
-    id: "identity-1",
+    id: TEST_IDENTITY_ADDRESS_HEX,
     accountId: new EthAddress(TEST_ETH_ADDRESS_HEX),
     name: "Default Identity",
     createdAt: 1700000000000,
@@ -80,7 +82,7 @@ export function createConnectedApp(
     appUrl: "https://app.example.com",
     appName: "Test App",
     lastConnectedAt: 1700000000000,
-    identityId: "identity-1",
+    identityId: TEST_IDENTITY_ADDRESS_HEX,
     appSecret: "secret-should-be-stripped",
     ...overrides,
   }

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -3,7 +3,36 @@ import type {
   PrivateKey as BeePrivateKey,
   Topic as BeeTopic,
 } from "@ethersphere/bee-js"
-import { NetworkSettingsSchemaV1 } from "./schemas"
+import {
+  NetworkSettingsSchemaV1,
+  ReferenceSchema,
+  BatchIdSchema,
+  AddressSchema,
+  PrivateKeySchema,
+  EncryptionKeySchema,
+  IdentifierSchema,
+  SignatureSchema,
+  TimestampSchema,
+  FeedIndexSchema,
+} from "./schemas"
+import type {
+  Reference,
+  Address,
+  Identifier,
+  Signature,
+  Timestamp,
+  FeedIndex,
+} from "./schemas"
+export type {
+  Reference,
+  BatchId,
+  Address,
+  PrivateKey,
+  Identifier,
+  Signature,
+  Timestamp,
+  FeedIndex,
+} from "./schemas"
 
 // ============================================================================
 // Constants
@@ -18,47 +47,6 @@ export const STORAGE_KEY_CONNECTED_APPS = "swarm-id-connected-apps"
 export const STORAGE_KEY_POSTAGE_STAMPS = "swarm-id-postage-stamps"
 export const STORAGE_KEY_NETWORK_SETTINGS = "swarm-id-network-settings"
 export const STORAGE_CHALLENGE_KEY = "swarm-storage-challenge"
-
-// ============================================================================
-// Base Types
-// ============================================================================
-
-// Helper for hex string validation
-const hexString = (length: number) =>
-  z.string().regex(new RegExp(`^[0-9a-fA-F]{${length}}$`), {
-    message: `Must be a ${length}-character hex string`,
-  })
-
-// Support both regular (32-byte = 64 hex chars) and encrypted (64-byte = 128 hex chars) references
-export const ReferenceSchema = z
-  .string()
-  .regex(/^[0-9a-fA-F]{64}$|^[0-9a-fA-F]{128}$/, {
-    message:
-      "Reference must be 64 hex chars (32 bytes) or 128 hex chars (64 bytes for encrypted)",
-  })
-export const BatchIdSchema = hexString(64) // 32 bytes
-export const AddressSchema = hexString(40) // 20 bytes
-export const PrivateKeySchema = hexString(64) // 32 bytes
-export const EncryptionKeySchema = hexString(64) // 32 bytes symmetric key
-export const IdentifierSchema = hexString(64) // 32 bytes
-export const SignatureSchema = hexString(130) // 65 bytes
-export const TimestampSchema = z.preprocess(
-  (val) => (typeof val === "bigint" ? val.toString() : val),
-  z.union([z.number(), z.string()]),
-)
-export const FeedIndexSchema = z.preprocess(
-  (val) => (typeof val === "bigint" ? val.toString() : val),
-  z.union([z.number(), z.string()]),
-)
-
-export type Reference = z.infer<typeof ReferenceSchema>
-export type BatchId = z.infer<typeof BatchIdSchema>
-export type Address = z.infer<typeof AddressSchema>
-export type PrivateKey = z.infer<typeof PrivateKeySchema>
-export type Identifier = z.infer<typeof IdentifierSchema>
-export type Signature = z.infer<typeof SignatureSchema>
-export type Timestamp = z.infer<typeof TimestampSchema>
-export type FeedIndex = z.infer<typeof FeedIndexSchema>
 
 // ============================================================================
 // Upload/Download Options

--- a/lib/src/utils/account-state-snapshot.test.ts
+++ b/lib/src/utils/account-state-snapshot.test.ts
@@ -8,6 +8,8 @@ import {
 import type { Account, ConnectedApp, PostageStamp } from "../schemas"
 import {
   TEST_ETH_ADDRESS_HEX,
+  TEST_IDENTITY_ADDRESS_HEX,
+  TEST_IDENTITY_ADDRESS_2_HEX,
   TEST_BATCH_ID_HEX,
   TEST_BATCH_ID_2_HEX,
   TEST_PRIVATE_KEY_HEX,
@@ -195,7 +197,7 @@ describe("appSecret in snapshots", () => {
         appUrl: "https://example.com",
         appName: "Test App",
         lastConnectedAt: 1700000000000,
-        identityId: "identity-1",
+        identityId: TEST_IDENTITY_ADDRESS_HEX,
         appSecret: "preserved-secret",
       },
     ]
@@ -312,18 +314,18 @@ describe("edge cases", () => {
   it("should handle multiple entities of each type", () => {
     const account = createPasskeyAccount()
     const identities = [
-      createIdentity({ id: "id-1", name: "Identity One" }),
-      createIdentity({ id: "id-2", name: "Identity Two" }),
-      createIdentity({ id: "id-3", name: "Identity Three" }),
+      createIdentity({ id: TEST_IDENTITY_ADDRESS_HEX, name: "Identity One" }),
+      createIdentity({ id: TEST_IDENTITY_ADDRESS_2_HEX, name: "Identity Two" }),
+      createIdentity({ id: "3".repeat(40), name: "Identity Three" }),
     ]
     const connectedApps = [
       createConnectedApp({
         appUrl: "https://app1.example.com",
-        identityId: "id-1",
+        identityId: TEST_IDENTITY_ADDRESS_HEX,
       }),
       createConnectedApp({
         appUrl: "https://app2.example.com",
-        identityId: "id-2",
+        identityId: TEST_IDENTITY_ADDRESS_2_HEX,
       }),
     ]
     const postageStamps = [
@@ -519,7 +521,7 @@ describe("bee-js type conversions", () => {
       },
       identities: [
         {
-          id: "id-1",
+          id: TEST_IDENTITY_ADDRESS_HEX,
           accountId: TEST_ETH_ADDRESS_HEX,
           name: "Identity",
           createdAt: 1700000000000,

--- a/lib/src/utils/hex.ts
+++ b/lib/src/utils/hex.ts
@@ -4,4 +4,24 @@
  * Re-exports hex conversion functions from key-derivation
  */
 
+import type { Address } from "../schemas"
+
 export { hexToUint8Array, uint8ArrayToHex } from "./key-derivation"
+
+/**
+ * Create a validated hex address string (40 lowercase hex chars).
+ * Accepts optional 0x prefix and any case.
+ *
+ * @param input - Ethereum address string (with or without 0x prefix)
+ * @returns Normalized 40-character lowercase hex string
+ * @throws {Error} If the input is not a valid 40-char hex address
+ */
+export function hexAddress(input: string): Address {
+  const clean = input.replace(/^0x/i, "").toLowerCase()
+  if (!/^[0-9a-f]{40}$/.test(clean)) {
+    throw new Error(
+      `Invalid hex address: expected 40 hex characters (with optional 0x prefix), got "${input}"`,
+    )
+  }
+  return clean
+}

--- a/swarm-ui/src/lib/docker-name.ts
+++ b/swarm-ui/src/lib/docker-name.ts
@@ -1,3 +1,5 @@
+import { hexAddress } from '@swarm-id/lib'
+
 const adjective = [
   'admiring',
   'adoring',
@@ -353,23 +355,9 @@ function capitalize(s: string) {
   return s.slice(0, 1).toUpperCase() + s.slice(1)
 }
 
-function validateEthereumAddress(address: string): string {
-  // Remove '0x' prefix if present
-  const cleanAddress = address.toLowerCase().replace(/^0x/, '')
-
-  // Validate: must be exactly 40 hexadecimal characters
-  if (!/^[0-9a-f]{40}$/.test(cleanAddress)) {
-    throw new Error(
-      `Invalid Ethereum address format: ${address}. Expected 40 hex characters with optional 0x prefix.`,
-    )
-  }
-
-  return cleanAddress
-}
-
 function addressToRandomNumbers(address: string): [number, number] {
   // Validate and clean the address
-  const cleanAddress = validateEthereumAddress(address)
+  const cleanAddress = hexAddress(address)
 
   // Take 13 hex chars (52 bits) for each number - safely within JavaScript's 53-bit integer range
   // 13 hex chars = 52 bits < 53 bits (safe integer range)

--- a/swarm-ui/src/lib/stores/identities.svelte.ts
+++ b/swarm-ui/src/lib/stores/identities.svelte.ts
@@ -39,10 +39,9 @@ export const identitiesStore = {
     return identities
   },
 
-  addIdentity(identity: Omit<Identity, 'id' | 'createdAt'> & { id?: string }): Identity {
+  addIdentity(identity: Omit<Identity, 'createdAt'>): Identity {
     const newIdentity: Identity = {
       ...identity,
-      id: identity.id ?? crypto.randomUUID(),
       createdAt: Date.now(),
     }
     identities = [...identities, newIdentity]

--- a/swarm-ui/src/routes/(app)/(create)/identity/new/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/identity/new/+page.svelte
@@ -22,6 +22,7 @@
   import { Bytes } from '@ethersphere/bee-js'
   import { toPrefixedHex } from '$lib/utils/hex'
   import { generateDockerName } from '$lib/docker-name'
+  import { hexAddress } from '@swarm-id/lib'
   import Vertical from '$lib/components/ui/vertical.svelte'
 
   type StampOption = 'account' | 'separate'
@@ -66,7 +67,7 @@
 
   function deriveIdentityFromAccount(account: Account, masterKey: Bytes, index: number) {
     const identityWallet = HDNodeWallet.fromSeed(toPrefixedHex(masterKey)).deriveChild(index)
-    const id = identityWallet.address
+    const id = hexAddress(identityWallet.address)
     const name = generateDockerName(id)
     const accountId = account.id
     const createdAt = Date.now()

--- a/swarm-ui/src/routes/(app)/connect/+page.svelte
+++ b/swarm-ui/src/routes/(app)/connect/+page.svelte
@@ -221,7 +221,7 @@
           secret: appSecret,
           identityId: selectedIdentity.id,
           identityName: selectedIdentity.name,
-          identityAddress: selectedIdentity.accountId.toHex(),
+          identityAddress: selectedIdentity.id,
         },
       },
       window.location.origin,

--- a/swarm-ui/tests/demo-connect-flow.test.ts
+++ b/swarm-ui/tests/demo-connect-flow.test.ts
@@ -93,8 +93,8 @@ test.describe('Demo App Connect Flow', () => {
     await expect(page.locator('.min-w-0.flex-1 .text-sm.font-medium')).toBeVisible({
       timeout: 15000,
     })
-    // The address is displayed in truncated format (first 6 chars + ... + last 4 chars)
-    // For the test seed phrase, the address is 0x9858EfFD...EcaEda94
+    // The identity address is displayed in truncated format (first 6 chars + ... + last 4 chars)
+    // For the test seed phrase, this is the HD wallet child key address
     await expect(page.locator('.min-w-0.flex-1 .text-xs.font-mono')).toContainText('...')
   })
 
@@ -168,8 +168,8 @@ test.describe('Demo App Connect Flow', () => {
     await expect(page.locator('.min-w-0.flex-1 .text-sm.font-medium')).toBeVisible({
       timeout: 15000,
     })
-    // The address is displayed in truncated format (first 6 chars + ... + last 4 chars)
-    // For the test seed phrase, the address is 0x9858EfFD...EcaEda94
+    // The identity address is displayed in truncated format (first 6 chars + ... + last 4 chars)
+    // For the test seed phrase, this is the HD wallet child key address
     await expect(page.locator('.min-w-0.flex-1 .text-xs.font-mono')).toContainText('...')
   })
 
@@ -237,8 +237,8 @@ test.describe('Demo App Connect Flow', () => {
     await expect(page.locator('.min-w-0.flex-1 .text-sm.font-medium')).toBeVisible({
       timeout: 15000,
     })
-    // The address is displayed in truncated format (first 6 chars + ... + last 4 chars)
-    // For the test seed phrase, the address is 0x9858EfFD...EcaEda94
+    // The identity address is displayed in truncated format (first 6 chars + ... + last 4 chars)
+    // For the test seed phrase, this is the HD wallet child key address
     await expect(page.locator('.min-w-0.flex-1 .text-xs.font-mono')).toContainText('...')
   })
 
@@ -327,8 +327,8 @@ test.describe('Demo App Connect Flow', () => {
     await expect(page.locator('.min-w-0.flex-1 .text-sm.font-medium')).toBeVisible({
       timeout: 15000,
     })
-    // The address is displayed in truncated format (first 6 chars + ... + last 4 chars)
-    // For the test seed phrase, the address is 0x9858EfFD...EcaEda94
+    // The identity address is displayed in truncated format (first 6 chars + ... + last 4 chars)
+    // For the test seed phrase, this is the HD wallet child key address
     await expect(page.locator('.min-w-0.flex-1 .text-xs.font-mono')).toContainText('...')
   })
 })


### PR DESCRIPTION
Fixes #247 

The fix involved refactoring the schemas so that the `AddressSchema` can be used for the `id`. 