### PR TITLE
feat: add pre-auth network settings menu

### DIFF
--- a/swarm-ui/src/lib/components/pre-auth-settings-menu.svelte
+++ b/swarm-ui/src/lib/components/pre-auth-settings-menu.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+  import Dropdown from '$lib/components/ui/dropdown.svelte'
+  import Button from '$lib/components/ui/button.svelte'
+  import type { Mode } from '$lib/components/ui/button.svelte'
+  import Horizontal from '$lib/components/ui/horizontal.svelte'
+  import Typography from '$lib/components/ui/typography.svelte'
+  import Vertical from '$lib/components/ui/vertical.svelte'
+  import FlexItem from '$lib/components/ui/flex-item.svelte'
+  import NetworkSettingsModal from './network-settings-modal.svelte'
+  import ThemeToggle from './theme-toggle.svelte'
+  import SettingsAdjust from 'carbon-icons-svelte/lib/SettingsAdjust.svelte'
+  import ContentDeliveryNetwork from 'carbon-icons-svelte/lib/ContentDeliveryNetwork.svelte'
+
+  interface Props {
+    mode?: Mode
+  }
+
+  let { mode = 'auto' }: Props = $props()
+
+  let networkSettingsModalOpen = $state(false)
+  let dropdownOpen = $state(false)
+</script>
+
+<Dropdown
+  buttonVariant="ghost"
+  buttonDimension="compact"
+  {mode}
+  autoClose={false}
+  bind:open={dropdownOpen}
+>
+  {#snippet button()}
+    <SettingsAdjust size={20} />
+  {/snippet}
+  <div class="menu">
+    <Vertical --vertical-gap="0" --vertical-align-items="stretch">
+      <Button
+        variant="ghost"
+        dimension="compact"
+        onclick={() => {
+          networkSettingsModalOpen = true
+          dropdownOpen = false
+        }}
+      >
+        <Horizontal
+          --horizontal-gap="var(--half-padding)"
+          --horizontal-align-items="center"
+          --horizontal-justify-content="stretch"
+          style="flex: 1"
+        >
+          <ContentDeliveryNetwork size={20} />
+          Network settings
+        </Horizontal>
+      </Button>
+      <Horizontal
+        --horizontal-gap="var(--half-padding)"
+        --horizontal-align-items="center"
+        --horizontal-justify-content="stretch"
+        style="flex: 1; padding: var(--half-padding);"
+      >
+        <Typography style="padding: var(--half-padding)">Appearance</Typography>
+        <FlexItem />
+        <ThemeToggle />
+      </Horizontal>
+    </Vertical>
+  </div>
+</Dropdown>
+
+<NetworkSettingsModal bind:open={networkSettingsModalOpen} />
+
+<style lang="postcss">
+  .menu {
+    background-color: var(--colors-ultra-low);
+    border: 1px solid var(--colors-low);
+    padding: var(--half-padding);
+    min-width: 220px;
+  }
+</style>

--- a/swarm-ui/src/routes/(app)/(create)/+layout@.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/+layout@.svelte
@@ -1,8 +1,13 @@
 <script lang="ts">
+  import PreAuthSettingsMenu from '$lib/components/pre-auth-settings-menu.svelte'
+
   let { children } = $props()
 </script>
 
 <div class="page-wrapper">
+  <div class="settings-menu">
+    <PreAuthSettingsMenu />
+  </div>
   <div class="page-content">
     <div class="content-area">
       {@render children()}
@@ -38,6 +43,13 @@
     width: 100%;
   }
 
+  .settings-menu {
+    position: absolute;
+    top: var(--double-padding);
+    right: var(--double-padding);
+    z-index: 10;
+  }
+
   @media screen and (max-width: 640px) {
     .page-content {
       padding: var(--padding);
@@ -45,6 +57,11 @@
 
     .content-area {
       flex: 1;
+    }
+
+    .settings-menu {
+      top: var(--padding);
+      right: var(--padding);
     }
   }
 </style>

--- a/swarm-ui/src/routes/(app)/+layout.svelte
+++ b/swarm-ui/src/routes/(app)/+layout.svelte
@@ -10,6 +10,7 @@
   import { identitiesStore } from '$lib/stores/identities.svelte'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import Drawer from '$lib/components/drawer.svelte'
+  import PreAuthSettingsMenu from '$lib/components/pre-auth-settings-menu.svelte'
 
   let { children } = $props()
 
@@ -62,6 +63,8 @@
             <Typography>{identity.name}</Typography>
           </Vertical>
         </Horizontal>
+      {:else}
+        <PreAuthSettingsMenu />
       {/if}
     </Horizontal>
 

--- a/swarm-ui/src/routes/(marketing)/+page.svelte
+++ b/swarm-ui/src/routes/(marketing)/+page.svelte
@@ -19,6 +19,7 @@
   import Login from 'carbon-icons-svelte/lib/Login.svelte'
   import UserIdentification from 'carbon-icons-svelte/lib/UserIdentification.svelte'
   import ArrowRight from 'carbon-icons-svelte/lib/ArrowRight.svelte'
+  import PreAuthSettingsMenu from '$lib/components/pre-auth-settings-menu.svelte'
 
   const DOCS_URL = 'https://swarm.snaha.net/docs'
 
@@ -39,6 +40,7 @@
         <SwarmLogo fill="var(--colors-dark-top)" height={30} />
       </a>
       <Horizontal --horizontal-gap="var(--half-padding)">
+        <PreAuthSettingsMenu mode="dark" />
         <Button variant="strong" dimension="compact" mode="dark" href={resolve(routes.ACCOUNT_NEW)}>
           Create identity
         </Button>


### PR DESCRIPTION
## Summary
- Adds a settings dropdown (gear icon) with "Network settings" and "Appearance" to all pre-auth pages, so users can configure their Bee node URL before signing in
- Menu appears on the marketing landing page, account creation/sign-in flows, and the home page when no identity is selected
- Reuses the existing `NetworkSettingsModal` and `ThemeToggle` components — no new stores or library changes needed

Closes #205

## Test plan
- [ ] Visit `/` (marketing page) — gear icon visible in header next to "Create identity"
- [ ] Visit `/account/new` — gear icon in top-right of header
- [ ] Visit any sign-in/sign-up flow (e.g. `/eth/new`, `/signin/ethereum`) — gear icon floating top-right
- [ ] Click gear — dropdown shows "Network settings" + "Appearance" (theme toggle)
- [ ] Click "Network settings" — modal opens, save/reset/cancel work, settings persist across reload
- [ ] Theme toggle works inside dropdown without closing it
- [ ] Sign in and select an identity — gear icon disappears, drawer takes over
- [ ] Test on mobile (< 640px) — menu repositions with smaller padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)