### PR TITLE
feat!: deterministic derivation key and postage signer key

### DIFF
--- a/docs-site/src/content/docs/api/index.mdx
+++ b/docs-site/src/content/docs/api/index.mdx
@@ -1523,27 +1523,28 @@ Functions for creating and reading encrypted `.swarmid` backup files. Exported f
 
 ### `createEncryptedExport(account, identities, connectedApps, postageStamps, swarmEncryptionKeyHex)`
 
-Create a fully encrypted `.swarmid` export object. Serializes account data, derives an AES-GCM-256 key from the stored `swarmEncryptionKey`, encrypts the payload, and builds a header with account metadata.
+Create a fully encrypted `.swarmid` export object. Serializes account data, derives an AES-GCM-256 key from the `swarmEncryptionKey` (which is itself derived from the account's stored `derivationKey`), encrypts the payload, and builds a header with account metadata.
 
 **Parameters:**
 
-| Parameter               | Type             | Description                                             |
-| ----------------------- | ---------------- | ------------------------------------------------------- |
-| `account`               | `Account`        | The account to export                                   |
-| `identities`            | `Identity[]`     | Account identities                                      |
-| `connectedApps`         | `ConnectedApp[]` | Connected applications (`appSecret` is stripped)        |
-| `postageStamps`         | `PostageStamp[]` | Postage stamps                                          |
-| `swarmEncryptionKeyHex` | `string`         | Hex-encoded swarm encryption key (persisted on account) |
+| Parameter               | Type             | Description                                                                                            |
+| ----------------------- | ---------------- | ------------------------------------------------------------------------------------------------------ |
+| `account`               | `Account`        | The account to export                                                                                  |
+| `identities`            | `Identity[]`     | Account identities                                                                                     |
+| `connectedApps`         | `ConnectedApp[]` | Connected applications (`appSecret` is stripped)                                                       |
+| `postageStamps`         | `PostageStamp[]` | Postage stamps                                                                                         |
+| `swarmEncryptionKeyHex` | `string`         | Hex-encoded swarm encryption key (derived from `account.derivationKey` via `deriveSwarmEncryptionKey`) |
 
 **Returns:** `Promise<EncryptedSwarmIdExport>`
 
 ```typescript
+const swarmEncryptionKey = await deriveSwarmEncryptionKey(account.derivationKey)
 const exported = await createEncryptedExport(
   account,
   identities,
   connectedApps,
   postageStamps,
-  swarmEncryptionKeyHex,
+  swarmEncryptionKey,
 )
 // Save as .swarmid file
 const blob = new Blob([JSON.stringify(exported)], { type: 'application/json' })
@@ -1555,15 +1556,16 @@ Decrypt an encrypted `.swarmid` export and return the parsed account state snaps
 
 **Parameters:**
 
-| Parameter               | Type      | Description                            |
-| ----------------------- | --------- | -------------------------------------- |
-| `encryptedData`         | `unknown` | The parsed JSON from a `.swarmid` file |
-| `swarmEncryptionKeyHex` | `string`  | Hex-encoded swarm encryption key       |
+| Parameter               | Type      | Description                                                     |
+| ----------------------- | --------- | --------------------------------------------------------------- |
+| `encryptedData`         | `unknown` | The parsed JSON from a `.swarmid` file                          |
+| `swarmEncryptionKeyHex` | `string`  | Hex-encoded swarm encryption key (derived from `derivationKey`) |
 
 **Returns:** `Promise<AccountStateSnapshotResult>` — `{ success: true, data: AccountStateSnapshot }` or `{ success: false, error: ZodError }`
 
 ```typescript
-const result = await decryptEncryptedExport(fileData, swarmEncryptionKeyHex)
+const swarmEncryptionKey = await deriveSwarmEncryptionKey(account.derivationKey)
+const result = await decryptEncryptedExport(fileData, swarmEncryptionKey)
 if (result.success) {
   const { identities, connectedApps, postageStamps } = result.data
 }
@@ -1583,13 +1585,13 @@ Parse and validate just the encrypted export header without decrypting. Useful f
 
 ### `deriveBackupEncryptionKey(swarmEncryptionKeyHex)`
 
-Derive an AES-GCM-256 `CryptoKey` for backup encryption from the stored `swarmEncryptionKey`. Uses HMAC-SHA256 with context `"swarm-id-backup-encryption-v1"`.
+Derive an AES-GCM-256 `CryptoKey` for backup encryption from the `swarmEncryptionKey` (which is itself derived from the stored `derivationKey`). Uses HMAC-SHA256 with context `"swarm-id-backup-encryption-v1"`.
 
 **Parameters:**
 
-| Parameter               | Type     | Description                      |
-| ----------------------- | -------- | -------------------------------- |
-| `swarmEncryptionKeyHex` | `string` | Hex-encoded swarm encryption key |
+| Parameter               | Type     | Description                                                     |
+| ----------------------- | -------- | --------------------------------------------------------------- |
+| `swarmEncryptionKeyHex` | `string` | Hex-encoded swarm encryption key (derived from `derivationKey`) |
 
 **Returns:** `Promise<CryptoKey>`
 
@@ -1686,7 +1688,34 @@ Restore account state from Swarm using passkey authentication result. Derives ke
 ```typescript
 interface RestoreAccountResult {
   snapshot: AccountStateSnapshot
-  swarmEncryptionKey: string
+  derivationKey: string
   credentialId: string
 }
+```
+
+## Key Derivation
+
+### `derivePostageSignerKey(derivationKey, identityId?)`
+
+Derive a deterministic postage batch signer key from the account's derivation key. When `identityId` is provided, derives a unique signer key for that identity; otherwise derives an account-level signer key.
+
+**Parameters:**
+
+| Parameter       | Type                  | Description                                       |
+| --------------- | --------------------- | ------------------------------------------------- |
+| `derivationKey` | `string`              | Account derivation key (64-char hex)              |
+| `identityId`    | `string \| undefined` | Optional identity ID for per-identity signer keys |
+
+**Returns:** `Promise<string>` — 32-byte signer key as hex string
+
+```typescript
+import { derivePostageSignerKey } from '@snaha/swarm-id'
+import { PrivateKey } from '@ethersphere/bee-js'
+
+// Account-level signer key
+const signerKeyHex = await derivePostageSignerKey(account.derivationKey)
+const signerKey = new PrivateKey(signerKeyHex)
+
+// Identity-specific signer key
+const identitySignerKeyHex = await derivePostageSignerKey(account.derivationKey, identity.id)
 ```

--- a/docs-site/src/content/docs/architecture.mdx
+++ b/docs-site/src/content/docs/architecture.mdx
@@ -75,10 +75,14 @@ Master Key (from Passkey/SIWE challenge)
 ├─> App-Specific Secret (HMAC-SHA256 with app origin)
 │       ├─> Low-stakes keys (feed, session) → shared with apps
 │       └─> High-stakes keys (stamps, ACT) → never shared
-├─> swarmEncryptionKey (HMAC-SHA256, persisted in account)
-│       ├─> backupKey (HMAC-SHA256 with "swarm-id-backup-encryption-v1")
-│       │       └─> AES-GCM-256 CryptoKey (for .swarmid encryption)
-│       └─> backup private key (for Swarm epoch feed owner)
+├─> derivationKey (HMAC-SHA256 with "derivation-key", persisted in account)
+│       ├─> swarmEncryptionKey (HMAC-SHA256 with "swarm-encryption")
+│       │       ├─> backup AES key (HMAC-SHA256 with "swarm-id-backup-encryption-v1")
+│       │       │       └─> AES-GCM-256 CryptoKey (for .swarmid encryption)
+│       │       └─> backup feed key (HMAC-SHA256 with "backup-key")
+│       │               └─> backup private key (for Swarm epoch feed owner)
+│       └─> postageSignerKey (HMAC-SHA256 with "postage-signer" or "postage-signer:{identityId}")
+│               └─> PrivateKey for signing postage batch chunks
 ```
 
 ### App Secret Derivation
@@ -157,12 +161,13 @@ During Ethereum account import, the user must re-enter their secret seed. The ma
 
 ### Export Flow
 
-Export requires **no re-authentication** — the `swarmEncryptionKey` is already persisted in the account. The flow:
+Export requires **no re-authentication** — the `derivationKey` is already persisted in the account. The flow:
 
 1. Serialize account state via `serializeAccountStateSnapshot()` (strips `appSecret`)
-2. Derive AES-GCM-256 key: `swarmEncryptionKey` → HMAC-SHA256 with context `"swarm-id-backup-encryption-v1"`
-3. Encrypt with random 12-byte IV
-4. Build header with account metadata + ciphertext
+2. Derive `swarmEncryptionKey` from `derivationKey` via HMAC-SHA256 with context `"swarm-encryption"`
+3. Derive AES-GCM-256 key: `swarmEncryptionKey` → HMAC-SHA256 with context `"swarm-id-backup-encryption-v1"`
+4. Encrypt with random 12-byte IV
+5. Build header with account metadata + ciphertext
 
 ### Import Flow
 
@@ -170,18 +175,19 @@ Import **requires authentication** to re-derive the encryption key:
 
 1. Parse the plaintext header to identify account type and metadata
 2. User authenticates (passkey or wallet) to obtain `masterKey`
-3. Derive `swarmEncryptionKey` → `backupKey` → AES-GCM-256 key
+3. Derive `derivationKey` → `swarmEncryptionKey` → `backupKey` → AES-GCM-256 key
 4. Decrypt and validate the payload via `deserializeAccountStateSnapshot()`
 
 ### Swarm Restore Flow
 
 When a passkey auth succeeds on a new device with no local account:
 
-1. Derive `swarmEncryptionKey` from `masterKey`
-2. Derive `backupKey` → epoch feed owner private key
-3. Build feed topic from account ID
-4. Look up latest epoch feed entry in Swarm
-5. Download and decrypt the account snapshot
+1. Derive `derivationKey` from `masterKey`
+2. Derive `swarmEncryptionKey` from `derivationKey`
+3. Derive `backupKey` → epoch feed owner private key
+4. Build feed topic from account ID
+5. Look up latest epoch feed entry in Swarm
+6. Download and decrypt the account snapshot
 
 ### Security: appSecret Exclusion
 

--- a/lib/README.md
+++ b/lib/README.md
@@ -304,22 +304,24 @@ import {
   createEncryptedExport,
   decryptEncryptedExport,
   parseEncryptedExportHeader,
+  deriveSwarmEncryptionKey,
 } from "@snaha/swarm-id"
 
-// Export (no re-auth needed — uses stored swarmEncryptionKey)
+// Export (no re-auth needed — derive swarmEncryptionKey from stored derivationKey)
+const swarmEncryptionKey = await deriveSwarmEncryptionKey(account.derivationKey)
 const exported = await createEncryptedExport(
   account,
   identities,
   connectedApps,
   postageStamps,
-  swarmEncryptionKeyHex,
+  swarmEncryptionKey,
 )
 
 // Read header metadata without decrypting
 const header = parseEncryptedExportHeader(fileData)
 
 // Import (requires auth to re-derive key)
-const result = await decryptEncryptedExport(fileData, swarmEncryptionKeyHex)
+const result = await decryptEncryptedExport(fileData, swarmEncryptionKey)
 if (result.success) {
   console.log(result.data) // AccountStateSnapshot
 }

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -152,7 +152,9 @@ export {
 export {
   // Account-level key derivation
   deriveAccountBackupKey,
-  deriveAccountSwarmEncryptionKey,
+  deriveAccountDerivationKey,
+  deriveSwarmEncryptionKey,
+  derivePostageSignerKey,
   backupKeyToPrivateKey,
   serializeAccountState,
   deserializeAccountState,

--- a/lib/src/schemas.ts
+++ b/lib/src/schemas.ts
@@ -121,7 +121,7 @@ const CommonAccountSchemaV1 = z.object({
   id: StoredEthAddress,
   name: z.string(),
   createdAt: z.number(),
-  swarmEncryptionKey: z.string().length(64),
+  derivationKey: z.string().length(64), // derived key for deterministic sub-key generation (64-char hex)
   defaultPostageStampBatchID: StoredBatchId.optional(),
   devices: z.array(DeviceSchemaV1).default([]),
 })

--- a/lib/src/swarm-id-proxy.ts
+++ b/lib/src/swarm-id-proxy.ts
@@ -89,7 +89,11 @@ import {
   createAccountsStorageManager,
   disconnectApp,
 } from "./utils/storage-managers"
-import { hexToUint8Array, uint8ArrayToHex } from "./utils/key-derivation"
+import {
+  hexToUint8Array,
+  uint8ArrayToHex,
+  deriveSwarmEncryptionKey,
+} from "./utils/key-derivation"
 import {
   createAsyncEpochFinder,
   createEpochUpdater,
@@ -417,7 +421,7 @@ export class SwarmIdProxy {
     }
 
     // Look up account info for utilization tracking
-    const accountInfo = this.lookupAccountForApp()
+    const accountInfo = await this.lookupAccountForApp()
     if (!accountInfo) {
       console.warn("[Proxy] Cannot initialize stamper: account not found")
       return
@@ -842,9 +846,9 @@ export class SwarmIdProxy {
    *
    * @returns Account info with owner address and encryption key, or undefined if not found
    */
-  private lookupAccountForApp():
-    | { owner: EthAddress; encryptionKey: Uint8Array }
-    | undefined {
+  private async lookupAccountForApp(): Promise<
+    { owner: EthAddress; encryptionKey: Uint8Array } | undefined
+  > {
     if (!this.parentOrigin) {
       return undefined
     }
@@ -877,9 +881,14 @@ export class SwarmIdProxy {
         return undefined
       }
 
+      // Derive swarm encryption key from stored derivation key
+      const swarmEncryptionKey = await deriveSwarmEncryptionKey(
+        account.derivationKey,
+      )
+
       return {
         owner: account.id,
-        encryptionKey: hexToUint8Array(account.swarmEncryptionKey),
+        encryptionKey: hexToUint8Array(swarmEncryptionKey),
       }
     } catch (error) {
       console.error("[Proxy] Error looking up account:", error)

--- a/lib/src/sync/index.ts
+++ b/lib/src/sync/index.ts
@@ -2,7 +2,9 @@
 export {
   // Account-level key derivation
   deriveAccountBackupKey,
-  deriveAccountSwarmEncryptionKey,
+  deriveAccountDerivationKey,
+  deriveSwarmEncryptionKey,
+  derivePostageSignerKey,
   backupKeyToPrivateKey,
 } from "../utils/key-derivation"
 export { serializeAccountState, deserializeAccountState } from "./serialization"

--- a/lib/src/sync/restore-account.ts
+++ b/lib/src/sync/restore-account.ts
@@ -15,7 +15,8 @@ import {
   type Bytes,
 } from "@ethersphere/bee-js"
 import {
-  deriveAccountSwarmEncryptionKey,
+  deriveAccountDerivationKey,
+  deriveSwarmEncryptionKey,
   deriveSecret,
 } from "../utils/key-derivation"
 import { ACCOUNT_SYNC_TOPIC_PREFIX } from "./sync-account"
@@ -29,7 +30,7 @@ import type { AccountStateSnapshot } from "../utils/account-state-snapshot"
  */
 export interface RestoreAccountResult {
   snapshot: AccountStateSnapshot
-  swarmEncryptionKey: string
+  derivationKey: string
   credentialId: string
 }
 
@@ -50,10 +51,9 @@ export async function restoreAccountFromSwarm(
 ): Promise<RestoreAccountResult | undefined> {
   const accountId = ethereumAddress.toHex()
 
-  // 1. Derive the swarm encryption key from the master key
-  const swarmEncryptionKey = await deriveAccountSwarmEncryptionKey(
-    masterKey.toHex(),
-  )
+  // 1. Derive the derivation key and swarm encryption key from the master key
+  const derivationKey = await deriveAccountDerivationKey(masterKey.toHex())
+  const swarmEncryptionKey = await deriveSwarmEncryptionKey(derivationKey)
 
   // 2. Derive the backup key (used as feed owner)
   const backupKeyHex = await deriveSecret(swarmEncryptionKey, "backup-key")
@@ -84,7 +84,7 @@ export async function restoreAccountFromSwarm(
 
   return {
     snapshot,
-    swarmEncryptionKey,
+    derivationKey,
     credentialId,
   }
 }

--- a/lib/src/sync/sync-account.ts
+++ b/lib/src/sync/sync-account.ts
@@ -15,7 +15,11 @@ import {
   Reference,
   type Chunk,
 } from "@ethersphere/bee-js"
-import { deriveSecret, hexToUint8Array } from "../utils/key-derivation"
+import {
+  deriveSecret,
+  deriveSwarmEncryptionKey,
+  hexToUint8Array,
+} from "../utils/key-derivation"
 import {
   updateAfterWrite,
   saveUtilizationState,
@@ -152,11 +156,13 @@ export function createSyncAccount(
     // Convert chunk addresses to Chunks
     const chunks = createChunksFromAddresses(chunkAddresses)
 
-    // Derive owner address from backup key
-    const backupKeyHex = await deriveSecret(
-      account.swarmEncryptionKey,
-      "backup-key",
+    // Derive swarm encryption key from derivation key
+    const swarmEncryptionKey = await deriveSwarmEncryptionKey(
+      account.derivationKey,
     )
+
+    // Derive owner address from backup key
+    const backupKeyHex = await deriveSecret(swarmEncryptionKey, "backup-key")
     const backupKey = new PrivateKey(backupKeyHex)
     const owner = backupKey.publicKey().address()
 
@@ -168,7 +174,7 @@ export function createSyncAccount(
       {
         bee,
         owner,
-        encryptionKey: hexToUint8Array(account.swarmEncryptionKey),
+        encryptionKey: hexToUint8Array(swarmEncryptionKey),
         cache: utilizationStore,
       },
     )
@@ -184,7 +190,7 @@ export function createSyncAccount(
       // Get stamper for signing chunks (with loaded bucket state)
       const stamper = await postageStampsStore.getStamper(batchID, {
         owner,
-        encryptionKey: hexToUint8Array(account.swarmEncryptionKey),
+        encryptionKey: hexToUint8Array(swarmEncryptionKey),
       })
       if (!stamper) {
         console.warn("[SyncCoordinator] Cannot create stamper, skipping upload")
@@ -198,7 +204,7 @@ export function createSyncAccount(
           await saveUtilizationState(utilizationState, {
             bee,
             stamper,
-            encryptionKey: hexToUint8Array(account.swarmEncryptionKey),
+            encryptionKey: hexToUint8Array(swarmEncryptionKey),
             cache: utilizationStore,
             tracker,
           })
@@ -234,13 +240,14 @@ export function createSyncAccount(
    * @param accountId - Account ID (hex address)
    * @returns Snapshot and sync context, or undefined if account/stamp not found
    */
-  function getAccountStateSnapshot(accountId: string):
+  async function getAccountStateSnapshot(accountId: string): Promise<
     | {
         snapshot: AccountStateSnapshot
         encryptionKey: string
         defaultStamp: PostageStamp
       }
-    | undefined {
+    | undefined
+  > {
     // Get account
     const account = accountsStore.getAccount(new EthAddress(accountId))
     if (!account) {
@@ -264,6 +271,9 @@ export function createSyncAccount(
       console.warn("[SyncCoordinator] Default stamp not found")
       return undefined
     }
+
+    // Derive swarm encryption key from stored derivation key
+    const encryptionKey = await deriveSwarmEncryptionKey(account.derivationKey)
 
     // Collect account state
     const identities = identitiesStore.getIdentitiesByAccount(account.id)
@@ -290,7 +300,7 @@ export function createSyncAccount(
 
     return {
       snapshot,
-      encryptionKey: account.swarmEncryptionKey,
+      encryptionKey,
       defaultStamp,
     }
   }
@@ -301,8 +311,8 @@ export function createSyncAccount(
     const startTime = performance.now()
     const timestamp = () => new Date().toISOString()
 
-    // Capture state snapshot BEFORE any async operations
-    const snapshotResult = getAccountStateSnapshot(accountId)
+    // Capture state snapshot (derives encryption key from derivation key)
+    const snapshotResult = await getAccountStateSnapshot(accountId)
     if (!snapshotResult) {
       return undefined
     }

--- a/lib/src/test-fixtures.ts
+++ b/lib/src/test-fixtures.ts
@@ -19,8 +19,8 @@ export const TEST_IDENTITY_ADDRESS_2_HEX = "2".repeat(40)
 export const TEST_BATCH_ID_HEX = "c".repeat(64)
 export const TEST_BATCH_ID_2_HEX = "e".repeat(64)
 export const TEST_PRIVATE_KEY_HEX = "d".repeat(64)
-export const TEST_ENCRYPTION_KEY_HEX = "f".repeat(64)
-export const DIFFERENT_ENCRYPTION_KEY_HEX = "3".repeat(64)
+export const TEST_DERIVATION_KEY_HEX = "f".repeat(64)
+export const DIFFERENT_DERIVATION_KEY_HEX = "1".repeat(64)
 
 export const TEST_DEVICE_ID = "550e8400-e29b-41d4-a716-446655440000"
 
@@ -42,7 +42,7 @@ export function createPasskeyAccount(
     createdAt: 1700000000000,
     type: "passkey" as const,
     credentialId: "credential-abc-123",
-    swarmEncryptionKey: TEST_ENCRYPTION_KEY_HEX,
+    derivationKey: TEST_DERIVATION_KEY_HEX,
     devices: [],
     ...overrides,
   }
@@ -60,7 +60,7 @@ export function createEthereumAccount(
     encryptedMasterKey: new Bytes(new Uint8Array([1, 2, 3, 4])),
     encryptionSalt: new Bytes(new Uint8Array([5, 6, 7, 8])),
     encryptedSecretSeed: new Bytes(new Uint8Array([9, 10, 11, 12])),
-    swarmEncryptionKey: TEST_ENCRYPTION_KEY_HEX,
+    derivationKey: TEST_DERIVATION_KEY_HEX,
     devices: [],
     ...overrides,
   }
@@ -74,7 +74,7 @@ export function createAgentAccount(
     name: "Test Agent Account",
     createdAt: 1700000000000,
     type: "agent" as const,
-    swarmEncryptionKey: TEST_ENCRYPTION_KEY_HEX,
+    derivationKey: TEST_DERIVATION_KEY_HEX,
     devices: [],
     ...overrides,
   }

--- a/lib/src/utils/backup-encryption.test.ts
+++ b/lib/src/utils/backup-encryption.test.ts
@@ -13,8 +13,8 @@ import {
 import {
   TEST_ETH_ADDRESS_HEX,
   TEST_ETH_ADDRESS_2_HEX,
-  TEST_ENCRYPTION_KEY_HEX,
-  DIFFERENT_ENCRYPTION_KEY_HEX,
+  TEST_DERIVATION_KEY_HEX,
+  DIFFERENT_DERIVATION_KEY_HEX,
   createPasskeyAccount,
   createEthereumAccount,
   createAgentAccount,
@@ -39,7 +39,7 @@ describe("round-trip: encrypt → decrypt for each account type", () => {
       identities,
       connectedApps,
       postageStamps,
-      account.swarmEncryptionKey,
+      TEST_DERIVATION_KEY_HEX,
     )
 
     expect(encrypted.accountType).toBe("passkey")
@@ -52,7 +52,7 @@ describe("round-trip: encrypt → decrypt for each account type", () => {
 
     const result = await decryptEncryptedExport(
       encrypted,
-      account.swarmEncryptionKey,
+      TEST_DERIVATION_KEY_HEX,
     )
 
     expect(result.success).toBe(true)
@@ -75,7 +75,7 @@ describe("round-trip: encrypt → decrypt for each account type", () => {
       identities,
       [],
       [],
-      account.swarmEncryptionKey,
+      TEST_DERIVATION_KEY_HEX,
     )
 
     expect(encrypted.accountType).toBe("ethereum")
@@ -83,7 +83,7 @@ describe("round-trip: encrypt → decrypt for each account type", () => {
 
     const result = await decryptEncryptedExport(
       encrypted,
-      account.swarmEncryptionKey,
+      TEST_DERIVATION_KEY_HEX,
     )
 
     expect(result.success).toBe(true)
@@ -102,14 +102,14 @@ describe("round-trip: encrypt → decrypt for each account type", () => {
       identities,
       [],
       [],
-      account.swarmEncryptionKey,
+      TEST_DERIVATION_KEY_HEX,
     )
 
     expect(encrypted.accountType).toBe("agent")
 
     const result = await decryptEncryptedExport(
       encrypted,
-      account.swarmEncryptionKey,
+      TEST_DERIVATION_KEY_HEX,
     )
 
     expect(result.success).toBe(true)
@@ -133,7 +133,7 @@ describe("round-trip: encrypt → decrypt for each account type", () => {
       identities,
       connectedApps,
       postageStamps,
-      account.swarmEncryptionKey,
+      TEST_DERIVATION_KEY_HEX,
     )
 
     // Simulate file write + read
@@ -142,7 +142,7 @@ describe("round-trip: encrypt → decrypt for each account type", () => {
 
     const result = await decryptEncryptedExport(
       fileData,
-      account.swarmEncryptionKey,
+      TEST_DERIVATION_KEY_HEX,
     )
 
     expect(result.success).toBe(true)
@@ -168,12 +168,12 @@ describe("appSecret preservation in encrypted export", () => {
       [],
       connectedApps,
       [],
-      account.swarmEncryptionKey,
+      TEST_DERIVATION_KEY_HEX,
     )
 
     const result = await decryptEncryptedExport(
       encrypted,
-      account.swarmEncryptionKey,
+      TEST_DERIVATION_KEY_HEX,
     )
 
     expect(result.success).toBe(true)
@@ -189,8 +189,8 @@ describe("appSecret preservation in encrypted export", () => {
 
 describe("key derivation determinism", () => {
   it("should derive the same CryptoKey from the same swarmEncryptionKey", async () => {
-    const key1 = await deriveBackupEncryptionKey(TEST_ENCRYPTION_KEY_HEX)
-    const key2 = await deriveBackupEncryptionKey(TEST_ENCRYPTION_KEY_HEX)
+    const key1 = await deriveBackupEncryptionKey(TEST_DERIVATION_KEY_HEX)
+    const key2 = await deriveBackupEncryptionKey(TEST_DERIVATION_KEY_HEX)
 
     // Verify determinism: encrypt with key1, decrypt with key2
     const plaintext = '{"determinism":"test"}'
@@ -201,8 +201,8 @@ describe("key derivation determinism", () => {
   })
 
   it("should derive different keys from different swarmEncryptionKeys", async () => {
-    const key1 = await deriveBackupEncryptionKey(TEST_ENCRYPTION_KEY_HEX)
-    const key2 = await deriveBackupEncryptionKey(DIFFERENT_ENCRYPTION_KEY_HEX)
+    const key1 = await deriveBackupEncryptionKey(TEST_DERIVATION_KEY_HEX)
+    const key2 = await deriveBackupEncryptionKey(DIFFERENT_DERIVATION_KEY_HEX)
 
     // Encrypt with key1, should fail to decrypt with key2
     const ciphertext = await encryptBackupPayload('{"test":true}', key1)
@@ -223,12 +223,12 @@ describe("wrong key rejection", () => {
       [createIdentity()],
       [],
       [],
-      account.swarmEncryptionKey,
+      TEST_DERIVATION_KEY_HEX,
     )
 
     const result = await decryptEncryptedExport(
       encrypted,
-      DIFFERENT_ENCRYPTION_KEY_HEX,
+      DIFFERENT_DERIVATION_KEY_HEX,
     )
 
     expect(result.success).toBe(false)
@@ -237,9 +237,9 @@ describe("wrong key rejection", () => {
   })
 
   it("should fail at the payload level with wrong key", async () => {
-    const correctKey = await deriveBackupEncryptionKey(TEST_ENCRYPTION_KEY_HEX)
+    const correctKey = await deriveBackupEncryptionKey(TEST_DERIVATION_KEY_HEX)
     const wrongKey = await deriveBackupEncryptionKey(
-      DIFFERENT_ENCRYPTION_KEY_HEX,
+      DIFFERENT_DERIVATION_KEY_HEX,
     )
 
     const ciphertext = await encryptBackupPayload('{"test": true}', correctKey)
@@ -298,7 +298,7 @@ describe("schema validation", () => {
       [],
       [],
       [],
-      TEST_ENCRYPTION_KEY_HEX,
+      TEST_DERIVATION_KEY_HEX,
     )
 
     const result = EncryptedSwarmIdExportSchemaV1.safeParse(encrypted)
@@ -311,7 +311,7 @@ describe("schema validation", () => {
       [],
       [],
       [],
-      TEST_ENCRYPTION_KEY_HEX,
+      TEST_DERIVATION_KEY_HEX,
     )
 
     const result = EncryptedSwarmIdExportSchemaV1.safeParse(encrypted)
@@ -324,7 +324,7 @@ describe("schema validation", () => {
       [],
       [],
       [],
-      TEST_ENCRYPTION_KEY_HEX,
+      TEST_DERIVATION_KEY_HEX,
     )
 
     const result = EncryptedSwarmIdExportSchemaV1.safeParse(encrypted)
@@ -378,7 +378,7 @@ describe("parseEncryptedExportHeader", () => {
       [],
       [],
       [],
-      TEST_ENCRYPTION_KEY_HEX,
+      TEST_DERIVATION_KEY_HEX,
     )
 
     const result = parseEncryptedExportHeader(encrypted)
@@ -419,7 +419,7 @@ describe("parseEncryptedExportHeader", () => {
 
 describe("encryptBackupPayload / decryptBackupPayload", () => {
   it("should encrypt and decrypt a payload", async () => {
-    const key = await deriveBackupEncryptionKey(TEST_ENCRYPTION_KEY_HEX)
+    const key = await deriveBackupEncryptionKey(TEST_DERIVATION_KEY_HEX)
     const plaintext = '{"hello":"world"}'
 
     const ciphertext = await encryptBackupPayload(plaintext, key)
@@ -431,7 +431,7 @@ describe("encryptBackupPayload / decryptBackupPayload", () => {
   })
 
   it("should produce different ciphertext for same input (random IV)", async () => {
-    const key = await deriveBackupEncryptionKey(TEST_ENCRYPTION_KEY_HEX)
+    const key = await deriveBackupEncryptionKey(TEST_DERIVATION_KEY_HEX)
     const plaintext = '{"test":true}'
 
     const ct1 = await encryptBackupPayload(plaintext, key)

--- a/lib/src/utils/backup-encryption.ts
+++ b/lib/src/utils/backup-encryption.ts
@@ -2,11 +2,12 @@
  * Backup Encryption Module
  *
  * Provides AES-GCM-256 encryption for .swarmid backup files.
- * The encryption key is derived from the account's swarmEncryptionKey
- * (which is always persisted on all account types), so export requires
- * NO re-authentication. Import requires auth to re-derive the key.
+ * The encryption key is derived from swarmEncryptionKey, which is itself
+ * derived from the account's derivationKey (always persisted on all
+ * account types), so export requires NO re-authentication.
+ * Import requires auth to re-derive the key.
  *
- * Key chain: masterKey → swarmEncryptionKey (stored) → backupKey (HMAC-SHA256)
+ * Key chain: masterKey → derivationKey (stored) → swarmEncryptionKey → backupKey (HMAC-SHA256)
  */
 
 import { z } from "zod"

--- a/lib/src/utils/key-derivation.ts
+++ b/lib/src/utils/key-derivation.ts
@@ -170,17 +170,52 @@ export async function deriveAccountBackupKey(
 }
 
 /**
- * Derive account Swarm encryption key from account master key
+ * Derive account derivation key from account master key
  *
- * Used for encrypting account snapshot data before upload to Swarm
+ * A generic 32-byte root key stored on the account, used for deterministically
+ * deriving further keys (e.g. swarmEncryptionKey) without re-authentication.
  *
  * @param accountMasterKey - Account master key (hex string)
- * @returns 32-byte encryption key (as hex string)
+ * @returns 32-byte derivation key (as hex string)
  */
-export async function deriveAccountSwarmEncryptionKey(
+export async function deriveAccountDerivationKey(
   accountMasterKey: string,
 ): Promise<string> {
-  return deriveSecret(accountMasterKey, `swarm-encryption`)
+  return deriveSecret(accountMasterKey, `derivation-key`)
+}
+
+/**
+ * Derive Swarm encryption key from account derivation key
+ *
+ * Used for encrypting account snapshot data before upload to Swarm.
+ * Derived from the stored derivationKey rather than the master key directly.
+ *
+ * @param derivationKey - Account derivation key (hex string)
+ * @returns 32-byte encryption key (as hex string)
+ */
+export async function deriveSwarmEncryptionKey(
+  derivationKey: string,
+): Promise<string> {
+  return deriveSecret(derivationKey, `swarm-encryption`)
+}
+
+/**
+ * Derive postage batch signer key from account derivation key
+ *
+ * Used as the PrivateKey for signing chunks uploaded with a postage batch.
+ * When identityId is provided, derives a unique signer key per identity;
+ * otherwise derives an account-level signer key.
+ *
+ * @param derivationKey - Account derivation key (hex string)
+ * @param identityId - Optional identity ID for per-identity signer keys
+ * @returns 32-byte signer key (as hex string)
+ */
+export async function derivePostageSignerKey(
+  derivationKey: string,
+  identityId?: string,
+): Promise<string> {
+  const context = identityId ? `postage-signer:${identityId}` : `postage-signer`
+  return deriveSecret(derivationKey, context)
 }
 
 /**

--- a/lib/src/utils/storage-managers.ts
+++ b/lib/src/utils/storage-managers.ts
@@ -101,7 +101,7 @@ export function serializeAccount(account: Account): Record<string, unknown> {
     name: account.name,
     createdAt: account.createdAt,
     type: account.type,
-    swarmEncryptionKey: account.swarmEncryptionKey,
+    derivationKey: account.derivationKey,
     defaultPostageStampBatchID: account.defaultPostageStampBatchID?.toString(),
     devices: account.devices,
   }

--- a/swarm-ui/src/lib/agent-account.ts
+++ b/swarm-ui/src/lib/agent-account.ts
@@ -19,7 +19,7 @@ export interface CreateAgentAccountOptions {
 }
 
 export interface CreateAgentAccountResult {
-  account: Omit<AgentAccount, 'swarmEncryptionKey'>
+  account: Omit<AgentAccount, 'derivationKey'>
   masterKey: Bytes
 }
 

--- a/swarm-ui/src/lib/components/add-postage-stamp.svelte
+++ b/swarm-ui/src/lib/components/add-postage-stamp.svelte
@@ -10,12 +10,11 @@
   import ArrowRight from 'carbon-icons-svelte/lib/ArrowRight.svelte'
   import { postageStampsStore } from '$lib/stores/postage-stamps.svelte'
   import { BatchId, PrivateKey } from '@ethersphere/bee-js'
-  import {
-    openStampPurchaseWidget,
-    generateSignerKey,
-    type BatchEvent,
-  } from '$lib/services/multichain-widget'
+  import { openStampPurchaseWidget, type BatchEvent } from '$lib/services/multichain-widget'
+  import { derivePostageSignerKey, hexToUint8Array } from '@snaha/swarm-id'
   import type { PostageStamp } from '@snaha/swarm-id'
+  import { accountsStore } from '$lib/stores/accounts.svelte'
+  import { EthAddress } from '@ethersphere/bee-js'
   import { devSettingsStore } from '$lib/stores/dev-settings.svelte'
   import { resolve } from '$app/paths'
   import routes from '$lib/routes'
@@ -29,6 +28,7 @@
 
   interface Props {
     accountId: string
+    identityId?: string
     onSuccess: (stamp: PostageStamp) => void
     onSkip?: () => void
     introText?: string
@@ -47,6 +47,7 @@
 
   let {
     accountId,
+    identityId,
     onSuccess,
     onSkip,
     introText = 'Synced accounts require a Swarm postage stamp.',
@@ -102,9 +103,15 @@
     }
   }
 
-  export function handlePurchase() {
-    // Generate random signer key
-    signerKeyBytes = generateSignerKey()
+  export async function handlePurchase() {
+    // Derive signer key from account's derivation key
+    const account = accountsStore.getAccount(new EthAddress(accountId))
+    if (!account) {
+      console.error('[AddPostageStamp] Account not found', accountId)
+      return
+    }
+    const signerKeyHex = await derivePostageSignerKey(account.derivationKey, identityId)
+    signerKeyBytes = hexToUint8Array(signerKeyHex)
     const signerKeyPrivate = new PrivateKey(signerKeyBytes)
 
     // Derive destination address from signer key

--- a/swarm-ui/src/lib/components/drawer.svelte
+++ b/swarm-ui/src/lib/components/drawer.svelte
@@ -31,7 +31,11 @@
   import Badge from '$lib/components/ui/badge.svelte'
   import { identitiesStore } from '$lib/stores/identities.svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
-  import { createEncryptedExport, SWARM_SECRET_PREFIX } from '@snaha/swarm-id'
+  import {
+    createEncryptedExport,
+    deriveSwarmEncryptionKey,
+    SWARM_SECRET_PREFIX,
+  } from '@snaha/swarm-id'
   import { connectedAppsStore } from '$lib/stores/connected-apps.svelte'
   import { postageStampsStore } from '$lib/stores/postage-stamps.svelte'
   import type { Account, Identity } from '$lib/types'
@@ -130,7 +134,7 @@
         accountIdentities,
         connectedApps,
         postageStamps,
-        account.swarmEncryptionKey,
+        await deriveSwarmEncryptionKey(account.derivationKey),
       )
       const json = JSON.stringify(encrypted, undefined, 2)
       const blob = new Blob([json], { type: 'application/json' })

--- a/swarm-ui/src/lib/services/multichain-widget.ts
+++ b/swarm-ui/src/lib/services/multichain-widget.ts
@@ -205,12 +205,3 @@ export function openStampPurchaseWidget(options: PurchaseStampOptions): void {
     }, MOCK_DELAY_MS)
   }
 }
-
-/**
- * Generate a random signer key (32 bytes)
- */
-export function generateSignerKey(): Uint8Array {
-  const key = new Uint8Array(32)
-  crypto.getRandomValues(key)
-  return key
-}

--- a/swarm-ui/src/routes/(app)/(create)/agent/new/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/agent/new/+page.svelte
@@ -20,11 +20,7 @@
   import { sessionStore } from '$lib/stores/session.svelte'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { createAgentAccount, validateSeedPhrase, countSeedPhraseWords } from '$lib/agent-account'
-  import {
-    deriveAccountSwarmEncryptionKey,
-    getOrCreateDeviceId,
-    mergeDevices,
-  } from '@snaha/swarm-id'
+  import { deriveAccountDerivationKey, getOrCreateDeviceId, mergeDevices } from '@snaha/swarm-id'
   import type { AccountSyncType } from '$lib/types'
 
   let showTypeTooltip = $state(false)
@@ -87,8 +83,8 @@
         seedPhrase: validation.phrase,
       })
 
-      // Derive swarmEncryptionKey from master key
-      const swarmEncryptionKey = await deriveAccountSwarmEncryptionKey(masterKey.toHex())
+      // Derive derivationKey from master key
+      const derivationKey = await deriveAccountDerivationKey(masterKey.toHex())
 
       // Store account (seed phrase is NOT stored - must be re-entered each time)
       const newAccount = accountsStore.addAccount({
@@ -96,7 +92,7 @@
         name: account.name,
         createdAt: account.createdAt,
         type: 'agent',
-        swarmEncryptionKey,
+        derivationKey,
         devices: mergeDevices([], getOrCreateDeviceId()),
       })
       sessionStore.setAccount(newAccount)

--- a/swarm-ui/src/routes/(app)/(create)/eth/new/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/eth/new/+page.svelte
@@ -31,11 +31,7 @@
   import { WarningAlt } from 'carbon-icons-svelte'
   import Confirmation from '$lib/components/confirmation.svelte'
   import { onMount } from 'svelte'
-  import {
-    deriveAccountSwarmEncryptionKey,
-    getOrCreateDeviceId,
-    mergeDevices,
-  } from '@snaha/swarm-id'
+  import { deriveAccountDerivationKey, getOrCreateDeviceId, mergeDevices } from '@snaha/swarm-id'
   import type { AccountSyncType } from '$lib/types'
 
   let showTypeTooltip = $state(false)
@@ -88,8 +84,8 @@
 
       const { masterKey, masterAddress } = deriveMasterKey(secretSeed, signed.publicKey)
 
-      // Derive swarmEncryptionKey from master key
-      const swarmEncryptionKey = await deriveAccountSwarmEncryptionKey(masterKey.toHex())
+      // Derive derivationKey from master key
+      const derivationKey = await deriveAccountDerivationKey(masterKey.toHex())
 
       // Encrypt masterKey before storage
 
@@ -116,7 +112,7 @@
         encryptedMasterKey: encryptedMasterKey,
         encryptionSalt: encryptionSalt,
         encryptedSecretSeed: encryptedSecretSeed,
-        swarmEncryptionKey: swarmEncryptionKey,
+        derivationKey,
         devices: mergeDevices([], getOrCreateDeviceId()),
       })
       sessionStore.setAccount(newAccount)

--- a/swarm-ui/src/routes/(app)/(create)/import/ethereum/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/import/ethereum/+page.svelte
@@ -22,7 +22,11 @@
     deriveSecretSeedEncryptionKey,
     encryptSecretSeed,
   } from '$lib/utils/encryption'
-  import { decryptEncryptedExport, deriveAccountSwarmEncryptionKey } from '@snaha/swarm-id'
+  import {
+    decryptEncryptedExport,
+    deriveAccountDerivationKey,
+    deriveSwarmEncryptionKey,
+  } from '@snaha/swarm-id'
   import { EthAddress, BatchId } from '@ethersphere/bee-js'
   import { restoreAccountToStores } from '$lib/utils/restore-account'
 
@@ -67,7 +71,8 @@
       }
 
       const { masterKey, masterAddress } = deriveMasterKey(secretSeed, signed.publicKey)
-      const swarmEncryptionKey = await deriveAccountSwarmEncryptionKey(masterKey.toHex())
+      const derivationKey = await deriveAccountDerivationKey(masterKey.toHex())
+      const swarmEncryptionKey = await deriveSwarmEncryptionKey(derivationKey)
 
       const result = await decryptEncryptedExport(fileData, swarmEncryptionKey)
 
@@ -94,7 +99,7 @@
           encryptedMasterKey,
           encryptionSalt,
           encryptedSecretSeed,
-          swarmEncryptionKey,
+          derivationKey,
           defaultPostageStampBatchID: result.data.metadata.defaultPostageStampBatchID
             ? new BatchId(result.data.metadata.defaultPostageStampBatchID)
             : undefined,

--- a/swarm-ui/src/routes/(app)/(create)/import/passkey/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/import/passkey/+page.svelte
@@ -13,7 +13,11 @@
   import { navigateToConnectOrHome } from '$lib/utils/navigation'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { authenticateWithPasskey } from '$lib/passkey'
-  import { decryptEncryptedExport, deriveAccountSwarmEncryptionKey } from '@snaha/swarm-id'
+  import {
+    decryptEncryptedExport,
+    deriveAccountDerivationKey,
+    deriveSwarmEncryptionKey,
+  } from '@snaha/swarm-id'
   import { BatchId } from '@ethersphere/bee-js'
   import { restoreAccountToStores } from '$lib/utils/restore-account'
 
@@ -56,9 +60,8 @@
         return
       }
 
-      const swarmEncryptionKey = await deriveAccountSwarmEncryptionKey(
-        passkeyAccount.masterKey.toHex(),
-      )
+      const derivationKey = await deriveAccountDerivationKey(passkeyAccount.masterKey.toHex())
+      const swarmEncryptionKey = await deriveSwarmEncryptionKey(derivationKey)
 
       const result = await decryptEncryptedExport(fileData, swarmEncryptionKey)
 
@@ -75,7 +78,7 @@
           name: result.data.metadata.accountName,
           type: 'passkey',
           credentialId: passkeyAccount.credentialId,
-          swarmEncryptionKey,
+          derivationKey,
           defaultPostageStampBatchID: result.data.metadata.defaultPostageStampBatchID
             ? new BatchId(result.data.metadata.defaultPostageStampBatchID)
             : undefined,

--- a/swarm-ui/src/routes/(app)/(create)/passkey/new/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/passkey/new/+page.svelte
@@ -20,11 +20,7 @@
   import Confirmation from '$lib/components/confirmation.svelte'
   import { onMount } from 'svelte'
   import ErrorMessage from '$lib/components/ui/error-message.svelte'
-  import {
-    deriveAccountSwarmEncryptionKey,
-    getOrCreateDeviceId,
-    mergeDevices,
-  } from '@snaha/swarm-id'
+  import { deriveAccountDerivationKey, getOrCreateDeviceId, mergeDevices } from '@snaha/swarm-id'
   import type { AccountSyncType } from '$lib/types'
 
   let accountName = $state('Passkey')
@@ -71,8 +67,8 @@
         userDisplayName: accountName.trim(),
       })
 
-      // Derive swarmEncryptionKey from master key
-      const swarmEncryptionKey = await deriveAccountSwarmEncryptionKey(account.masterKey.toHex())
+      // Derive derivationKey from master key
+      const derivationKey = await deriveAccountDerivationKey(account.masterKey.toHex())
 
       // Store account WITHOUT masterKey (passkey accounts never persist masterKey)
       const newAccount = accountsStore.addAccount({
@@ -81,7 +77,7 @@
         name: accountName.trim(),
         type: 'passkey',
         credentialId: account.credentialId,
-        swarmEncryptionKey: swarmEncryptionKey,
+        derivationKey,
         devices: mergeDevices([], getOrCreateDeviceId()),
       })
       sessionStore.setAccount(newAccount)

--- a/swarm-ui/src/routes/(app)/(create)/signin/ethereum/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/signin/ethereum/+page.svelte
@@ -15,7 +15,7 @@
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
   import { connectAndSign, deriveMasterKey } from '$lib/ethereum'
-  import { restoreAccountFromSwarm, deriveAccountSwarmEncryptionKey } from '@snaha/swarm-id'
+  import { restoreAccountFromSwarm, deriveAccountDerivationKey } from '@snaha/swarm-id'
   import { Bee, BatchId, EthAddress } from '@ethersphere/bee-js'
   import { restoreAccountToStores } from '$lib/utils/restore-account'
   import {
@@ -80,7 +80,7 @@
         const encryptedMasterKey = await encryptMasterKey(masterKey, encryptionKey)
         const secretSeedEncryptionKey = await deriveSecretSeedEncryptionKey(masterKey)
         const encryptedSecretSeed = await encryptSecretSeed(secretSeed, secretSeedEncryptionKey)
-        const swarmEncryptionKey = await deriveAccountSwarmEncryptionKey(masterKey.toHex())
+        const derivationKey = await deriveAccountDerivationKey(masterKey.toHex())
 
         account = restoreAccountToStores({
           account: {
@@ -92,7 +92,7 @@
             encryptedMasterKey,
             encryptionSalt,
             encryptedSecretSeed,
-            swarmEncryptionKey,
+            derivationKey,
             defaultPostageStampBatchID: result.snapshot.metadata.defaultPostageStampBatchID
               ? new BatchId(result.snapshot.metadata.defaultPostageStampBatchID)
               : undefined,

--- a/swarm-ui/src/routes/(app)/(create)/signin/passkey/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/signin/passkey/+page.svelte
@@ -69,7 +69,7 @@
           name: result.snapshot.metadata.accountName,
           type: 'passkey',
           credentialId: passkeyAccount.credentialId,
-          swarmEncryptionKey: result.swarmEncryptionKey,
+          derivationKey: result.derivationKey,
           defaultPostageStampBatchID: result.snapshot.metadata.defaultPostageStampBatchID
             ? new BatchId(result.snapshot.metadata.defaultPostageStampBatchID)
             : undefined,

--- a/swarm-ui/src/routes/(app)/(create)/stamps/identity/new/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/stamps/identity/new/+page.svelte
@@ -56,6 +56,7 @@
       <AddPostageStamp
         bind:this={addPostageStampRef}
         accountId={account.id.toHex()}
+        identityId={currentIdentityId}
         onSuccess={handleSuccess}
         introText="You chose to use a separate stamp for this identity."
         variant="account-creation"

--- a/swarm-ui/src/routes/(app)/identity/[id]/stamps/new/+page@.svelte
+++ b/swarm-ui/src/routes/(app)/identity/[id]/stamps/new/+page@.svelte
@@ -90,6 +90,7 @@
       <AddPostageStamp
         bind:this={addPostageStampRef}
         accountId={account.id.toHex()}
+        {identityId}
         onSuccess={handleSuccess}
         onSkip={isUpgrade ? undefined : navigateBack}
         {introText}


### PR DESCRIPTION
- **BREAKING CHANGE**: Replace `swarmEncryptionKey` with a generic `derivationKey` on all account types (passkey, ethereum, agent). The derivation key is stored in the account and used to deterministically derive sub-keys without re-authentication.
- Derive postage batch `signerKey` from `derivationKey` instead of generating it randomly, making it recoverable on new devices. Supports per-identity signer keys via optional `identityId` parameter.
- New key hierarchy: `masterKey -> derivationKey [stored] -> swarmEncryptionKey | postageSignerKey [computed]`

**Key changes:**
- `deriveAccountDerivationKey(masterKey)` derives root key stored on account
- `deriveSwarmEncryptionKey(derivationKey)` replaces old direct `swarmEncryptionKey`
- `derivePostageSignerKey(derivationKey, identityId?)` replaces `generateSignerKey()`
- All account creation, import, signin, and sync flows updated
- Documentation updated (architecture, API reference, README)

**Breaking:** Existing accounts, `.swarmid` exports, and Swarm-synced data are incompatible and will need to be recreated.

Closes snaha/swarm-id#222
