### PR TITLE
chore: pre-major release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,7 +3,9 @@
     "lib": {
       "release-type": "node",
       "package-name": "@snaha/swarm-id",
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
Fix `release-please` to not bump major version for breaking change until 1.0