### PR TITLE
feat: require authentication before deleting an account

### DIFF
--- a/swarm-ui/src/lib/components/delete-modal.svelte
+++ b/swarm-ui/src/lib/components/delete-modal.svelte
@@ -50,8 +50,12 @@
       <Typography style="color: var(--colors-red)">{error}</Typography>
     {/if}
     <section class="buttons">
-      <LoaderButton variant="strong" dimension="compact" onclick={confirm} class="danger-button"
-        >{buttonTitle}</LoaderButton
+      <LoaderButton
+        variant="strong"
+        dimension="compact"
+        onclick={confirm}
+        stayActive={false}
+        class="danger-button">{buttonTitle}</LoaderButton
       >
       <Button variant="ghost" dimension="compact" onclick={oncancel} disabled={disableCancel}
         >{cancelTitle}</Button

--- a/swarm-ui/src/lib/components/delete-modal.svelte
+++ b/swarm-ui/src/lib/components/delete-modal.svelte
@@ -16,6 +16,7 @@
     text: string
     buttonTitle: string
     cancelTitle?: string
+    error?: string
   }
   let {
     oncancel,
@@ -25,6 +26,7 @@
     text,
     buttonTitle,
     cancelTitle = "Don't delete",
+    error,
     ...restProps
   }: ModalProps & Props = $props()
 </script>
@@ -39,6 +41,9 @@
 
     {#if text}
       <Typography>{text}</Typography>
+    {/if}
+    {#if error}
+      <Typography style="color: var(--colors-red)">{error}</Typography>
     {/if}
     <section class="buttons">
       <LoaderButton variant="strong" dimension="compact" onclick={confirm} class="danger-button"

--- a/swarm-ui/src/lib/components/delete-modal.svelte
+++ b/swarm-ui/src/lib/components/delete-modal.svelte
@@ -17,6 +17,7 @@
     buttonTitle: string
     cancelTitle?: string
     error?: string
+    disableCancel?: boolean
   }
   let {
     oncancel,
@@ -27,6 +28,7 @@
     buttonTitle,
     cancelTitle = "Don't delete",
     error,
+    disableCancel = false,
     ...restProps
   }: ModalProps & Props = $props()
 </script>
@@ -36,7 +38,9 @@
     <header class="horizontal">
       <Typography variant="h5">{title}</Typography>
       <div class="grower"></div>
-      <Button variant="ghost" dimension="compact" onclick={oncancel}><Close size={24} /></Button>
+      <Button variant="ghost" dimension="compact" onclick={oncancel} disabled={disableCancel}
+        ><Close size={24} /></Button
+      >
     </header>
 
     {#if text}
@@ -49,7 +53,9 @@
       <LoaderButton variant="strong" dimension="compact" onclick={confirm} class="danger-button"
         >{buttonTitle}</LoaderButton
       >
-      <Button variant="ghost" dimension="compact" onclick={oncancel}>{cancelTitle}</Button>
+      <Button variant="ghost" dimension="compact" onclick={oncancel} disabled={disableCancel}
+        >{cancelTitle}</Button
+      >
       <div class="grower"></div>
     </section>
   </section>

--- a/swarm-ui/src/lib/components/drawer.svelte
+++ b/swarm-ui/src/lib/components/drawer.svelte
@@ -79,6 +79,11 @@
   let showDeleteModal = $state(false)
   let showDeleteSeedModal = $state(false)
   let deleteError = $state<string | undefined>(undefined)
+  let isDeleteAuthInProgress = $state(false)
+  // Non-reactive flag set when the user cancels mid-auth. Checked before
+  // performing deletion so a late-resolving auth promise can't override the
+  // user's intent (e.g. reflexive biometric touch after clicking Cancel).
+  let deleteCancelled = false
 
   // Generation details state
   let isUnmasked = $state(false)
@@ -134,19 +139,29 @@
 
   async function handleDeleteAccount() {
     deleteError = undefined
+    deleteCancelled = false
+    isDeleteAuthInProgress = true
     try {
-      await getMasterKeyFromAccount(account)
-    } catch (err) {
-      if (err instanceof SeedPhraseRequiredError) {
-        showDeleteModal = false
-        showDeleteSeedModal = true
+      try {
+        await getMasterKeyFromAccount(account)
+      } catch (err) {
+        if (err instanceof SeedPhraseRequiredError) {
+          showDeleteModal = false
+          showDeleteSeedModal = true
+          return
+        }
+        deleteError = err instanceof Error ? err.message : 'Authentication failed'
+        console.error('Authentication failed:', err)
         return
       }
-      deleteError = err instanceof Error ? err.message : 'Authentication failed'
-      console.error('Authentication failed:', err)
-      return
+      if (deleteCancelled) {
+        // User dismissed the modal while auth was pending — honor that.
+        return
+      }
+      await performAccountDeletion()
+    } finally {
+      isDeleteAuthInProgress = false
     }
-    await performAccountDeletion()
   }
 
   async function handleDeleteSeedPhraseProvided(seedPhrase: string) {
@@ -755,7 +770,13 @@
   buttonTitle="Delete account"
   confirm={handleDeleteAccount}
   error={deleteError}
+  disableCancel={isDeleteAuthInProgress}
   oncancel={() => {
+    if (isDeleteAuthInProgress) {
+      // Late cancel paths (Esc, click-outside) can still fire while auth is
+      // pending; mark cancelled so the resolved auth doesn't trigger deletion.
+      deleteCancelled = true
+    }
     showDeleteModal = false
     deleteError = undefined
   }}

--- a/swarm-ui/src/lib/components/drawer.svelte
+++ b/swarm-ui/src/lib/components/drawer.svelte
@@ -46,7 +46,11 @@
   import type { Account, Identity } from '$lib/types'
   import type { Bytes } from '@ethersphere/bee-js'
   import { deriveSecretSeedEncryptionKey, decryptSecretSeed } from '$lib/utils/encryption'
-  import { getMasterKeyFromAccount } from '$lib/utils/account-auth'
+  import {
+    getMasterKeyFromAccount,
+    SeedPhraseRequiredError,
+    getMasterKeyFromAgentAccount,
+  } from '$lib/utils/account-auth'
   import EthereumLogo from './ethereum-logo.svelte'
   import PasskeyLogo from './passkey-logo.svelte'
   import Input from './ui/input/input.svelte'
@@ -54,6 +58,7 @@
   import CopyButton from './copy-button.svelte'
   import Tooltip from './ui/tooltip.svelte'
   import DeleteModal from './delete-modal.svelte'
+  import EnterSeedModal from './enter-seed-modal.svelte'
   import Bot from 'carbon-icons-svelte/lib/Bot.svelte'
 
   type Props = {
@@ -72,6 +77,8 @@
   let showExportTooltip = $state(false)
   let networkSettingsModalOpen = $state(false)
   let showDeleteModal = $state(false)
+  let showDeleteSeedModal = $state(false)
+  let deleteError = $state<string | undefined>(undefined)
 
   // Generation details state
   let isUnmasked = $state(false)
@@ -110,7 +117,7 @@
     accountsStore.setAccountName(account.id, accountName)
   }
 
-  async function handleDeleteAccount() {
+  async function performAccountDeletion() {
     const accountId = account.id
     const accountIdentities = identitiesStore.getIdentitiesByAccount(accountId)
     for (const identity of accountIdentities) {
@@ -120,8 +127,42 @@
     postageStampsStore.removeStampsByAccount(accountId.toHex())
     accountsStore.removeAccount(accountId)
     sessionStore.clearAccount()
+    showDeleteModal = false
     drawerOpen = false
     await goto(resolve(routes.HOME))
+  }
+
+  async function handleDeleteAccount() {
+    deleteError = undefined
+    try {
+      await getMasterKeyFromAccount(account)
+    } catch (err) {
+      if (err instanceof SeedPhraseRequiredError) {
+        showDeleteModal = false
+        showDeleteSeedModal = true
+        return
+      }
+      deleteError = err instanceof Error ? err.message : 'Authentication failed'
+      console.error('Authentication failed:', err)
+      return
+    }
+    await performAccountDeletion()
+  }
+
+  async function handleDeleteSeedPhraseProvided(seedPhrase: string) {
+    try {
+      getMasterKeyFromAgentAccount(account, seedPhrase)
+    } catch (err) {
+      deleteError = err instanceof Error ? err.message : 'Invalid seed phrase'
+      showDeleteModal = true
+      console.error('Invalid seed phrase:', err)
+      return
+    }
+    await performAccountDeletion()
+  }
+
+  function handleDeleteSeedModalCancel() {
+    showDeleteSeedModal = false
   }
 
   let showPasskeyExportWarning = $state(false)
@@ -608,7 +649,10 @@
             dimension="compact"
             danger
             leftAlign
-            onclick={() => (showDeleteModal = true)}
+            onclick={() => {
+              deleteError = undefined
+              showDeleteModal = true
+            }}
           >
             <TrashCan size={20} />
             Delete account
@@ -707,10 +751,20 @@
 <DeleteModal
   bind:open={showDeleteModal}
   title="Delete account?"
-  text="This will permanently delete your account and all associated data. This action cannot be undone."
+  text="This will permanently delete your account and all associated data. This action cannot be undone. You'll be asked to authenticate before the account is deleted."
   buttonTitle="Delete account"
   confirm={handleDeleteAccount}
-  oncancel={() => (showDeleteModal = false)}
+  error={deleteError}
+  oncancel={() => {
+    showDeleteModal = false
+    deleteError = undefined
+  }}
+/>
+
+<EnterSeedModal
+  bind:open={showDeleteSeedModal}
+  onUnlock={handleDeleteSeedPhraseProvided}
+  onCancel={handleDeleteSeedModalCancel}
 />
 
 <style>


### PR DESCRIPTION
## Summary

- Account deletion now requires fresh authentication before any local data is removed.
- Routes per account type via the existing `getMasterKeyFromAccount` helper:
  - **Passkey** — WebAuthn re-auth
  - **Ethereum** — wallet connect + signature
  - **Agent** — `EnterSeedModal` collects the seed phrase (handled via `SeedPhraseRequiredError`)
- Auth failures keep the confirm modal open with an inline error so the user can retry or cancel; only on success does deletion run (clears identities, apps, stamps, account, session, then navigates home).
- `DeleteModal` gained an optional `error` prop for the inline message; confirm-dialog copy updated to mention the auth step.

Closes #241

## Test plan

- [x] Passkey account: confirm WebAuthn prompt appears on delete; cancel leaves account intact, success deletes and routes home.
- [x] Ethereum account: wallet signature is required; rejecting it shows the inline error and keeps the modal open.
- [x] Agent account: confirm `EnterSeedModal` opens; invalid seed re-opens the delete modal with an error; valid seed deletes the account.
- [x] Re-opening the delete modal after a prior error starts clean (no stale error text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)