### PR TITLE
ci: remove registry-url to enable OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          registry-url: 'https://registry.npmjs.org'
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

- Remove `registry-url` from `setup-node` in the publish workflow
- When `registry-url` is set, `setup-node` creates an `.npmrc` with `_authToken=${NODE_AUTH_TOKEN}`, which overrides npm's native OIDC trusted publisher authentication and causes `E404` on publish
- Without it, npm uses OIDC directly — matching the working `vojtechsimetka/swarm-id` publish workflow that successfully published

## Test plan

- [ ] Merge and trigger a release to verify npm publish succeeds with OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)