### PR TITLE
feat: device id

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -264,6 +264,7 @@ export type {
 
 // Entity types from schemas
 export type {
+  Device,
   Account,
   PasskeyAccount,
   EthereumAccount,
@@ -277,6 +278,7 @@ export type {
 
 // Network settings constants and schema
 export {
+  DeviceSchemaV1,
   DEFAULT_BEE_NODE_URL,
   DEFAULT_GNOSIS_RPC_URL,
   NetworkSettingsSchemaV1,
@@ -304,6 +306,13 @@ export type {
   Timestamp,
   FeedIndex,
 } from "./schemas"
+
+// Device ID utilities
+export {
+  getOrCreateDeviceId,
+  getDeviceId,
+  mergeDevices,
+} from "./utils/device-id"
 
 // Batch utilization types
 export type {

--- a/lib/src/schemas.ts
+++ b/lib/src/schemas.ts
@@ -97,36 +97,52 @@ const StoredBytes = z
   .transform((arr) => new Bytes(new Uint8Array(arr)))
 
 // ============================================================================
+// Device Schema
+// ============================================================================
+
+/**
+ * Device Schema V1
+ * Tracks devices that have accessed an account for multi-device support.
+ */
+export const DeviceSchemaV1 = z.object({
+  deviceId: z.string(),
+  createdAt: z.number(),
+  lastSignedInAt: z.number(),
+})
+
+// ============================================================================
 // Account Schemas
 // ============================================================================
 
 /**
- * Passkey Account Schema V1
+ * Common fields shared by all account types
  */
-export const PasskeyAccountSchemaV1 = z.object({
+const CommonAccountSchemaV1 = z.object({
   id: StoredEthAddress,
   name: z.string(),
   createdAt: z.number(),
+  swarmEncryptionKey: z.string().length(64),
+  defaultPostageStampBatchID: StoredBatchId.optional(),
+  devices: z.array(DeviceSchemaV1).default([]),
+})
+
+/**
+ * Passkey Account Schema V1
+ */
+export const PasskeyAccountSchemaV1 = CommonAccountSchemaV1.extend({
   type: z.literal("passkey"),
   credentialId: z.string(),
-  swarmEncryptionKey: z.string().length(64), // NEW: derived encryption key for Swarm data (64-char hex)
-  defaultPostageStampBatchID: StoredBatchId.optional(), // NEW: account default stamp
 })
 
 /**
  * Ethereum Account Schema V1
  */
-export const EthereumAccountSchemaV1 = z.object({
-  id: StoredEthAddress,
-  name: z.string(),
-  createdAt: z.number(),
+export const EthereumAccountSchemaV1 = CommonAccountSchemaV1.extend({
   type: z.literal("ethereum"),
   ethereumAddress: StoredEthAddress,
   encryptedMasterKey: StoredBytes,
   encryptionSalt: StoredBytes,
-  encryptedSecretSeed: StoredBytes, // Encrypted secret seed for later retrieval
-  swarmEncryptionKey: z.string().length(64), // NEW: derived encryption key for Swarm data (64-char hex)
-  defaultPostageStampBatchID: StoredBatchId.optional(), // NEW: account default stamp
+  encryptedSecretSeed: StoredBytes,
 })
 
 /**
@@ -134,13 +150,8 @@ export const EthereumAccountSchemaV1 = z.object({
  * For automated testing and programmatic use with BIP39 seed phrases
  * Seed phrase is NOT stored - must be re-entered on each authentication (like passkey)
  */
-export const AgentAccountSchemaV1 = z.object({
-  id: StoredEthAddress,
-  name: z.string(),
-  createdAt: z.number(),
+export const AgentAccountSchemaV1 = CommonAccountSchemaV1.extend({
   type: z.literal("agent"),
-  swarmEncryptionKey: z.string().length(64), // derived encryption key for Swarm data (64-char hex)
-  defaultPostageStampBatchID: StoredBatchId.optional(),
 })
 
 /**
@@ -225,6 +236,7 @@ export const AccountMetadataSchemaV1 = z.object({
   defaultPostageStampBatchID: z.string().length(64).optional(), // BatchId hex string
   createdAt: z.number(),
   lastModified: z.number(),
+  devices: z.array(DeviceSchemaV1).default([]),
 })
 
 const ACCOUNT_STATE_SNAPSHOT_VERSION = 1
@@ -247,6 +259,7 @@ export const AccountStateSnapshotSchemaV1 = z.object({
 // Derived Types (guaranteed to match current schema version)
 // ============================================================================
 
+export type Device = z.infer<typeof DeviceSchemaV1>
 export type PasskeyAccount = z.infer<typeof PasskeyAccountSchemaV1>
 export type EthereumAccount = z.infer<typeof EthereumAccountSchemaV1>
 export type AgentAccount = z.infer<typeof AgentAccountSchemaV1>

--- a/lib/src/sync/sync-account.test.ts
+++ b/lib/src/sync/sync-account.test.ts
@@ -18,6 +18,7 @@ import {
   createIdentity,
   createConnectedApp,
   createPostageStamp,
+  createDevice,
 } from "../test-fixtures"
 
 // ============================================================================
@@ -276,6 +277,36 @@ describe("createSyncAccount", () => {
     const result = await syncAccount(TEST_ETH_ADDRESS_HEX)
     expect(result).toBeUndefined()
     expect(uploadCallCount).toBe(0)
+  })
+
+  it("should include account devices in synced metadata", async () => {
+    const device = createDevice()
+    const stores = createMockStores()
+    ;(
+      stores.accountsStore.getAccount as ReturnType<typeof vi.fn>
+    ).mockReturnValue(
+      createPasskeyAccount({
+        defaultPostageStampBatchID: new BatchId(TEST_BATCH_ID_HEX),
+        devices: [device],
+      }),
+    )
+
+    const syncAccount = createSyncAccount({
+      bee: {} as never,
+      ...stores,
+      utilizationStore: {} as UtilizationStoreDB,
+      utilizationUploader: {
+        scheduleUpload: vi.fn().mockResolvedValue(undefined),
+      } as unknown as DebouncedUtilizationUploader,
+    })
+
+    await syncAccount(TEST_ETH_ADDRESS_HEX)
+
+    expect(capturedUploadData).toBeDefined()
+    const deserialized = deserializeAccountState(capturedUploadData!)
+
+    expect(deserialized.metadata.devices).toHaveLength(1)
+    expect(deserialized.metadata.devices[0].deviceId).toBe(device.deviceId)
   })
 
   it("should include SOC address in returned chunk addresses", async () => {

--- a/lib/src/sync/sync-account.ts
+++ b/lib/src/sync/sync-account.ts
@@ -281,6 +281,7 @@ export function createSyncAccount(
         defaultPostageStampBatchID: defaultStampBatchID.toHex(),
         createdAt: account.createdAt,
         lastModified: Date.now(),
+        devices: account.devices,
       },
       identities,
       connectedApps: apps,

--- a/lib/src/test-fixtures.ts
+++ b/lib/src/test-fixtures.ts
@@ -3,6 +3,7 @@
  */
 import { EthAddress, BatchId, PrivateKey, Bytes } from "@ethersphere/bee-js"
 import type {
+  Device,
   PasskeyAccount,
   EthereumAccount,
   AgentAccount,
@@ -21,6 +22,17 @@ export const TEST_PRIVATE_KEY_HEX = "d".repeat(64)
 export const TEST_ENCRYPTION_KEY_HEX = "f".repeat(64)
 export const DIFFERENT_ENCRYPTION_KEY_HEX = "3".repeat(64)
 
+export const TEST_DEVICE_ID = "550e8400-e29b-41d4-a716-446655440000"
+
+export function createDevice(overrides?: Partial<Device>): Device {
+  return {
+    deviceId: TEST_DEVICE_ID,
+    createdAt: 1700000000000,
+    lastSignedInAt: 1700000000000,
+    ...overrides,
+  }
+}
+
 export function createPasskeyAccount(
   overrides?: Partial<PasskeyAccount>,
 ): PasskeyAccount {
@@ -31,6 +43,7 @@ export function createPasskeyAccount(
     type: "passkey" as const,
     credentialId: "credential-abc-123",
     swarmEncryptionKey: TEST_ENCRYPTION_KEY_HEX,
+    devices: [],
     ...overrides,
   }
 }
@@ -48,6 +61,7 @@ export function createEthereumAccount(
     encryptionSalt: new Bytes(new Uint8Array([5, 6, 7, 8])),
     encryptedSecretSeed: new Bytes(new Uint8Array([9, 10, 11, 12])),
     swarmEncryptionKey: TEST_ENCRYPTION_KEY_HEX,
+    devices: [],
     ...overrides,
   }
 }
@@ -61,6 +75,7 @@ export function createAgentAccount(
     createdAt: 1700000000000,
     type: "agent" as const,
     swarmEncryptionKey: TEST_ENCRYPTION_KEY_HEX,
+    devices: [],
     ...overrides,
   }
 }

--- a/lib/src/utils/account-state-snapshot.test.ts
+++ b/lib/src/utils/account-state-snapshot.test.ts
@@ -19,6 +19,7 @@ import {
   createIdentity,
   createConnectedApp,
   createPostageStamp,
+  createDevice,
 } from "../test-fixtures"
 
 /**
@@ -41,6 +42,7 @@ function serializeFromAccount(
       defaultPostageStampBatchID: account.defaultPostageStampBatchID?.toHex(),
       createdAt: account.createdAt,
       lastModified: Date.now(),
+      devices: account.devices,
     },
     identities,
     connectedApps,
@@ -169,6 +171,54 @@ describe("round-trip: serialize → JSON → deserialize", () => {
       "https://example.com/icon.png",
     )
     expect(result.data.postageStamps[0].batchTTL).toBe(86400)
+  })
+})
+
+// ============================================================================
+// Device Tracking Tests
+// ============================================================================
+
+describe("device tracking in metadata", () => {
+  it("should round-trip devices through metadata", () => {
+    const device = createDevice()
+    const account = createPasskeyAccount({ devices: [device] })
+    const serialized = serializeFromAccount(account, [], [], [])
+    const result = deserializeAccountStateSnapshot(
+      JSON.parse(JSON.stringify(serialized)),
+    )
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+
+    expect(result.data.metadata.devices).toHaveLength(1)
+    expect(result.data.metadata.devices[0].deviceId).toBe(device.deviceId)
+    expect(result.data.metadata.devices[0].createdAt).toBe(device.createdAt)
+    expect(result.data.metadata.devices[0].lastSignedInAt).toBe(
+      device.lastSignedInAt,
+    )
+  })
+
+  it("should default to empty array when devices are absent", () => {
+    const raw = {
+      version: 1,
+      timestamp: Date.now(),
+      accountId: TEST_ETH_ADDRESS_HEX,
+      metadata: {
+        accountName: "Test",
+        createdAt: 1700000000000,
+        lastModified: Date.now(),
+      },
+      identities: [],
+      connectedApps: [],
+      postageStamps: [],
+    }
+
+    const result = deserializeAccountStateSnapshot(raw)
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+
+    expect(result.data.metadata.devices).toEqual([])
   })
 })
 

--- a/lib/src/utils/account-state-snapshot.ts
+++ b/lib/src/utils/account-state-snapshot.ts
@@ -66,6 +66,7 @@ export function serializeAccountStateSnapshot(input: {
       defaultPostageStampBatchID: input.metadata.defaultPostageStampBatchID,
       createdAt: input.metadata.createdAt,
       lastModified: input.metadata.lastModified,
+      devices: input.metadata.devices,
     },
     identities: input.identities.map(serializeIdentity),
     connectedApps: input.connectedApps.map(serializeConnectedApp),

--- a/lib/src/utils/backup-encryption.ts
+++ b/lib/src/utils/backup-encryption.ts
@@ -231,6 +231,7 @@ export async function createEncryptedExport(
       defaultPostageStampBatchID: account.defaultPostageStampBatchID?.toHex(),
       createdAt: account.createdAt,
       lastModified: now,
+      devices: account.devices,
     },
     identities,
     connectedApps,

--- a/lib/src/utils/device-id.test.ts
+++ b/lib/src/utils/device-id.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest"
+import { mergeDevices } from "./device-id"
+import { createDevice, TEST_DEVICE_ID } from "../test-fixtures"
+
+describe("mergeDevices", () => {
+  it("should add a new device to an empty list", () => {
+    const result = mergeDevices([], "new-device-id")
+
+    expect(result).toHaveLength(1)
+    expect(result[0].deviceId).toBe("new-device-id")
+    expect(result[0].createdAt).toBeGreaterThan(0)
+    expect(result[0].lastSignedInAt).toBe(result[0].createdAt)
+  })
+
+  it("should update lastSignedInAt for an existing device", () => {
+    const existing = [createDevice({ lastSignedInAt: 1000 })]
+
+    const result = mergeDevices(existing, TEST_DEVICE_ID)
+
+    expect(result).toHaveLength(1)
+    expect(result[0].deviceId).toBe(TEST_DEVICE_ID)
+    expect(result[0].createdAt).toBe(1700000000000) // preserved
+    expect(result[0].lastSignedInAt).toBeGreaterThan(1000)
+  })
+
+  it("should preserve other devices when adding a new one", () => {
+    const existing = [createDevice()]
+
+    const result = mergeDevices(existing, "second-device")
+
+    expect(result).toHaveLength(2)
+    expect(result[0].deviceId).toBe(TEST_DEVICE_ID)
+    expect(result[1].deviceId).toBe("second-device")
+  })
+
+  it("should preserve other devices when updating an existing one", () => {
+    const existing = [
+      createDevice({ deviceId: "device-a" }),
+      createDevice({ deviceId: "device-b", lastSignedInAt: 1000 }),
+    ]
+
+    const result = mergeDevices(existing, "device-b")
+
+    expect(result).toHaveLength(2)
+    expect(result[0].deviceId).toBe("device-a")
+    expect(result[0].lastSignedInAt).toBe(1700000000000) // unchanged
+    expect(result[1].deviceId).toBe("device-b")
+    expect(result[1].lastSignedInAt).toBeGreaterThan(1000)
+  })
+})

--- a/lib/src/utils/device-id.ts
+++ b/lib/src/utils/device-id.ts
@@ -1,0 +1,54 @@
+/**
+ * Device ID Utilities
+ *
+ * Manages a per-browser device identifier stored in localStorage and
+ * provides helpers for merging device lists across sync/restore.
+ */
+
+import type { Device } from "../schemas"
+
+const DEVICE_ID_KEY = "swarm-id-device-id"
+
+/**
+ * Get the current device ID, creating one if it doesn't exist.
+ */
+export function getOrCreateDeviceId(): string {
+  const existing = localStorage.getItem(DEVICE_ID_KEY)
+  if (existing) return existing
+
+  const id = crypto.randomUUID()
+  localStorage.setItem(DEVICE_ID_KEY, id)
+  return id
+}
+
+/**
+ * Get the current device ID without creating one.
+ */
+export function getDeviceId(): string | undefined {
+  return localStorage.getItem(DEVICE_ID_KEY) ?? undefined
+}
+
+/**
+ * Merge a device list with the current device.
+ *
+ * Upserts the current device (updates lastSignedInAt if present,
+ * creates a new entry if not). Preserves all other device entries.
+ */
+export function mergeDevices(
+  existing: Device[],
+  currentDeviceId: string,
+): Device[] {
+  const now = Date.now()
+  const found = existing.some((d) => d.deviceId === currentDeviceId)
+
+  if (found) {
+    return existing.map((d) =>
+      d.deviceId === currentDeviceId ? { ...d, lastSignedInAt: now } : d,
+    )
+  }
+
+  return [
+    ...existing,
+    { deviceId: currentDeviceId, createdAt: now, lastSignedInAt: now },
+  ]
+}

--- a/lib/src/utils/storage-managers.ts
+++ b/lib/src/utils/storage-managers.ts
@@ -96,43 +96,30 @@ const parsePostageStampsV1: VersionParser<PostageStamp> = (data: unknown) => {
  * Serialize Account for storage
  */
 export function serializeAccount(account: Account): Record<string, unknown> {
+  const common = {
+    id: account.id.toString(),
+    name: account.name,
+    createdAt: account.createdAt,
+    type: account.type,
+    swarmEncryptionKey: account.swarmEncryptionKey,
+    defaultPostageStampBatchID: account.defaultPostageStampBatchID?.toString(),
+    devices: account.devices,
+  }
+
   if (account.type === "passkey") {
+    return { ...common, credentialId: account.credentialId }
+  } else if (account.type === "ethereum") {
     return {
-      id: account.id.toString(),
-      name: account.name,
-      createdAt: account.createdAt,
-      type: account.type,
-      credentialId: account.credentialId,
-      swarmEncryptionKey: account.swarmEncryptionKey,
-      defaultPostageStampBatchID:
-        account.defaultPostageStampBatchID?.toString(),
-    }
-  } else if (account.type === "agent") {
-    return {
-      id: account.id.toString(),
-      name: account.name,
-      createdAt: account.createdAt,
-      type: account.type,
-      swarmEncryptionKey: account.swarmEncryptionKey,
-      defaultPostageStampBatchID:
-        account.defaultPostageStampBatchID?.toString(),
-    }
-  } else {
-    return {
-      id: account.id.toString(),
-      name: account.name,
-      createdAt: account.createdAt,
-      type: account.type,
+      ...common,
       ethereumAddress: account.ethereumAddress.toString(),
       encryptedMasterKey: Array.from(account.encryptedMasterKey.toUint8Array()),
       encryptionSalt: Array.from(account.encryptionSalt.toUint8Array()),
       encryptedSecretSeed: Array.from(
         account.encryptedSecretSeed.toUint8Array(),
       ),
-      swarmEncryptionKey: account.swarmEncryptionKey,
-      defaultPostageStampBatchID:
-        account.defaultPostageStampBatchID?.toString(),
     }
+  } else {
+    return common
   }
 }
 

--- a/swarm-ui/src/lib/agent-account.ts
+++ b/swarm-ui/src/lib/agent-account.ts
@@ -6,6 +6,7 @@
 import { HDNodeWallet, Mnemonic } from 'ethers'
 import { EthAddress, Bytes } from '@ethersphere/bee-js'
 import type { AgentAccount } from '@snaha/swarm-id'
+import { getOrCreateDeviceId, mergeDevices } from '@snaha/swarm-id'
 
 export interface AgentAccountResult {
   ethereumAddress: EthAddress
@@ -96,6 +97,7 @@ export function createAgentAccount(options: CreateAgentAccountOptions): CreateAg
       name: options.name,
       createdAt: Date.now(),
       type: 'agent',
+      devices: mergeDevices([], getOrCreateDeviceId()),
     },
     masterKey,
   }

--- a/swarm-ui/src/lib/stores/accounts.svelte.ts
+++ b/swarm-ui/src/lib/stores/accounts.svelte.ts
@@ -1,6 +1,6 @@
 import { browser } from '$app/environment'
 import { EthAddress, BatchId } from '@ethersphere/bee-js'
-import { createAccountsStorageManager, type Account } from '@snaha/swarm-id'
+import { createAccountsStorageManager, type Account, type Device } from '@snaha/swarm-id'
 import { triggerSync } from '$lib/utils/sync-hooks'
 
 // ============================================================================
@@ -48,6 +48,13 @@ export const accountsStore = {
     accounts = accounts.map((account) => (account.id.equals(id) ? { ...account, name } : account))
     saveAccounts(accounts)
     triggerSync(id.toHex())
+  },
+
+  updateDevices(id: EthAddress, devices: Device[]) {
+    accounts = accounts.map((account) =>
+      account.id.equals(id) ? { ...account, devices } : account,
+    )
+    saveAccounts(accounts)
   },
 
   setDefaultStamp(id: EthAddress, batchID: BatchId | undefined) {

--- a/swarm-ui/src/lib/utils/restore-account.ts
+++ b/swarm-ui/src/lib/utils/restore-account.ts
@@ -1,4 +1,5 @@
-import type { Account, Identity, ConnectedApp, PostageStamp } from '@snaha/swarm-id'
+import type { Account, Identity, ConnectedApp, PostageStamp, Device } from '@snaha/swarm-id'
+import { mergeDevices, getOrCreateDeviceId } from '@snaha/swarm-id'
 import { accountsStore } from '$lib/stores/accounts.svelte'
 import { identitiesStore } from '$lib/stores/identities.svelte'
 import { connectedAppsStore } from '$lib/stores/connected-apps.svelte'
@@ -9,10 +10,12 @@ interface RestoreData {
   identities: Identity[]
   connectedApps: ConnectedApp[]
   postageStamps: PostageStamp[]
+  devices?: Device[]
 }
 
 export function restoreAccountToStores(data: RestoreData): Account {
-  accountsStore.addAccount(data.account)
+  const devices = mergeDevices(data.devices ?? [], getOrCreateDeviceId())
+  accountsStore.addAccount({ ...data.account, devices })
 
   for (const identity of data.identities) {
     identitiesStore.addIdentity(identity)

--- a/swarm-ui/src/routes/(app)/(create)/agent/new/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/agent/new/+page.svelte
@@ -20,7 +20,11 @@
   import { sessionStore } from '$lib/stores/session.svelte'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { createAgentAccount, validateSeedPhrase, countSeedPhraseWords } from '$lib/agent-account'
-  import { deriveAccountSwarmEncryptionKey } from '@snaha/swarm-id'
+  import {
+    deriveAccountSwarmEncryptionKey,
+    getOrCreateDeviceId,
+    mergeDevices,
+  } from '@snaha/swarm-id'
   import type { AccountSyncType } from '$lib/types'
 
   let showTypeTooltip = $state(false)
@@ -93,6 +97,7 @@
         createdAt: account.createdAt,
         type: 'agent',
         swarmEncryptionKey,
+        devices: mergeDevices([], getOrCreateDeviceId()),
       })
       sessionStore.setAccount(newAccount)
       sessionStore.setSyncedCreation(accountType === 'synced')

--- a/swarm-ui/src/routes/(app)/(create)/eth/new/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/eth/new/+page.svelte
@@ -31,7 +31,11 @@
   import { WarningAlt } from 'carbon-icons-svelte'
   import Confirmation from '$lib/components/confirmation.svelte'
   import { onMount } from 'svelte'
-  import { deriveAccountSwarmEncryptionKey } from '@snaha/swarm-id'
+  import {
+    deriveAccountSwarmEncryptionKey,
+    getOrCreateDeviceId,
+    mergeDevices,
+  } from '@snaha/swarm-id'
   import type { AccountSyncType } from '$lib/types'
 
   let showTypeTooltip = $state(false)
@@ -113,6 +117,7 @@
         encryptionSalt: encryptionSalt,
         encryptedSecretSeed: encryptedSecretSeed,
         swarmEncryptionKey: swarmEncryptionKey,
+        devices: mergeDevices([], getOrCreateDeviceId()),
       })
       sessionStore.setAccount(newAccount)
       sessionStore.setSyncedCreation(accountType === 'synced')

--- a/swarm-ui/src/routes/(app)/(create)/import/ethereum/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/import/ethereum/+page.svelte
@@ -98,10 +98,12 @@
           defaultPostageStampBatchID: result.data.metadata.defaultPostageStampBatchID
             ? new BatchId(result.data.metadata.defaultPostageStampBatchID)
             : undefined,
+          devices: [],
         },
         identities: result.data.identities,
         connectedApps: result.data.connectedApps,
         postageStamps: result.data.postageStamps,
+        devices: result.data.metadata.devices,
       })
 
       sessionStore.setAccount(account)

--- a/swarm-ui/src/routes/(app)/(create)/import/passkey/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/import/passkey/+page.svelte
@@ -79,10 +79,12 @@
           defaultPostageStampBatchID: result.data.metadata.defaultPostageStampBatchID
             ? new BatchId(result.data.metadata.defaultPostageStampBatchID)
             : undefined,
+          devices: [],
         },
         identities: result.data.identities,
         connectedApps: result.data.connectedApps,
         postageStamps: result.data.postageStamps,
+        devices: result.data.metadata.devices,
       })
 
       sessionStore.setAccount(account)

--- a/swarm-ui/src/routes/(app)/(create)/passkey/new/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/passkey/new/+page.svelte
@@ -20,7 +20,11 @@
   import Confirmation from '$lib/components/confirmation.svelte'
   import { onMount } from 'svelte'
   import ErrorMessage from '$lib/components/ui/error-message.svelte'
-  import { deriveAccountSwarmEncryptionKey } from '@snaha/swarm-id'
+  import {
+    deriveAccountSwarmEncryptionKey,
+    getOrCreateDeviceId,
+    mergeDevices,
+  } from '@snaha/swarm-id'
   import type { AccountSyncType } from '$lib/types'
 
   let accountName = $state('Passkey')
@@ -78,6 +82,7 @@
         type: 'passkey',
         credentialId: account.credentialId,
         swarmEncryptionKey: swarmEncryptionKey,
+        devices: mergeDevices([], getOrCreateDeviceId()),
       })
       sessionStore.setAccount(newAccount)
       sessionStore.setSyncedCreation(accountType === 'synced')

--- a/swarm-ui/src/routes/(app)/(create)/signin/ethereum/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/signin/ethereum/+page.svelte
@@ -96,10 +96,12 @@
             defaultPostageStampBatchID: result.snapshot.metadata.defaultPostageStampBatchID
               ? new BatchId(result.snapshot.metadata.defaultPostageStampBatchID)
               : undefined,
+            devices: [],
           },
           identities: result.snapshot.identities,
           connectedApps: result.snapshot.connectedApps,
           postageStamps: result.snapshot.postageStamps,
+          devices: result.snapshot.metadata.devices,
         })
       }
 

--- a/swarm-ui/src/routes/(app)/(create)/signin/passkey/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/signin/passkey/+page.svelte
@@ -73,10 +73,12 @@
           defaultPostageStampBatchID: result.snapshot.metadata.defaultPostageStampBatchID
             ? new BatchId(result.snapshot.metadata.defaultPostageStampBatchID)
             : undefined,
+          devices: [],
         },
         identities: result.snapshot.identities,
         connectedApps: result.snapshot.connectedApps,
         postageStamps: result.snapshot.postageStamps,
+        devices: result.snapshot.metadata.devices,
       })
 
       sessionStore.setAccount(restoredAccount)


### PR DESCRIPTION
Generate a random `deviceId` per browser on first use and track a list of
known devices per account. Each device entry stores `createdAt` and
`lastSignedInAt` timestamps. Devices are merged on sign-in, account
creation, import, and restore flows, and synced to Swarm via account
metadata.

Introduces `CommonAccountSchemaV1` to deduplicate fields shared across
passkey, ethereum, and agent account schemas.

Closes https://github.com/snaha/swarm-id/issues/228
