### PR TITLE
docs: clean up README files and extend documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
 # Swarm Identity Management
 
-This monorepo implements a cross-browser compatible authentication and identity management system for Swarm dApps.
+Cross-browser compatible authentication and identity management for Swarm dApps.
+
+**[Documentation](https://swarm-docs.snaha.net)** | **[Demo](https://swarm-demo.snaha.net)** | **[Identity UI](https://swarm-id.snaha.net)**
 
 ## Packages
 
-- **[lib/](./lib/README.md)** - The Swarm ID TypeScript library for authentication and Bee API operations
-- **[swarm-ui/](./swarm-ui/)** - SvelteKit-based identity management UI
-- **[demo/](./demo/)** - Demo dApp with library integration examples
-- **[docs-site/](./docs-site/)** - Starlight (Astro) documentation website
-- **[bee-js/](https://github.com/agazso/bee-js/tree/feat/encrypted-chunk-streams)** - A custom fork of the [bee-js](https://github.com/ethersphere/bee-js) library, containing encrypted, streaming chunked upload and download functionality.
+- **[lib/](./lib/README.md)** — `@snaha/swarm-id` TypeScript library for authentication and Bee API operations
+- **[swarm-ui/](./swarm-ui/)** — SvelteKit identity management UI (trusted domain)
+- **[demo/](./demo/)** — Demo dApp with library integration examples
+- **[docs-site/](./docs-site/)** — Starlight (Astro) documentation website
 
 ## Architecture
 
@@ -16,14 +17,42 @@ The project uses an OAuth-style popup authentication flow using the Storage Acce
 
 **Key Innovation**: The popup-based authentication allows dApps to securely derive app-specific secrets from a master identity, with browser-enforced storage partitioning providing cross-app isolation.
 
-## Live Demos
+[Architecture deep-dive →](https://swarm-docs.snaha.net/architecture)
 
-The applications are deployed and available at:
+## Quick Start
 
-- **Demo App**: [https://swarm-demo.snaha.net](https://swarm-demo.snaha.net)
-- **Identity UI**: [https://swarm-id.snaha.net](https://swarm-id.snaha.net)
+```bash
+pnpm add @snaha/swarm-id
+```
 
-### Deployment
+```typescript
+import { SwarmIdClient } from '@snaha/swarm-id'
+
+const client = new SwarmIdClient({
+  iframeOrigin: 'https://swarm-id.snaha.net',
+  metadata: {
+    name: 'My dApp',
+    description: 'A demo Swarm application',
+  },
+  onAuthChange: (authenticated) => {
+    console.log('Auth status:', authenticated)
+  },
+})
+
+await client.initialize()
+
+const status = await client.checkAuthStatus()
+if (status.authenticated) {
+  const result = await client.uploadData(new TextEncoder().encode('Hello, Swarm!'))
+  console.log('Uploaded:', result.reference)
+}
+
+client.destroy()
+```
+
+[Full integration guide →](https://swarm-docs.snaha.net/getting-started)
+
+## Deployment
 
 Both apps are deployed to Digital Ocean App Platform as separate static sites:
 
@@ -37,51 +66,7 @@ Both apps are deployed to Digital Ocean App Platform as separate static sites:
 - SvelteKit identity management UI
 - Proxy/auth pages for iframe communication
 
-## Quick Start
-
-### Build Everything
-
-```bash
-# Clone the forked bee-js library
-git clone https://github.com/agazso/bee-js
-
-# Build the forked bee-js library
-cd bee-js && git checkout feat/encrypted-chunk-streams && npm install && npm build
-
-# Install all workspace dependencies
-pnpm install
-
-# Build library + both apps
-pnpm build
-
-# Or build specific apps
-pnpm build:swarm-demo    # Builds lib + demo app
-pnpm build:swarm-id      # Builds lib + identity UI
-```
-
-### Build Outputs
-
-**demo/build/** (Demo App)
-
-```
-demo/build/
-├── index.html          # SvelteKit static output (SPA fallback)
-└── _app/               # Vite-bundled assets (JS, CSS)
-```
-
-**swarm-id-build/** (Identity UI)
-
-```
-swarm-id-build/
-├── [SvelteKit app files including prerendered routes: /proxy, /connect]
-└── _app/               # Vite-bundled assets (JS, CSS)
-```
-
-See [lib/README.md](./lib/README.md) for detailed library documentation.
-
-## Local Development Setup
-
-### Quick Start
+## Local Development
 
 ```bash
 pnpm install
@@ -152,24 +137,7 @@ curl -X POST "http://localhost:1633/stamps/10000000/17"
 curl "http://localhost:1633/stamps/<batchID>"
 ```
 
-**Client-Side Stamp Signing:**
-
-Stamps bought via the API are owned by the queen node. Use the queen's private key for client-side signing:
-
-```typescript
-import { Stamper } from '@ethersphere/bee-js'
-
-const queenKey = '566058308ad5fa3888173c741a1fb902c9f1f19559b11fc2738dfc53637ce4e9'
-const stamper = Stamper.fromBlank(queenKey, batchId, depth)
-const envelope = stamper.stamp(chunk)
-```
-
-**Known Keys:**
-
-| Node     | Private Key                                                        | Address                                      |
-| -------- | ------------------------------------------------------------------ | -------------------------------------------- |
-| Queen    | `566058308ad5fa3888173c741a1fb902c9f1f19559b11fc2738dfc53637ce4e9` | `0x26234a2ad3ba8b398a762f279b792cfacd536a3f` |
-| Worker 1 | `195cf6324303f6941ad119d0a1d2e862d810078e1370b8d205552a543ff40aab` | -                                            |
+See the [Local Development guide](https://swarm-docs.snaha.net/local-development) for client-side stamp signing, known dev keys, SSH tunnel setup, and more.
 
 ### Developer Tools (/dev route)
 
@@ -179,189 +147,15 @@ The Identity UI includes a Developer Tools page at http://localhost:5174/dev wit
 - **Stamps**: Buy postage stamps from the local Bee node using pre-funded signer keys
 - **Sync**: Manually trigger account sync to test postage stamp utilization tracking
 
-### Testing with Real Domains (SSH Tunnel)
-
-To test storage partitioning behavior with real TLS certificates (as in production), you can use SSH tunnels to a VPS with nginx.
-
-**Architecture:**
-
-```
-Your VPS (nginx + HTTPS)              Your Local Machine
-┌─────────────────────────┐           ┌─────────────────────┐
-│ demo.yourdomain.com     │◄──────────│ SSH -R tunnels      │
-│   → 127.0.0.1:18080     │           │   18080 → demo      │
-│ id.yourdomain.com       │           │   5174 → identity   │
-│   → 127.0.0.1:5174      │           │   (Vite dev server) │
-└─────────────────────────┘           └─────────────────────┘
-```
-
-**VPS Setup (one-time):**
-
-1. Add nginx server blocks pointing to `127.0.0.1:18080` (demo) and `127.0.0.1:5174` (identity)
-2. Get SSL certificates with certbot
-3. Add DNS A records for both subdomains
-
-**Local usage:**
-
-```bash
-# Terminal 1: Start demo server
-pnpm dev:demo
-
-# Terminal 2: Start SvelteKit dev server with allowed hosts
-VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=id.yourdomain.com pnpm dev:swarm-ui
-
-# Terminal 3: Open SSH tunnel
-ssh -R 18080:localhost:3000 -R 5174:localhost:5174 user@your-vps
-```
-
-**Note:** The `VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS` environment variable is required when accessing the Vite dev server through a foreign hostname. Without it, Vite will reject requests from the tunneled domain.
-
-**Access the demo:**
-
-```
-https://demo.yourdomain.com/?idDomain=https://id.yourdomain.com
-```
-
-The `?idDomain=` parameter tells the demo which identity service to use. This allows testing cross-origin storage partitioning with real browser security policies while still having hot reload for the identity UI.
-
-**Important:**
-
-- If you change library code, rebuild it: `cd lib && pnpm build`
-- Use `cd lib && pnpm build:watch` for automatic rebuilds during development
-
 ## Project Structure
 
 ```
 .
-├── lib/                  # Swarm ID TypeScript library
-│   ├── src/              # Library source code
-│   ├── dist/             # Built library files (ES6 modules)
-│   └── README.md         # Library documentation
+├── lib/                  # @snaha/swarm-id TypeScript library
 ├── demo/                 # Demo app (SvelteKit)
-│   ├── src/              # SvelteKit source code
-│   │   ├── routes/       # SvelteKit routes (/, /feeds, /soc, etc.)
-│   │   └── lib/          # Stores, components, utilities
-│   └── build/            # Build output (deployed to swarm-demo.snaha.net)
-├── swarm-ui/             # SvelteKit identity management UI
-│   ├── src/              # SvelteKit source code
-│   │   └── routes/       # SvelteKit routes including /proxy and /connect
-│   └── build/            # SvelteKit production build
-├── docs-site/            # Starlight documentation site
-│   ├── src/content/docs/ # Documentation pages (MDX)
-│   └── dist/             # Built static site
-├── bee-js/               # bee-js library (linked dependency)
+├── swarm-ui/             # Identity management UI (SvelteKit)
+├── docs-site/            # Documentation website (Starlight/Astro)
 └── swarm-id-build/       # Build output (deployed to swarm-id.snaha.net)
-```
-
-### Key Build Artifacts
-
-**Library Distribution** (`lib/dist/`)
-
-- ES6 modules with TypeScript definitions
-- Source maps for debugging
-- ~350KB per module (uncompressed)
-- Imported via standard `<script type="module">`
-
-**Demo App Build** (`demo/build/`)
-
-- SvelteKit static build via `@sveltejs/adapter-static`
-- Vite bundles all dependencies (library included via workspace link)
-- Deployed to swarm-demo.snaha.net
-
-**Identity UI Build** (`swarm-id-build/`)
-
-- Full SvelteKit production build
-- Prerendered routes for `/proxy` and `/connect`
-- Deployed to swarm-id.snaha.net
-
-## Documentation
-
-- **[Documentation Site](./docs-site/)**: Full documentation website (run `pnpm docs:dev` to preview)
-- **[The Book of Swarm](./The-Book-of-Swarm.pdf)**: Comprehensive Swarm documentation
-- **[Swarm Identity Management Proposal](./docs/Swarm-Identity-Management-Proposal.md)**: Identity system proposal
-- **[Library Documentation](./lib/README.md)**: API reference and usage examples
-
-### Documentation Development
-
-```bash
-# Start docs dev server (http://localhost:4321)
-pnpm dev:docs
-
-# Build docs for production
-pnpm build:docs
-
-# Preview production build
-pnpm preview:docs
-```
-
-## Development Workflow
-
-### Architecture Overview
-
-```
-┌─────────────────────────────────────────────────────────┐
-│  Browser: http://localhost:3000 (Demo App)              │
-│  ┌────────────────────────────────────────────────┐     │
-│  │ Demo App (SvelteKit)                            │     │
-│  │                                                │     │
-│  │  ┌─────────────────────────────────────────┐   │     │
-│  │  │ <iframe src="http://localhost:5174">    │   │     │
-│  │  │                                         │   │     │
-│  │  │ Identity UI (SvelteKit)                 │   │     │
-│  │  │   - Proxy for Bee API calls             │   │     │
-│  │  │   - Auth popup handler                  │   │     │
-│  │  └─────────────────────────────────────────┘   │     │
-│  └────────────────────────────────────────────────┘     │
-└─────────────────────────────────────────────────────────┘
-```
-
-## Development Tips
-
-- **TypeScript Execution**: Use `pnpx tsx` instead of `npx ts-node` to run TypeScript files
-- **Browser DevTools**: Check Application → Storage to verify storage partitioning
-- **Hot Reload**: Changes in `swarm-ui/src/` will automatically reload in the browser
-- **Debugging**: Use browser DevTools on both the parent page and the iframe
-
-## AI Coding Agent Configuration
-
-This project includes configuration for [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and other AI coding agents, following [best practices](https://code.claude.com/docs/en/best-practices.md) for effective AI-assisted development.
-
-### Structure
-
-```
-CLAUDE.md                        → symlink to AGENT.md
-AGENT.md                         # Core project context: architecture, commands, code style rules
-.claude/
-├── settings.json                # Shared team settings (permissions, hooks)
-├── settings.local.json          # Personal overrides (gitignored)
-└── rules/                       # Modular, path-scoped instructions
-    ├── swarm-ui.md              # Svelte 5, Diete, Carbon Icons (loads for swarm-ui/** only)
-    ├── figma.md                 # Figma MCP workflow (loads for swarm-ui/** only)
-    └── bee-cluster.md           # Local Bee cluster commands and known dev keys
-```
-
-### How It Works
-
-- **`AGENT.md`** is the main instruction file, kept concise (~100 lines). It contains only information that would cause mistakes if absent: architecture overview, essential commands, code style rules (no-semicolons, no-null, no-any), and pre-commit requirements.
-
-- **`.claude/rules/`** contains modular rules that load automatically based on which files are being edited. For example, Svelte 5 rune patterns and Diete design system conventions only load when working in `swarm-ui/`.
-
-- **`.claude/settings.json`** defines shared team configuration:
-  - **Permissions**: Pre-approved commands (`pnpm build`, `pnpm check:all`, `git status`, Figma MCP tools, etc.) so agents don't prompt for common operations.
-
-- **`settings.local.json`** (gitignored) is for personal permission overrides.
-
-### Adding New Rules
-
-To add context that only applies to a specific package or directory, create a new `.md` file in `.claude/rules/` with a YAML frontmatter `paths` filter:
-
-```markdown
----
-paths:
-  - 'lib/**'
----
-
-# lib-specific instructions here
 ```
 
 ## Troubleshooting

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -22,6 +22,7 @@ export default defineConfig({
             { label: 'Introduction', slug: '' },
             { label: 'Quick Start', slug: 'getting-started' },
             { label: 'Architecture', slug: 'architecture' },
+            { label: 'Local Development', slug: 'local-development' },
           ],
         },
         {

--- a/docs-site/src/content/docs/architecture.mdx
+++ b/docs-site/src/content/docs/architecture.mdx
@@ -29,7 +29,7 @@ The architecture consists of three main components:
 │  ┌────────────────────────────────────────────────────┐     │
 │  │ Auth Popup (https://swarm-id.snaha.net)            │     │
 │  │                                                    │     │
-│  │ SwarmIdAuth                                        │     │
+│  │ Auth Popup (SvelteKit /connect route)               │     │
 │  │   - Stores master key (first-party context)        │     │
 │  │   - Derives app-specific secrets                   │     │
 │  │   - Sends secret to iframe via postMessage         │     │
@@ -57,14 +57,14 @@ Runs inside the hidden iframe on the trusted domain. It:
 - Proxies Bee API calls with authentication
 - Validates all incoming messages from the parent
 
-### SwarmIdAuth
+### Auth Popup
 
-Runs in the authentication popup window. It:
+The authentication popup is implemented as a SvelteKit route (`/connect`) in the identity management UI. It:
 
 - Manages the master key in first-party localStorage
 - Derives app-specific secrets using HMAC-SHA256
 - Sends secrets to the iframe via postMessage
-- Provides the authentication UI
+- Provides the authentication UI (Passkey/WebAuthn and SIWE flows)
 
 ## Key Hierarchy
 

--- a/docs-site/src/content/docs/getting-started.mdx
+++ b/docs-site/src/content/docs/getting-started.mdx
@@ -113,38 +113,6 @@ console.log(fileData.name, fileData.data)
 
 ## Local Development
 
-For local development, you'll need to set up HTTPS servers with proper certificates.
-
-### Prerequisites
-
-1. **Install mkcert** for local SSL certificates:
-
-   ```bash
-   # macOS
-   brew install mkcert
-
-   # Linux
-   wget https://github.com/FiloSottile/mkcert/releases/download/v1.4.4/mkcert-v1.4.4-linux-amd64
-   chmod +x mkcert-v1.4.4-linux-amd64
-   sudo mv mkcert-v1.4.4-linux-amd64 /usr/local/bin/mkcert
-   ```
-
-2. **Generate certificates**:
-
-   ```bash
-   mkcert -install
-   mkcert swarm-app.local swarm-id.local
-   ```
-
-3. **Configure `/etc/hosts`**:
-
-   ```
-   127.0.0.1  swarm-app.local
-   127.0.0.1  swarm-id.local
-   ```
-
-### Running Locally
-
 ```bash
 # Clone the repository
 git clone https://github.com/snaha/swarm-id
@@ -152,14 +120,17 @@ git clone https://github.com/snaha/swarm-id
 # Install dependencies
 pnpm install
 
-# Build the library
-cd lib && pnpm build && cd ..
-
-# Start the development servers
-./start-servers.sh
+# Start both demo and identity UI
+pnpm dev
 ```
 
-Then open [https://swarm-app.local:8080](https://swarm-app.local:8080) in your browser.
+Open http://localhost:3000 — that's it!
+
+- Demo app runs on port 3000
+- Identity UI runs on port 5174
+- No HTTPS, certificates, or custom domains required (`localhost` is a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts))
+
+For advanced setup (local Bee cluster, SSH tunnels for real-domain testing, known dev keys), see the [Local Development guide](/local-development).
 
 ## Import & Export
 

--- a/docs-site/src/content/docs/local-development.mdx
+++ b/docs-site/src/content/docs/local-development.mdx
@@ -1,0 +1,80 @@
+---
+title: Local Development
+description: Advanced local development setup for Swarm ID
+---
+
+This guide covers advanced local development topics. For basic setup, see the [Quick Start](/getting-started).
+
+## Development Tips
+
+- **TypeScript Execution**: Use `pnpx tsx` instead of `npx ts-node` to run TypeScript files
+- **Browser DevTools**: Check Application → Storage to verify storage partitioning
+- **Hot Reload**: Changes in `swarm-ui/src/` will automatically reload in the browser
+- **Debugging**: Use browser DevTools on both the parent page and the iframe
+- **Library changes**: If you change library code, rebuild it with `cd lib && pnpm build`, or use `cd lib && pnpm build:watch` for automatic rebuilds
+
+## Client-Side Stamp Signing
+
+Stamps bought via the local Bee API are owned by the queen node. Use the queen's private key for client-side signing:
+
+```typescript
+import { Stamper } from '@ethersphere/bee-js'
+
+const queenKey = '566058308ad5fa3888173c741a1fb902c9f1f19559b11fc2738dfc53637ce4e9'
+const stamper = Stamper.fromBlank(queenKey, batchId, depth)
+const envelope = stamper.stamp(chunk)
+```
+
+## Known Dev Keys
+
+These are the pre-funded keys available in the local FDP Play Bee cluster:
+
+| Node     | Private Key                                                        | Address                                      |
+| -------- | ------------------------------------------------------------------ | -------------------------------------------- |
+| Queen    | `566058308ad5fa3888173c741a1fb902c9f1f19559b11fc2738dfc53637ce4e9` | `0x26234a2ad3ba8b398a762f279b792cfacd536a3f` |
+| Worker 1 | `195cf6324303f6941ad119d0a1d2e862d810078e1370b8d205552a543ff40aab` | -                                            |
+
+## Testing with Real Domains (SSH Tunnel)
+
+To test storage partitioning behavior with real TLS certificates (as in production), you can use SSH tunnels to a VPS with nginx.
+
+### Architecture
+
+```
+Your VPS (nginx + HTTPS)              Your Local Machine
+┌─────────────────────────┐           ┌─────────────────────┐
+│ demo.yourdomain.com     │◄──────────│ SSH -R tunnels      │
+│   → 127.0.0.1:18080     │           │   18080 → demo      │
+│ id.yourdomain.com       │           │   5174 → identity   │
+│   → 127.0.0.1:5174      │           │   (Vite dev server) │
+└─────────────────────────┘           └─────────────────────┘
+```
+
+### VPS Setup (one-time)
+
+1. Add nginx server blocks pointing to `127.0.0.1:18080` (demo) and `127.0.0.1:5174` (identity)
+2. Get SSL certificates with certbot
+3. Add DNS A records for both subdomains
+
+### Local Usage
+
+```bash
+# Terminal 1: Start demo server
+pnpm dev:demo
+
+# Terminal 2: Start SvelteKit dev server with allowed hosts
+VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS=id.yourdomain.com pnpm dev:swarm-ui
+
+# Terminal 3: Open SSH tunnel
+ssh -R 18080:localhost:3000 -R 5174:localhost:5174 user@your-vps
+```
+
+The `VITE_ADDITIONAL_SERVER_ALLOWED_HOSTS` environment variable is required when accessing the Vite dev server through a foreign hostname. Without it, Vite will reject requests from the tunneled domain.
+
+### Access the Demo
+
+```
+https://demo.yourdomain.com/?idDomain=https://id.yourdomain.com
+```
+
+The `?idDomain=` parameter tells the demo which identity service to use. This allows testing cross-origin storage partitioning with real browser security policies while still having hot reload for the identity UI.

--- a/lib/README.md
+++ b/lib/README.md
@@ -1,431 +1,75 @@
-# Swarm ID Client Library
+# @snaha/swarm-id
 
-A TypeScript library for integrating Swarm ID authentication and Bee API operations into dApps.
+TypeScript library for integrating Swarm ID authentication and Bee API operations into dApps.
 
 ## Overview
 
-The Swarm ID library provides a secure, iframe-based authentication system for Swarm applications. It consists of three main components:
+The Swarm ID library provides a secure, iframe-based authentication system for Swarm applications. It consists of two main components:
 
-1. **SwarmIdClient** - For parent windows/dApps to interact with the authentication system
-2. **SwarmIdProxy** - Runs in the iframe, handles authentication and proxies Bee API calls
-3. **SwarmIdAuth** - Runs in the popup window for user authentication
+1. **SwarmIdClient** — For parent windows/dApps to interact with the authentication system
+2. **SwarmIdProxy** — Runs in the iframe, handles authentication and proxies Bee API calls
+
+Authentication is handled by the SvelteKit identity management UI ([swarm-ui](../swarm-ui/)).
 
 ## Installation
 
-From the monorepo root:
-
 ```bash
-pnpm install
+# Using pnpm (recommended)
+pnpm add @snaha/swarm-id
+
+# Using npm
+npm install @snaha/swarm-id
 ```
 
-Or directly in the lib folder:
-
-```bash
-cd lib
-pnpm install
-```
-
-## Building
-
-From the monorepo root:
-
-```bash
-# Build the library
-pnpm build
-
-# Watch mode
-pnpm build:watch
-
-# Lint code
-pnpm lint
-
-# Auto-fix linting issues
-pnpm lint:fix
-```
-
-Or directly in the lib folder:
-
-```bash
-cd lib
-
-# Build once
-pnpm build
-
-# Watch mode
-pnpm build:watch
-
-# Lint code
-pnpm lint
-
-# Auto-fix linting issues
-pnpm lint:fix
-```
-
-## Project Structure
-
-```
-lib/
-├── index.ts                    # Main library exports
-├── types.ts                    # Zod schemas & TypeScript interfaces
-├── swarm-id-client.ts         # Client for parent windows
-├── swarm-id-proxy.ts          # Proxy logic for iframe
-├── swarm-id-auth.ts           # Auth popup logic
-├── utils/
-│   ├── key-derivation.ts      # Cryptographic utilities
-│   ├── backup-encryption.ts   # AES-GCM-256 encryption for .swarmid files
-│   └── account-state-snapshot.ts # Shared serialization for export & sync
-├── sync/
-│   └── restore-account.ts     # Swarm-based account restoration
-└── tsconfig.json              # TypeScript configuration
-
-dist/                           # Built output (generated)
-├── swarm-id.esm.js            # ESM bundle
-├── swarm-id.umd.js            # UMD bundle
-├── swarm-id-client.js         # Individual module (ESM)
-├── swarm-id-proxy.js          # Individual module (ESM)
-├── swarm-id-auth.js           # Individual module (ESM)
-└── *.d.ts                     # TypeScript declarations
-```
-
-## Usage
-
-### In a Parent dApp
+## Basic Usage
 
 ```typescript
-import { SwarmIdClient } from "swarm-id"
+import { SwarmIdClient } from '@snaha/swarm-id'
 
-// Initialize the client
+// 1. Create the client
 const client = new SwarmIdClient({
-  iframeOrigin: "https://swarm-id.local:8081",
-  beeApiUrl: "http://localhost:1633",
-  timeout: 30000,
+  iframeOrigin: 'https://swarm-id.snaha.net',
+  metadata: {
+    name: 'My dApp',
+    description: 'A demo Swarm application',
+  },
   onAuthChange: (authenticated) => {
-    console.log("Auth status changed:", authenticated)
+    console.log('Auth status:', authenticated)
   },
 })
 
-// Initialize and wait for ready
+// 2. Initialize (creates hidden iframe)
 await client.initialize()
 
-// Get the auth iframe (positioned fixed in bottom-right corner)
-const iframe = client.getAuthIframe()
+// 3a. Option A: Use iframe authentication button
+// The iframe will show a connect/disconnect button automatically
 
-// Check auth status
+// 3b. Option B: Manual authentication with connect()
+// Open authentication page in new window/browser tab (useful for custom UI)
+const authUrl = client.connect()
+console.log('Authentication opened at:', authUrl)
+
+// 4. Check if user is authenticated
 const status = await client.checkAuthStatus()
-console.log("Authenticated:", status.authenticated)
 
-// Upload data
-const result = await client.uploadData(
-  "your-postage-batch-id",
-  new Uint8Array([1, 2, 3, 4, 5]),
-  { pin: true },
-)
-console.log("Uploaded:", result.reference)
+// 5. Upload data (after authentication)
+if (status.authenticated) {
+  const result = await client.uploadData(new TextEncoder().encode('Hello, Swarm!'))
+  console.log('Uploaded:', result.reference)
+}
 
-// Download data
-const data = await client.downloadData(result.reference)
-console.log("Downloaded:", data)
-
-// Upload file
-const file = new File(["Hello World"], "hello.txt")
-const fileResult = await client.uploadFile("your-postage-batch-id", file)
-console.log("File uploaded:", fileResult.reference)
-
-// Download file
-const downloadedFile = await client.downloadFile(fileResult.reference)
-console.log("File name:", downloadedFile.name)
-console.log("File data:", downloadedFile.data)
-
-// Cleanup
+// 6. Cleanup when done
 client.destroy()
 ```
 
-### In the Iframe (SvelteKit `/proxy` route)
+## Documentation
 
-```typescript
-import { initProxy } from "swarm-id/proxy"
+Full documentation is available at **[swarm-docs.snaha.net](https://swarm-docs.snaha.net)**:
 
-const proxy = initProxy({
-  beeApiUrl: "http://localhost:1633",
-})
-```
-
-### In the Auth Popup (SvelteKit `/connect` route)
-
-```typescript
-import { initAuth } from "swarm-id/auth"
-
-try {
-  const auth = await initAuth()
-
-  // Display app origin
-  console.log("App requesting access:", auth.getAppOrigin())
-
-  // Check if user has master key
-  if (!auth.hasMasterKey()) {
-    // Setup new identity
-    const masterKey = await auth.setupNewIdentity()
-    console.log("New identity created")
-  }
-
-  // Authenticate
-  await auth.authenticate()
-  console.log("Authentication successful")
-
-  // Close popup
-  auth.close(1500)
-} catch (error) {
-  console.error("Auth failed:", error)
-}
-```
-
-## API Reference
-
-### SwarmIdClient
-
-#### Constructor
-
-```typescript
-new SwarmIdClient(options: ClientOptions)
-```
-
-Options:
-
-- `iframeOrigin` (string, required) - Origin of the Swarm ID iframe
-- `beeApiUrl` (string, optional) - Bee node API URL (default: 'http://localhost:1633')
-- `timeout` (number, optional) - Request timeout in ms (default: 30000)
-- `onAuthChange` (function, optional) - Callback for auth status changes
-
-#### Methods
-
-**Authentication**
-
-- `initialize()` - Initialize the client and embed iframe
-- `getAuthIframe()` - Get the auth iframe element
-- `checkAuthStatus()` - Check authentication status
-- `connect()` - Open authentication popup programmatically (see [Browser Compatibility](#browser-compatibility-and-storage-access))
-- `disconnect()` - Disconnect and clear authentication data
-- `getConnectionInfo()` - Get connection info including upload capability
-
-**Data Operations**
-
-- `uploadData(batchId, data, options?)` - Upload raw data
-- `downloadData(reference, options?)` - Download raw data
-
-**File Operations**
-
-- `uploadFile(batchId, file, name?, options?)` - Upload file
-- `downloadFile(reference, path?, options?)` - Download file
-
-**Chunk Operations**
-
-- `uploadChunk(batchId, data, options?)` - Upload chunk
-- `downloadChunk(reference, options?)` - Download chunk
-
-**Postage Operations**
-
-- `createPostageBatch(amount, depth, options?)` - Create postage batch
-- `getPostageBatch(batchId)` - Get postage batch info
-
-**Cleanup**
-
-- `destroy()` - Destroy client and clean up resources
-
-### SwarmIdProxy
-
-#### Constructor
-
-```typescript
-new SwarmIdProxy(options: ProxyOptions)
-```
-
-Options:
-
-- `beeApiUrl` (string, required) - Bee node API URL
-
-### SwarmIdAuth
-
-#### Constructor
-
-```typescript
-new SwarmIdAuth(options?: AuthOptions)
-```
-
-Options:
-
-- `masterKeyStorageKey` (string, optional) - LocalStorage key for master key (default: 'swarm-master-key')
-
-#### Methods
-
-- `initialize()` - Initialize auth popup
-- `getAppOrigin()` - Get the requesting app's origin
-- `getMasterKey()` - Get the master key (truncated for display)
-- `hasMasterKey()` - Check if master key exists
-- `setupNewIdentity()` - Generate and store new master key
-- `authenticate()` - Authenticate and send secret to iframe
-- `close(delay?)` - Close popup window (default delay: 1500ms)
-
-## Message Protocol
-
-The library uses postMessage for secure cross-origin communication with Zod schema validation.
-
-### Parent → Iframe Messages
-
-- `parentIdentify` - Identify parent to iframe
-- `checkAuth` - Check authentication status
-- `requestAuth` - Request authentication (open popup)
-- `uploadData` - Upload data request
-- `downloadData` - Download data request
-- (and other Bee API operations)
-
-### Iframe → Parent Messages
-
-- `proxyReady` - Iframe is ready
-- `authStatusResponse` - Auth status response
-- `authSuccess` - Authentication succeeded
-- `uploadDataResponse` - Upload response with reference
-- `downloadDataResponse` - Download response with data
-- `error` - Error message
-
-### Popup → Iframe Messages
-
-- `setSecret` - Send derived secret to iframe
-
-## Import & Export
-
-Accounts can be exported to encrypted `.swarmid` backup files and restored via import or from Swarm.
-
-### .swarmid File Format
-
-Each file contains a plaintext JSON header (account metadata, type-specific fields) plus an AES-GCM-256 encrypted payload containing the account state snapshot.
-
-```typescript
-import {
-  createEncryptedExport,
-  decryptEncryptedExport,
-  parseEncryptedExportHeader,
-} from "@snaha/swarm-id"
-
-// Export (no re-auth needed — uses stored swarmEncryptionKey)
-const exported = await createEncryptedExport(
-  account,
-  identities,
-  connectedApps,
-  postageStamps,
-  swarmEncryptionKeyHex,
-)
-
-// Read header metadata without decrypting
-const header = parseEncryptedExportHeader(fileData)
-
-// Import (requires auth to re-derive key)
-const result = await decryptEncryptedExport(fileData, swarmEncryptionKeyHex)
-if (result.success) {
-  console.log(result.data) // AccountStateSnapshot
-}
-```
-
-### Account State Snapshots
-
-The `serializeAccountStateSnapshot()` and `deserializeAccountStateSnapshot()` functions provide shared serialization used by both file export and Swarm sync. Connected app secrets are included in snapshots so that backups preserve app connections without requiring re-authentication.
-
-### Swarm Sync & Restore
-
-When a passkey auth succeeds on a new device with no local account, `restoreAccountFromSwarm()` derives the necessary keys, finds the epoch feed in Swarm, downloads and decrypts the latest account snapshot.
-
-```typescript
-import { restoreAccountFromSwarm } from "@snaha/swarm-id"
-
-const result = await restoreAccountFromSwarm(
-  bee,
-  masterKey,
-  ethereumAddress,
-  credentialId,
-)
-if (result) {
-  console.log(result.snapshot) // AccountStateSnapshot
-}
-```
-
-## Security Features
-
-- **Origin Validation** - All postMessage calls validate sender origin
-- **Parent Origin Locking** - Parent can only identify itself once
-- **HMAC-SHA256 Key Derivation** - App-specific secrets derived from master key
-- **Partitioned Storage** - Secrets isolated per (iframe-origin, parent-origin) pair
-- **Master Key Protection** - Master key never leaves first-party context
-- **Type-safe Messages** - Zod schema validation on all messages
-- **Backup Encryption** - AES-GCM-256 with random IV for .swarmid files
-- **appSecret Exclusion** - App secrets are never included in exports or sync snapshots
-
-## Browser Compatibility and Storage Access
-
-There are two ways to trigger authentication:
-
-1. **Iframe button** - User clicks the button rendered inside the iframe (`getAuthIframe()`)
-2. **Custom button** - App calls `client.connect()` from its own button
-
-### Storage Access API
-
-The iframe needs access to shared localStorage to read accounts, identities, and postage stamps. Browsers may partition iframe storage, requiring the [Storage Access API](https://developer.mozilla.org/en-US/docs/Web/API/Storage_Access_API) to access unpartitioned storage. This API **requires a user gesture inside the iframe**.
-
-### Environment Compatibility
-
-| Environment                           | Iframe button | Custom button       | Notes                                                                        |
-| ------------------------------------- | ------------- | ------------------- | ---------------------------------------------------------------------------- |
-| **Production (Chrome/Firefox)**       | Yes           | Yes                 | Secure context, storage not partitioned                                      |
-| **Localhost (Chrome, Firefox, etc.)** | Yes           | After iframe button | Iframe button requests Storage Access first                                  |
-| **Safari (any)**                      | Yes           | Yes                 | Download-only mode: auth works, uploads disabled (ITP storage partitioning)  |
-| **Safari private mode**               | Yes           | Yes                 | Download-only mode; sessions are ephemeral (lost when private window closes) |
-
-### How It Works
-
-**Production (Chrome/Firefox)**: In a secure context (HTTPS), browsers don't partition iframe storage, so both authentication methods work immediately.
-
-**Localhost (Chrome/Firefox)**: Browsers partition iframe storage, requiring the [Storage Access API](https://developer.mozilla.org/en-US/docs/Web/API/Storage_Access_API). The iframe button triggers a user gesture inside the iframe, allowing it to request Storage Access. Once granted, the custom button also works.
-
-**Safari**: Safari's Intelligent Tracking Prevention (ITP) partitions all storage for third-party iframes, preventing access to signing keys and postage stamps. Safari operates in download-only mode: authentication and downloads work, but uploads are not available. See [#167](https://github.com/snaha/swarm-id/issues/167) for details.
-
-**Safari private mode**: Download-only mode applies; sessions are also ephemeral — all storage is cleared when the private window closes.
-
-### Recommendation
-
-- **Production (Chrome/Firefox)**: Either button works immediately
-- **Development**: Use Chrome/Firefox with iframe button first, then custom button works
-- **Safari**: Download-only mode (auth works, uploads disabled); private mode sessions are ephemeral
-
-## Development
-
-### Code Style
-
-- Use `undefined` instead of `null`
-- No semicolons
-- TypeScript strict mode
-- ESLint with @typescript-eslint
-
-### Testing
-
-```bash
-# Run linter
-pnpm lint
-
-# Auto-fix issues
-pnpm lint:fix
-```
-
-## TODO
-
-- [ ] Integrate real Bee API calls (currently simulated)
-- [ ] Add unit tests
-- [ ] Add integration tests
-- [ ] Update HTML files to use library
-- [ ] Browser compatibility testing
-- [ ] Add error recovery and retry logic
-- [ ] Add request cancellation support
-- [ ] Add progress callbacks for uploads/downloads
-- [ ] Document security model
-- [ ] Publish to npm
+- [Quick Start](https://swarm-docs.snaha.net/getting-started) — Installation and integration guide
+- [Architecture](https://swarm-docs.snaha.net/architecture) — How the system works, key hierarchy, backup & recovery
+- [API Reference](https://swarm-docs.snaha.net/api) — Complete SwarmIdClient API documentation
 
 ## License
 
-ISC
+[Apache 2.0](../LICENSE)


### PR DESCRIPTION
## Summary

Closes #250

- Remove all stale `SwarmIdAuth` / `swarm-id-auth` references (class no longer exists — auth is handled by SvelteKit `/connect` route)
- Remove outdated TODO section, project structure tree, and duplicate API/security/browser-compat content from `lib/README.md` — now a concise npm package page with one example + docs site links
- Streamline root `README.md` (~400 → ~170 lines): remove build outputs, SSH tunnels, AI agent config, architecture diagram; keep deployment, FDP Play, /dev route, troubleshooting
- Fix `getting-started.mdx`: replace stale mkcert/`start-servers.sh` instructions with simple `pnpm dev` setup
- Fix `architecture.mdx`: rename `SwarmIdAuth` → `Auth Popup` in diagram and component description
- Add new `local-development.mdx` docs page with content moved from README (SSH tunnel setup, dev tips, known dev keys, client-side stamp signing)

## Test plan

- [x] `pnpm check:all` — 0 errors, 433 tests passing
- [x] `pnpm build:docs` — all 6 pages built successfully including new `local-development`
- [x] No stale `SwarmIdAuth`, `swarm-id-auth`, `start-servers.sh`, or `mkcert` references remain
- [ ] Visual review of README.md and lib/README.md rendering on GitHub
- [ ] Browse docs site (`pnpm dev:docs`) — verify Local Development page in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)