### PR TITLE
feat(swarm-ui): exclude /dev route from production builds

### DIFF
--- a/.do/swarm-id-app.yaml
+++ b/.do/swarm-id-app.yaml
@@ -50,6 +50,9 @@ envs:
   - key: CI
     value: 'true'
 
+  - key: EXCLUDE_DEV_ROUTE
+    value: 'true'
+
 # Deployment alerts
 alerts:
   - rule: DEPLOYMENT_FAILED

--- a/swarm-ui/knip.ts
+++ b/swarm-ui/knip.ts
@@ -11,7 +11,7 @@ const config: KnipConfig = {
     '$lib/*': ['src/lib/*'],
   },
   ignore: ['playwright/index.ts', 'src/lib/time.ts', 'src/lib/schemas.ts'],
-  ignoreDependencies: ['@snaha/swarm-id', '@ethersphere/bee-js'],
+  ignoreDependencies: ['@snaha/swarm-id'],
   ignoreExportsUsedInFile: true,
   'playwright-ct': false,
 }

--- a/swarm-ui/vite.config.ts
+++ b/swarm-ui/vite.config.ts
@@ -1,11 +1,63 @@
 // Copyright 2026 The Swarm Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { existsSync, renameSync } from 'node:fs'
+import { resolve } from 'node:path'
+
 import { sveltekit } from '@sveltejs/kit/vite'
-import { defineConfig } from 'vitest/config'
+import { defineConfig, type Plugin } from 'vitest/config'
+
+const DEV_ROUTE_DIR = resolve('src/routes/(app)/dev')
+const DEV_ROUTE_STASH = resolve('.dev-route-stash')
+
+// Build-time exclusion of the /dev route. When EXCLUDE_DEV_ROUTE=true, the
+// route directory is moved out of src/routes/ before SvelteKit walks the
+// filesystem, then restored after the bundle closes — so /dev is absent from
+// the manifest and the SPA bundle entirely.
+function excludeDevRoute(): Plugin {
+  let stashed = false
+  const stash = () => {
+    if (process.env.EXCLUDE_DEV_ROUTE !== 'true') return
+    if (!existsSync(DEV_ROUTE_DIR)) return
+    if (existsSync(DEV_ROUTE_STASH)) {
+      throw new Error(
+        `Cannot stash /dev route: ${DEV_ROUTE_STASH} already exists from a previous interrupted build`,
+      )
+    }
+    renameSync(DEV_ROUTE_DIR, DEV_ROUTE_STASH)
+    stashed = true
+  }
+  const restore = () => {
+    if (!stashed) return
+    if (existsSync(DEV_ROUTE_STASH)) {
+      renameSync(DEV_ROUTE_STASH, DEV_ROUTE_DIR)
+    }
+    stashed = false
+  }
+  return {
+    name: 'exclude-dev-route',
+    apply: 'build',
+    enforce: 'pre',
+    config() {
+      stash()
+      process.once('exit', restore)
+      process.once('SIGINT', () => {
+        restore()
+        process.exit(130)
+      })
+      process.once('SIGTERM', () => {
+        restore()
+        process.exit(143)
+      })
+    },
+    closeBundle() {
+      restore()
+    },
+  }
+}
 
 export default defineConfig({
-  plugins: [sveltekit()],
+  plugins: [excludeDevRoute(), sveltekit()],
   optimizeDeps: {
     exclude: ['@snaha/swarm-id'],
   },


### PR DESCRIPTION
## Summary

- Adds an `excludeDevRoute()` Vite plugin in [swarm-ui/vite.config.ts](swarm-ui/vite.config.ts) that, when `EXCLUDE_DEV_ROUTE=true`, physically moves `src/routes/(app)/dev/` out of the routes tree before SvelteKit walks the filesystem (in the `config()` hook, which runs before SvelteKit's `sync.all()`) and restores it on `closeBundle` / `process.once('exit'/SIGINT/SIGTERM)`. `apply: 'build'` keeps it out of `vite dev`.
- Sets `EXCLUDE_DEV_ROUTE=true` in [.do/swarm-id-app.yaml](.do/swarm-id-app.yaml) so production deployments to `swarm-id.snaha.net` strip the route entirely (no prerendered HTML, no entry in the SPA manifest, no JS chunk).
- Drops `@ethersphere/bee-js` from `swarm-ui/knip.ts` `ignoreDependencies` — it is a direct dependency used across 26 files, and knip flagged the entry as no longer needed.

Local development is untouched: `pnpm dev` still serves `/dev` per the FDP Play Bee cluster workflow, and `pnpm build` (without the flag) still bundles the route.

Closes #296.