### PR TITLE
fix: open auth window directly on Chrome/Firefox to avoid popup blocking

### DIFF
--- a/demo/src/lib/components/layout/sidebar-auth.svelte
+++ b/demo/src/lib/components/layout/sidebar-auth.svelte
@@ -7,17 +7,8 @@
   import InfoButton from '$lib/components/ui/tooltip/info-button.svelte'
   import { clientStore } from '$lib/stores/client.svelte'
 
-  const isHTTP = $derived(typeof window !== 'undefined' && window.location.protocol === 'http:')
-  const hasITP = $derived(
-    typeof navigator !== 'undefined' && /^((?!chrome|android).)*safari/i.test(navigator.userAgent),
-  )
-
   let agentSignup = $state(false)
   let popoverOpen = $state(false)
-
-  const connectDisabled = $derived(
-    isHTTP && !hasITP && !clientStore.storageVerified && !clientStore.authenticated,
-  )
 
   // Close popover when auth state changes (covers iframe button connect/disconnect)
   let prevAuth = $state(clientStore.authenticated)
@@ -112,18 +103,11 @@
           clientStore.connect({ agent: agentSignup })
           popoverOpen = false
         }}
-        disabled={connectDisabled}
         size="sm"
         class="w-full mt-2"
       >
         {clientStore.authenticated ? 'Disconnect' : 'Connect'}
       </Button>
-      {#if connectDisabled}
-        <p class="text-xs text-muted-foreground mt-1.5">
-          Disabled because your browser cannot verify cross-site storage access yet. Use the iframe
-          button below to authenticate first.
-        </p>
-      {/if}
     </div>
 
     <Separator />

--- a/demo/src/lib/stores/client.svelte.ts
+++ b/demo/src/lib/stores/client.svelte.ts
@@ -3,7 +3,6 @@ import { resolveProxyOrigin } from '$lib/utils/environment'
 import { logStore } from './log.svelte'
 
 const PROXY_PATH = '/proxy'
-const STORAGE_VERIFIED_KEY = 'swarm-demo-storage-verified'
 const CLIENT_TIMEOUT = 600000 // 10 minutes for large file uploads
 
 const BEE_ICON =
@@ -33,7 +32,6 @@ let canUpload = $state(false)
 let storagePartitioned = $state(false)
 let identity = $state<IdentityInfo | undefined>(undefined)
 let stamp = $state<StampInfo | undefined>(undefined)
-let storageVerified = $state(false)
 let deferred = $state(false)
 let initializing = $state(false)
 
@@ -77,9 +75,6 @@ async function updateAuthStatus(isAuthenticated: boolean) {
   authenticated = isAuthenticated
 
   if (isAuthenticated) {
-    storageVerified = true
-    localStorage.setItem(STORAGE_VERIFIED_KEY, 'true')
-
     try {
       const connectionInfo = await client!.getConnectionInfo()
       logStore.log(
@@ -147,9 +142,6 @@ export const clientStore = {
   get stamp() {
     return stamp
   },
-  get storageVerified() {
-    return storageVerified
-  },
   get deferred() {
     return deferred
   },
@@ -168,8 +160,6 @@ export const clientStore = {
     initializing = true
 
     const proxyOrigin = resolveProxyOrigin()
-    storageVerified = localStorage.getItem(STORAGE_VERIFIED_KEY) === 'true'
-
     logStore.log('Initializing Swarm ID client...')
     logStore.log(`PROXY_ORIGIN: ${proxyOrigin}`)
     logStore.log(`PROXY_PATH: ${PROXY_PATH}`)

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -398,6 +398,9 @@ export { SWARM_SECRET_PREFIX, STORAGE_CHALLENGE_KEY } from "./types"
 // URL building utilities
 export { buildAuthUrl } from "./utils/url"
 
+// Browser detection utilities
+export { isWebKit } from "./utils/browser"
+
 // Manifest builder utilities for /bzz/ feed compatibility
 export {
   buildBzzCompatibleManifest,

--- a/lib/src/swarm-id-client.test.ts
+++ b/lib/src/swarm-id-client.test.ts
@@ -1,10 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import { SwarmIdClient } from "./swarm-id-client"
+import * as browser from "./utils/browser"
 
 describe("SwarmIdClient connect()", () => {
   let client: SwarmIdClient
 
   beforeEach(() => {
+    vi.restoreAllMocks()
+
     // Mock window object and its properties
     const mockWindow = {
       addEventListener: vi.fn(),
@@ -38,57 +41,91 @@ describe("SwarmIdClient connect()", () => {
     })
   })
 
-  it("should send connect message to proxy", async () => {
-    vi.spyOn(client, "ensureReady").mockImplementation(() => {})
-    const sendRequestSpy = vi
-      .spyOn(client as never, "sendRequest")
-      .mockResolvedValue({
-        type: "connectResponse",
-        requestId: "test",
-        success: true,
-      })
-
-    await client.connect()
-
-    expect(sendRequestSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "connect",
-        agent: undefined,
-      }),
-    )
-  })
-
-  it("should send agent flag to proxy when agent option is true", async () => {
-    vi.spyOn(client, "ensureReady").mockImplementation(() => {})
-    const sendRequestSpy = vi
-      .spyOn(client as never, "sendRequest")
-      .mockResolvedValue({
-        type: "connectResponse",
-        requestId: "test",
-        success: true,
-      })
-
-    await client.connect({ agent: true })
-
-    expect(sendRequestSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: "connect",
-        agent: true,
-      }),
-    )
-  })
-
-  it("should throw when popup fails to open", async () => {
-    vi.spyOn(client, "ensureReady").mockImplementation(() => {})
-    vi.spyOn(client as never, "sendRequest").mockResolvedValue({
-      type: "connectResponse",
-      requestId: "test",
-      success: false,
+  describe("non-WebKit (Chrome/Firefox)", () => {
+    beforeEach(() => {
+      vi.spyOn(browser, "isWebKit").mockReturnValue(false)
     })
 
-    await expect(client.connect()).rejects.toThrow(
-      "Failed to open authentication popup",
-    )
+    it("should open window directly with auth URL", async () => {
+      vi.spyOn(client, "ensureReady").mockImplementation(() => {})
+
+      await client.connect()
+
+      expect(window.open).toHaveBeenCalledWith(
+        expect.stringContaining("https://swarm-id.example.com/connect#origin="),
+        "_blank",
+      )
+    })
+
+    it("should include agent param in auth URL", async () => {
+      vi.spyOn(client, "ensureReady").mockImplementation(() => {})
+
+      await client.connect({ agent: true })
+
+      expect(window.open).toHaveBeenCalledWith(
+        expect.stringContaining("agent="),
+        "_blank",
+      )
+    })
+  })
+
+  describe("WebKit (Safari/iOS)", () => {
+    beforeEach(() => {
+      vi.spyOn(browser, "isWebKit").mockReturnValue(true)
+    })
+
+    it("should send connect message to proxy", async () => {
+      vi.spyOn(client, "ensureReady").mockImplementation(() => {})
+      const sendRequestSpy = vi
+        .spyOn(client as never, "sendRequest")
+        .mockResolvedValue({
+          type: "connectResponse",
+          requestId: "test",
+          success: true,
+        })
+
+      await client.connect()
+
+      expect(sendRequestSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "connect",
+          agent: undefined,
+        }),
+      )
+    })
+
+    it("should send agent flag to proxy", async () => {
+      vi.spyOn(client, "ensureReady").mockImplementation(() => {})
+      const sendRequestSpy = vi
+        .spyOn(client as never, "sendRequest")
+        .mockResolvedValue({
+          type: "connectResponse",
+          requestId: "test",
+          success: true,
+        })
+
+      await client.connect({ agent: true })
+
+      expect(sendRequestSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "connect",
+          agent: true,
+        }),
+      )
+    })
+
+    it("should throw when popup fails to open", async () => {
+      vi.spyOn(client, "ensureReady").mockImplementation(() => {})
+      vi.spyOn(client as never, "sendRequest").mockResolvedValue({
+        type: "connectResponse",
+        requestId: "test",
+        success: false,
+      })
+
+      await expect(client.connect()).rejects.toThrow(
+        "Failed to open authentication popup",
+      )
+    })
   })
 
   it("should throw error if client is not initialized", async () => {

--- a/lib/src/swarm-id-client.ts
+++ b/lib/src/swarm-id-client.ts
@@ -80,6 +80,8 @@ import {
 } from "./types"
 import { EthAddress, Identifier, PrivateKey, Topic } from "@ethersphere/bee-js"
 import { uint8ArrayToHex } from "./utils/key-derivation"
+import { buildAuthUrl } from "./utils/url"
+import { isWebKit } from "./utils/browser"
 
 const DEFAULT_TIMEOUT_MS = 30000
 const DEFAULT_INITIALIZATION_TIMEOUT_MS = 30000
@@ -780,12 +782,13 @@ export class SwarmIdClient {
    * to the client when they return.
    *
    * **Browser Compatibility:**
-   * - Production (Chrome/Firefox): Works immediately
-   * - Localhost (Chrome/Firefox): Works after iframe button grants Storage Access
-   * - Safari (any): Download-only mode — auth works, uploads disabled (ITP storage partitioning). Private mode sessions are ephemeral (lost when the private window closes).
+   * - Chrome/Firefox: Opens window directly from parent context (preserves user gesture,
+   *   no popup blocking). Auth is communicated via localStorage storage events.
+   * - Safari/iOS: Delegates to proxy iframe which opens popup with storage partitioning
+   *   detection. Download-only mode — auth works, uploads disabled (ITP storage partitioning).
+   *   Private mode sessions are ephemeral (lost when the private window closes).
    *
-   * For localhost development with Chrome/Firefox, click the iframe button first
-   * to grant Storage Access. For Safari details, see https://github.com/snaha/swarm-id/issues/167
+   * For Safari details, see https://github.com/snaha/swarm-id/issues/167
    *
    * @param options - Configuration options for the connect flow
    * @param options.agent - When true, shows the agent sign-up option on the connect page
@@ -805,21 +808,41 @@ export class SwarmIdClient {
    */
   async connect(options: ConnectOptions = {}): Promise<void> {
     this.ensureReady()
-    const requestId = this.generateRequestId()
 
-    const response = await this.sendRequest<{
-      type: "connectResponse"
-      requestId: string
-      success: boolean
-    }>({
-      type: "connect",
-      requestId,
-      agent: options.agent,
-      popupMode: options.popupMode,
-    })
+    if (isWebKit()) {
+      // Safari/iOS: proxy opens popup with storage partitioning challenge
+      const requestId = this.generateRequestId()
+      const response = await this.sendRequest<{
+        type: "connectResponse"
+        requestId: string
+        success: boolean
+      }>({
+        type: "connect",
+        requestId,
+        agent: options.agent,
+        popupMode: options.popupMode,
+      })
+      if (!response.success) {
+        throw new Error("Failed to open authentication popup")
+      }
+    } else {
+      // Chrome/Firefox: open window directly to preserve user gesture (avoids popup blocking).
+      // No challenge needed — these browsers don't partition same-origin localStorage,
+      // so the proxy iframe picks up auth changes via storage events.
+      const basePath = this.iframePath.replace(/\/proxy$/, "")
+      const authUrl = buildAuthUrl(
+        this.iframeOrigin + basePath,
+        window.location.origin,
+        this.metadata,
+        { agent: options.agent },
+      )
 
-    if (!response.success) {
-      throw new Error("Failed to open authentication popup")
+      const effectivePopupMode = options.popupMode ?? this.popupMode
+      if (effectivePopupMode === "popup") {
+        window.open(authUrl, "_blank", "width=500,height=600")
+      } else {
+        window.open(authUrl, "_blank")
+      }
     }
   }
 

--- a/lib/src/utils/browser.ts
+++ b/lib/src/utils/browser.ts
@@ -1,0 +1,10 @@
+/**
+ * Detect WebKit-based browsers (Safari on macOS, all browsers on iOS/iPadOS).
+ * iOS browsers all use WebKit regardless of branding.
+ */
+export function isWebKit(): boolean {
+  const ua = navigator.userAgent
+  const isIOS = /iPad|iPhone|iPod/.test(ua)
+  const isSafari = /^((?!chrome|android).)*safari/i.test(ua)
+  return isIOS || isSafari
+}


### PR DESCRIPTION
## Summary

Fixes #255

- **Chrome/Firefox**: `connect()` now opens the auth window directly from the parent context, preserving the user gesture so the popup is not blocked. Auth is communicated via localStorage storage events (no partitioning on these browsers).
- **Safari/iOS**: Keeps the existing proxy-delegated flow with storage partitioning detection and postMessage fallback (unchanged behavior).
- Removes the `connectDisabled` guard and `storageVerified` state from the demo app since the connect button no longer needs to be disabled.
- Adds centralized `isWebKit()` browser detection in `lib/src/utils/browser.ts` (previously duplicated inline in 3 demo components).

## Test plan

- [x] Chrome: click Connect — popup opens without being blocked (no "allow popups" prompt)
- [x] Firefox: same as Chrome
- [x] Safari: behavior unchanged — proxy opens popup with challenge, postMessage fallback for partitioned storage
- [x] HTTP localhost on Chrome/Firefox: connect works immediately without clicking the iframe button first
- [x] `pnpm check:all` passes (format, lint, typecheck, 435 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)