### PR TITLE
fix: use Bee node batchTTL for stamp expiry, show Expired badge

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -463,6 +463,7 @@ export {
   fetchSwarmPrice,
   fetchChainState,
   calculateStampAmountForDays,
+  fetchBatchTTL,
   SWARMSCAN_STATS_URL,
   GNOSIS_BLOCK_TIME,
   BLOCKS_PER_DAY,

--- a/lib/src/swarm-id-proxy.ts
+++ b/lib/src/swarm-id-proxy.ts
@@ -3607,7 +3607,6 @@ export class SwarmIdProxy {
         batchTTL = calculateTTLSeconds(stamp.amount, pricePerGBPerMonth)
       } catch (error) {
         console.warn("[Proxy] Failed to calculate TTL:", error)
-        batchTTL = stamp.batchTTL
       }
     }
 

--- a/lib/src/swarm-id-proxy.ts
+++ b/lib/src/swarm-id-proxy.ts
@@ -103,7 +103,11 @@ import {
 } from "./proxy/feeds/epochs"
 import { createAsyncSequentialFinder } from "./proxy/feeds/sequence"
 import { Binary } from "cafe-utility"
-import { calculateTTLSeconds, fetchSwarmPrice } from "./utils/ttl"
+import {
+  calculateTTLSeconds,
+  fetchBatchTTL,
+  fetchSwarmPrice,
+} from "./utils/ttl"
 import { tryCreateTag } from "./utils/tag"
 import { DEFAULT_BEE_NODE_URL, UtilizationUpdateMessageSchema } from "./schemas"
 import { buildAuthUrl } from "./utils/url"
@@ -3590,13 +3594,21 @@ export class SwarmIdProxy {
       return
     }
 
-    // Fetch current price from Swarmscan to calculate TTL
-    let batchTTL: number | undefined = stamp.batchTTL
-    try {
-      const pricePerGBPerMonth = await fetchSwarmPrice()
-      batchTTL = calculateTTLSeconds(stamp.amount, pricePerGBPerMonth)
-    } catch (error) {
-      console.warn("[Proxy] Failed to calculate TTL:", error)
+    // Prefer the Bee node's authoritative batchTTL (computed from live chain
+    // state). Fall back to the Swarmscan-price approximation when the Bee node
+    // does not know about this batch (e.g. public gateway).
+    let batchTTL: number | undefined = await fetchBatchTTL(
+      this.beeApiUrl,
+      stamp.batchID.toHex(),
+    )
+    if (batchTTL === undefined) {
+      try {
+        const pricePerGBPerMonth = await fetchSwarmPrice()
+        batchTTL = calculateTTLSeconds(stamp.amount, pricePerGBPerMonth)
+      } catch (error) {
+        console.warn("[Proxy] Failed to calculate TTL:", error)
+        batchTTL = stamp.batchTTL
+      }
     }
 
     // Map PostageStamp to public PostageBatch (exclude signerKey)

--- a/lib/src/utils/ttl.test.ts
+++ b/lib/src/utils/ttl.test.ts
@@ -2,7 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
-import { calculateStampAmountForDays, fetchChainState } from "./ttl"
+import {
+  calculateStampAmountForDays,
+  fetchChainState,
+  fetchBatchTTL,
+} from "./ttl"
+
+const BATCH_ID =
+  "b88a934e78c793bde43abcb7d2e41dc87de06ad18a747bdd672b0e32f23c687e"
+
+function mockResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response
+}
 
 describe("calculateStampAmountForDays", () => {
   // bee-compose default PriceOracle floor: 24_000 PLUR/chunk/block
@@ -47,14 +62,6 @@ describe("fetchChainState", () => {
   afterEach(() => {
     fetchSpy.mockRestore()
   })
-
-  function mockResponse(body: unknown, ok = true, status = 200): Response {
-    return {
-      ok,
-      status,
-      json: () => Promise.resolve(body),
-    } as Response
-  }
 
   it("parses block and currentPrice from /chainstate", async () => {
     fetchSpy.mockResolvedValue(
@@ -109,5 +116,99 @@ describe("fetchChainState", () => {
     await expect(fetchChainState("http://localhost:1633")).rejects.toThrow(
       /block/,
     )
+  })
+})
+
+describe("fetchBatchTTL", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch")
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it("returns batchTTL from Bee /stamps/{id} response", async () => {
+    fetchSpy.mockResolvedValue(mockResponse({ batchTTL: 86400 }))
+
+    const ttl = await fetchBatchTTL("https://bee.example.com", BATCH_ID)
+
+    expect(ttl).toBe(86400)
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `https://bee.example.com/stamps/${BATCH_ID}`,
+    )
+  })
+
+  it("strips a trailing slash from the Bee URL", async () => {
+    fetchSpy.mockResolvedValue(mockResponse({ batchTTL: 123 }))
+
+    await fetchBatchTTL("https://bee.example.com/", BATCH_ID)
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `https://bee.example.com/stamps/${BATCH_ID}`,
+    )
+  })
+
+  it("returns undefined when the stamp is not found (404)", async () => {
+    fetchSpy.mockResolvedValue(mockResponse({}, false, 404))
+
+    const ttl = await fetchBatchTTL("https://bee.example.com", BATCH_ID)
+
+    expect(ttl).toBeUndefined()
+  })
+
+  it("returns undefined when the response is missing batchTTL", async () => {
+    fetchSpy.mockResolvedValue(mockResponse({ amount: "100" }))
+
+    const ttl = await fetchBatchTTL("https://bee.example.com", BATCH_ID)
+
+    expect(ttl).toBeUndefined()
+  })
+
+  it("returns undefined when the response body is not an object", async () => {
+    fetchSpy.mockResolvedValue(mockResponse(null))
+
+    const ttl = await fetchBatchTTL("https://bee.example.com", BATCH_ID)
+
+    expect(ttl).toBeUndefined()
+  })
+
+  it("returns undefined when batchTTL is not a number", async () => {
+    fetchSpy.mockResolvedValue(mockResponse({ batchTTL: "86400" }))
+
+    const ttl = await fetchBatchTTL("https://bee.example.com", BATCH_ID)
+
+    expect(ttl).toBeUndefined()
+  })
+
+  it("normalises negative TTL values to 0", async () => {
+    // Bee returns negative batchTTL for expired stamps in some versions.
+    fetchSpy.mockResolvedValue(mockResponse({ batchTTL: -1 }))
+
+    const ttl = await fetchBatchTTL("https://bee.example.com", BATCH_ID)
+
+    expect(ttl).toBe(0)
+  })
+
+  it("returns undefined when fetch rejects", async () => {
+    fetchSpy.mockRejectedValue(new Error("network error"))
+
+    const ttl = await fetchBatchTTL("https://bee.example.com", BATCH_ID)
+
+    expect(ttl).toBeUndefined()
+  })
+
+  it("returns undefined when JSON parsing fails", async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.reject(new Error("invalid json")),
+    } as unknown as Response)
+
+    const ttl = await fetchBatchTTL("https://bee.example.com", BATCH_ID)
+
+    expect(ttl).toBeUndefined()
   })
 })

--- a/lib/src/utils/ttl.test.ts
+++ b/lib/src/utils/ttl.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
 import {
   calculateStampAmountForDays,
+  calculateTTLSeconds,
   fetchChainState,
   fetchBatchTTL,
 } from "./ttl"
@@ -49,6 +50,68 @@ describe("calculateStampAmountForDays", () => {
   it("returns 0n for non-positive price", () => {
     expect(calculateStampAmountForDays(0n, 1)).toBe(0n)
     expect(calculateStampAmountForDays(-1n, 1)).toBe(0n)
+  })
+})
+
+describe("calculateTTLSeconds", () => {
+  // Reference figures from the bug report on issue #279:
+  //   amount = 13_737_600_001 PLUR (per chunk)
+  //   pricePerGBPerMonth ≈ 0.7025 BZZ/GiB/month  → ≈ 15.4 days lifetime
+  const ISSUE_279_AMOUNT = 13_737_600_001n
+  const ISSUE_279_PRICE = 0.70253870579712
+  const ISSUE_279_TTL_SECONDS_LOWER = 13 * 86_400 // 13d
+  const ISSUE_279_TTL_SECONDS_UPPER = 17 * 86_400 // 17d
+
+  it("returns a plausible lifetime for the issue #279 values", () => {
+    const ttl = calculateTTLSeconds(ISSUE_279_AMOUNT, ISSUE_279_PRICE)
+    expect(ttl).toBeGreaterThan(ISSUE_279_TTL_SECONDS_LOWER)
+    expect(ttl).toBeLessThan(ISSUE_279_TTL_SECONDS_UPPER)
+  })
+
+  it("accepts string and number amounts equivalently to bigint", () => {
+    const fromBigint = calculateTTLSeconds(ISSUE_279_AMOUNT, ISSUE_279_PRICE)
+    const fromString = calculateTTLSeconds("13737600001", ISSUE_279_PRICE)
+    const fromNumber = calculateTTLSeconds(13_737_600_001, ISSUE_279_PRICE)
+    expect(fromString).toBe(fromBigint)
+    expect(fromNumber).toBe(fromBigint)
+  })
+
+  it("returns 0 when the price is 0 (e.g. local dev chain)", () => {
+    expect(calculateTTLSeconds(ISSUE_279_AMOUNT, 0)).toBe(0)
+  })
+
+  it("returns 0 when the price is negative", () => {
+    expect(calculateTTLSeconds(ISSUE_279_AMOUNT, -1)).toBe(0)
+  })
+
+  it("returns 0 when the price is not finite", () => {
+    expect(calculateTTLSeconds(ISSUE_279_AMOUNT, NaN)).toBe(0)
+    expect(calculateTTLSeconds(ISSUE_279_AMOUNT, Infinity)).toBe(0)
+  })
+
+  it("returns 0 when the amount is 0", () => {
+    expect(calculateTTLSeconds(0n, ISSUE_279_PRICE)).toBe(0)
+  })
+
+  it("returns 0 when the amount is negative", () => {
+    expect(calculateTTLSeconds(-1n, ISSUE_279_PRICE)).toBe(0)
+  })
+
+  it("scales linearly with amount", () => {
+    const single = calculateTTLSeconds(ISSUE_279_AMOUNT, ISSUE_279_PRICE)
+    const double = calculateTTLSeconds(ISSUE_279_AMOUNT * 2n, ISSUE_279_PRICE)
+    // Linear within BigInt truncation noise (well under 1%).
+    expect(double).toBeGreaterThan(single * 2 - 1)
+    expect(double).toBeLessThan(single * 2 + 1)
+  })
+
+  it("preserves precision past Number.MAX_SAFE_INTEGER", () => {
+    // 1e18 PLUR per chunk would overflow `Number(amountBigInt) * 1e16` math.
+    // BigInt path stays accurate, so the result is finite and positive.
+    const huge = 1_000_000_000_000_000_000n
+    const ttl = calculateTTLSeconds(huge, ISSUE_279_PRICE)
+    expect(Number.isFinite(ttl)).toBe(true)
+    expect(ttl).toBeGreaterThan(0)
   })
 })
 

--- a/lib/src/utils/ttl.ts
+++ b/lib/src/utils/ttl.ts
@@ -25,7 +25,7 @@ export const BLOCKS_PER_DAY = (24n * 60n * 60n) / BigInt(GNOSIS_BLOCK_TIME)
 const SECONDS_PER_MINUTE = 60
 const SECONDS_PER_HOUR = 60 * SECONDS_PER_MINUTE
 const SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR
-const SECONDS_PER_MONTH = 2_592_000n // 30 * 24 * 60 * 60
+const SECONDS_PER_MONTH = 30n * BigInt(SECONDS_PER_DAY)
 
 /**
  * Swarm constants. `CHUNKS_PER_GB = 1 GiB / 4 KiB chunk`.

--- a/lib/src/utils/ttl.ts
+++ b/lib/src/utils/ttl.ts
@@ -99,9 +99,11 @@ export function calculateTTLSeconds(
   }
   const perChunkPerMonthCost = bzzToPlur(pricePerGBPerMonth) / CHUNKS_PER_GB
   if (perChunkPerMonthCost <= 0n) {
-    // Sub-attoBZZ prices (under ~2.6e-11 BZZ/GiB/month) truncate to 0 under
-    // BigInt division. Return 0 instead of letting the next line throw on
-    // divide-by-zero — there's no meaningful lifetime to report.
+    // Defensive: the chain's PriceOracle enforces a floor of 24_000 PLUR per
+    // chunk per block (≈ 0.33 BZZ/GiB/month), so any real Swarmscan response
+    // is ~10^10× above the BigInt-truncates-to-zero threshold. This guard
+    // only fires for pathological caller input — without it the next line
+    // would throw on divide-by-zero.
     return 0
   }
   return Number((amountBigInt * SECONDS_PER_MONTH) / perChunkPerMonthCost)

--- a/lib/src/utils/ttl.ts
+++ b/lib/src/utils/ttl.ts
@@ -28,10 +28,29 @@ const SECONDS_PER_MONTH = 30 * SECONDS_PER_DAY // 2,592,000
 /**
  * Swarm constants
  */
-const PLUR_PER_BZZ = 1e16
+const PLUR_DECIMALS = 16 // 1 BZZ = 1e16 PLUR
 const CHUNK_SIZE_BYTES = 4096
 const BYTES_PER_GB = 1024 * 1024 * 1024
 const CHUNKS_PER_GB = Math.floor(BYTES_PER_GB / CHUNK_SIZE_BYTES) // 262144
+const CHUNKS_PER_GB_BIGINT = BigInt(CHUNKS_PER_GB)
+const SECONDS_PER_MONTH_BIGINT = BigInt(SECONDS_PER_MONTH)
+
+/**
+ * Converts a BZZ amount (possibly fractional) to PLUR as a BigInt.
+ *
+ * Goes through a fixed-decimal string instead of `bzz * 1e16` to preserve
+ * precision: `1e16` exceeds `Number.MAX_SAFE_INTEGER` (2^53), so direct
+ * multiplication loses low-order digits for any non-trivial price.
+ */
+function bzzToPlur(bzz: number): bigint {
+  const str = bzz.toFixed(PLUR_DECIMALS)
+  const negative = str.startsWith("-")
+  const unsigned = negative ? str.slice(1) : str
+  const [intPart, decPart = ""] = unsigned.split(".")
+  const paddedDec = decPart.padEnd(PLUR_DECIMALS, "0").slice(0, PLUR_DECIMALS)
+  const magnitude = BigInt(intPart + paddedDec)
+  return negative ? -magnitude : magnitude
+}
 
 /**
  * Swarmscan API URL for price data
@@ -53,24 +72,43 @@ export async function fetchSwarmPrice(): Promise<number> {
 }
 
 /**
- * Calculates TTL in seconds from stamp amount and Swarmscan price.
+ * Approximates the lifetime of a postage stamp deposit in seconds, assuming
+ * the chain's per-block price stays constant at `pricePerGBPerMonth` for the
+ * full lifetime. This is the answer to "how long would a stamp with this
+ * deposit last at the current price" — not the remaining TTL of an existing
+ * stamp (for that, prefer {@link fetchBatchTTL}, which uses live chain state).
  *
- * @param amount - Stamp amount in PLUR (smallest BZZ unit)
- * @param pricePerGBPerMonth - Price from Swarmscan (in BZZ)
- * @returns TTL in seconds
+ * Uses BigInt math throughout. `pricePerGBPerMonth * 1e16` (PLUR conversion)
+ * silently loses precision in Number, since `1e16 > Number.MAX_SAFE_INTEGER`.
+ *
+ * @param amount - Stamp amount in PLUR (per-chunk)
+ * @param pricePerGBPerMonth - Price in BZZ per GiB per month (from Swarmscan)
+ * @returns Lifetime in seconds. Returns `0` if the amount or price is
+ *          non-positive or the price is not finite — a 0-price chain
+ *          technically never expires stamps, but returning 0 keeps callers
+ *          inside safe Number range and is the conservative display choice.
  */
 export function calculateTTLSeconds(
   amount: bigint | number | string,
   pricePerGBPerMonth: number,
 ): number {
+  if (!Number.isFinite(pricePerGBPerMonth) || pricePerGBPerMonth <= 0) {
+    return 0
+  }
   const amountBigInt = BigInt(amount)
-  // Cost per chunk per month in PLUR
+  if (amountBigInt <= 0n) {
+    return 0
+  }
+  // Cost per chunk per month in PLUR. BigInt division truncates toward zero;
+  // CHUNKS_PER_GB_BIGINT is small enough that this rounding is sub-second.
   const perChunkPerMonthCost =
-    (pricePerGBPerMonth * PLUR_PER_BZZ) / CHUNKS_PER_GB
-  // TTL in months
-  const ttlMonths = Number(amountBigInt) / perChunkPerMonthCost
-  // TTL in seconds
-  return ttlMonths * SECONDS_PER_MONTH
+    bzzToPlur(pricePerGBPerMonth) / CHUNKS_PER_GB_BIGINT
+  if (perChunkPerMonthCost <= 0n) {
+    return 0
+  }
+  return Number(
+    (amountBigInt * SECONDS_PER_MONTH_BIGINT) / perChunkPerMonthCost,
+  )
 }
 
 /**

--- a/lib/src/utils/ttl.ts
+++ b/lib/src/utils/ttl.ts
@@ -97,10 +97,11 @@ export function calculateTTLSeconds(
   if (amountBigInt <= 0n) {
     return 0
   }
-  // Cost per chunk per month in PLUR. BigInt division truncates toward zero;
-  // CHUNKS_PER_GB is small enough that this rounding is sub-second.
   const perChunkPerMonthCost = bzzToPlur(pricePerGBPerMonth) / CHUNKS_PER_GB
   if (perChunkPerMonthCost <= 0n) {
+    // Sub-attoBZZ prices (under ~2.6e-11 BZZ/GiB/month) truncate to 0 under
+    // BigInt division. Return 0 instead of letting the next line throw on
+    // divide-by-zero — there's no meaningful lifetime to report.
     return 0
   }
   return Number((amountBigInt * SECONDS_PER_MONTH) / perChunkPerMonthCost)
@@ -268,15 +269,13 @@ export async function fetchBatchTTL(
       return undefined
     }
     const data: unknown = await response.json()
-    if (
-      typeof data !== "object" ||
-      data === null ||
-      !("batchTTL" in data) ||
-      typeof (data as { batchTTL: unknown }).batchTTL !== "number"
-    ) {
+    if (typeof data !== "object" || data === null) {
       return undefined
     }
-    const ttl = (data as { batchTTL: number }).batchTTL
+    const ttl = (data as { batchTTL?: unknown }).batchTTL
+    if (typeof ttl !== "number") {
+      return undefined
+    }
     return ttl < 0 ? 0 : ttl
   } catch {
     return undefined

--- a/lib/src/utils/ttl.ts
+++ b/lib/src/utils/ttl.ts
@@ -18,22 +18,20 @@ export const GNOSIS_BLOCK_TIME = 5
 export const BLOCKS_PER_DAY = (24n * 60n * 60n) / BigInt(GNOSIS_BLOCK_TIME)
 
 /**
- * Time constants
+ * Time constants. `SECONDS_PER_MONTH` is BigInt because its only consumer is
+ * the BigInt math in {@link calculateTTLSeconds}; the others stay Number
+ * because {@link formatTTL} uses them with `Math.floor` / modulo.
  */
 const SECONDS_PER_MINUTE = 60
 const SECONDS_PER_HOUR = 60 * SECONDS_PER_MINUTE
 const SECONDS_PER_DAY = 24 * SECONDS_PER_HOUR
-const SECONDS_PER_MONTH = 30 * SECONDS_PER_DAY // 2,592,000
+const SECONDS_PER_MONTH = 2_592_000n // 30 * 24 * 60 * 60
 
 /**
- * Swarm constants
+ * Swarm constants. `CHUNKS_PER_GB = 1 GiB / 4 KiB chunk`.
  */
 const PLUR_DECIMALS = 16 // 1 BZZ = 1e16 PLUR
-const CHUNK_SIZE_BYTES = 4096
-const BYTES_PER_GB = 1024 * 1024 * 1024
-const CHUNKS_PER_GB = Math.floor(BYTES_PER_GB / CHUNK_SIZE_BYTES) // 262144
-const CHUNKS_PER_GB_BIGINT = BigInt(CHUNKS_PER_GB)
-const SECONDS_PER_MONTH_BIGINT = BigInt(SECONDS_PER_MONTH)
+const CHUNKS_PER_GB = 262_144n // (1024 * 1024 * 1024) / 4096
 
 /**
  * Converts a BZZ amount (possibly fractional) to PLUR as a BigInt.
@@ -100,15 +98,12 @@ export function calculateTTLSeconds(
     return 0
   }
   // Cost per chunk per month in PLUR. BigInt division truncates toward zero;
-  // CHUNKS_PER_GB_BIGINT is small enough that this rounding is sub-second.
-  const perChunkPerMonthCost =
-    bzzToPlur(pricePerGBPerMonth) / CHUNKS_PER_GB_BIGINT
+  // CHUNKS_PER_GB is small enough that this rounding is sub-second.
+  const perChunkPerMonthCost = bzzToPlur(pricePerGBPerMonth) / CHUNKS_PER_GB
   if (perChunkPerMonthCost <= 0n) {
     return 0
   }
-  return Number(
-    (amountBigInt * SECONDS_PER_MONTH_BIGINT) / perChunkPerMonthCost,
-  )
+  return Number((amountBigInt * SECONDS_PER_MONTH) / perChunkPerMonthCost)
 }
 
 /**

--- a/lib/src/utils/ttl.ts
+++ b/lib/src/utils/ttl.ts
@@ -211,3 +211,41 @@ export function calculateStampAmountForDays(
   }
   return currentPrice * BLOCKS_PER_DAY * BigInt(days)
 }
+
+/**
+ * Fetches the remaining batchTTL (in seconds) for a stamp directly from a Bee
+ * node's `/stamps/{batchId}` endpoint. The Bee node computes this from current
+ * chain state (per-block price and cumulative outpayment), so it is more
+ * accurate than the constant-price approximation in {@link calculateTTLSeconds}.
+ *
+ * @param beeUrl - Bee node URL
+ * @param batchId - Hex-encoded batch ID (without `0x` prefix)
+ * @returns Remaining TTL in seconds, or `undefined` if the Bee node does not
+ *          know about this batch or the request fails. Negative values from
+ *          the Bee API are normalised to `0` (expired).
+ */
+export async function fetchBatchTTL(
+  beeUrl: string,
+  batchId: string,
+): Promise<number | undefined> {
+  try {
+    const base = beeUrl.replace(/\/$/, "")
+    const response = await fetch(`${base}/stamps/${batchId}`)
+    if (!response.ok) {
+      return undefined
+    }
+    const data: unknown = await response.json()
+    if (
+      typeof data !== "object" ||
+      data === null ||
+      !("batchTTL" in data) ||
+      typeof (data as { batchTTL: unknown }).batchTTL !== "number"
+    ) {
+      return undefined
+    }
+    const ttl = (data as { batchTTL: number }).batchTTL
+    return ttl < 0 ? 0 : ttl
+  } catch {
+    return undefined
+  }
+}

--- a/swarm-ui/src/routes/(app)/identity/[id]/stamps/+page.svelte
+++ b/swarm-ui/src/routes/(app)/identity/[id]/stamps/+page.svelte
@@ -24,7 +24,12 @@
   import { onMount } from 'svelte'
   import { SvelteMap } from 'svelte/reactivity'
   import WarningAltFilled from 'carbon-icons-svelte/lib/WarningAltFilled.svelte'
-  import { calculateTTLSeconds, fetchBatchTTL, getBlockTimestamp } from '@snaha/swarm-id'
+  import {
+    calculateTTLSeconds,
+    fetchBatchTTL,
+    fetchSwarmPrice,
+    getBlockTimestamp,
+  } from '@snaha/swarm-id'
   import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
 
   const BATCH_ID_PREVIEW_LENGTH = 8
@@ -35,7 +40,6 @@
   const MS_PER_SECOND = 1000
   const SECONDS_PER_MONTH = 2592000
   const MAX_UTILIZATION_PERCENT = 100
-  const SWARMSCAN_STATS_URL = 'https://api.swarmscan.io/v1/postage-stamps/stats'
   const EXPIRY_SOON_LIFETIME_FRACTION = 0.1
   const BEEPORT_TOPUP_URL = 'https://beeport.eth.limo/?topup='
 
@@ -88,9 +92,7 @@
   onMount(async () => {
     // Fetch Swarmscan price
     try {
-      const res = await fetch(SWARMSCAN_STATS_URL)
-      const data: { pricePerGBPerMonth: number } = await res.json()
-      pricePerGBPerMonth = data.pricePerGBPerMonth
+      pricePerGBPerMonth = await fetchSwarmPrice()
     } catch {
       // Silently fail — only the constant-price fallback and the "expires
       // soon" heuristic become unavailable. The Bee batchTTL path can still

--- a/swarm-ui/src/routes/(app)/identity/[id]/stamps/+page.svelte
+++ b/swarm-ui/src/routes/(app)/identity/[id]/stamps/+page.svelte
@@ -55,9 +55,10 @@
 
   let pricePerGBPerMonth = $state<number | undefined>(undefined)
   const blockTimestamps = new SvelteMap<number, number>()
-  // Map of batchID hex → { expiry timestamp in ms, sourced from Bee node /stamps/{id} }.
-  // The Bee node computes batchTTL from current chain state, so it accounts for
-  // price changes since stamp creation that the Swarmscan approximation cannot.
+  // Map of batchID hex → expiry timestamp in ms (Date.now() + batchTTL), sourced
+  // from the configured Bee node's `/stamps/{id}` response. Bee computes batchTTL
+  // from live chain state, so it accounts for price changes since stamp creation
+  // that the Swarmscan-price approximation cannot.
   const beeExpiryMs = new SvelteMap<string, number>()
 
   async function fetchBlockTimestamp(blockNumber: number): Promise<number | undefined> {
@@ -91,7 +92,9 @@
       const data: { pricePerGBPerMonth: number } = await res.json()
       pricePerGBPerMonth = data.pricePerGBPerMonth
     } catch {
-      // Silently fail — expiry date just won't render
+      // Silently fail — only the constant-price fallback and the "expires
+      // soon" heuristic become unavailable. The Bee batchTTL path can still
+      // render an accurate expiry date without it.
     }
 
     // Fetch block timestamps and authoritative batchTTL for stamps
@@ -123,20 +126,28 @@
     return batchId.toHex().slice(0, BATCH_ID_PREVIEW_LENGTH)
   }
 
+  interface StampExpiry {
+    expiryMs: number
+    /** True when expiryMs comes from the constant-price fallback rather than
+     * Bee's live chain state. The chain price may have moved since the stamp
+     * was purchased, so an estimated date can disagree with reality (see #279).
+     */
+    estimated: boolean
+  }
+
   /**
-   * Resolves a stamp's expiry timestamp in ms.
-   * Prefers the Bee node's batchTTL (which uses live chain state) over the
-   * Swarmscan-price approximation, which assumes price has been constant since
-   * stamp creation and produces dates in the past once the chain price rises.
+   * Resolves a stamp's expiry timestamp in ms, marking it as estimated when
+   * we had to fall back to the Swarmscan-price approximation. Bee's batchTTL
+   * (when available) reflects actual chain state and is treated as truth.
    */
-  function getExpiryMs(
+  function getExpiry(
     stamp: PostageStamp,
     price: number | undefined,
     blockTimestamp: number | undefined,
     beeExpiry: number | undefined,
-  ): number | undefined {
+  ): StampExpiry | undefined {
     if (beeExpiry !== undefined) {
-      return beeExpiry
+      return { expiryMs: beeExpiry, estimated: false }
     }
     if (price === undefined) {
       return undefined
@@ -144,11 +155,12 @@
     const durationSeconds = calculateTTLSeconds(stamp.amount, price)
     const startTimeMs =
       blockTimestamp !== undefined ? blockTimestamp * MS_PER_SECOND : stamp.createdAt
-    return startTimeMs + durationSeconds * MS_PER_SECOND
+    return { expiryMs: startTimeMs + durationSeconds * MS_PER_SECOND, estimated: true }
   }
 
-  function formatExpiryDate(expiryMs: number): string {
-    return new Date(expiryMs).toLocaleDateString()
+  function formatExpiryDate(expiryMs: number, estimated: boolean): string {
+    const date = new Date(expiryMs).toLocaleDateString()
+    return estimated ? `~${date}` : date
   }
 
   function isExpired(expiryMs: number): boolean {
@@ -223,23 +235,22 @@
 
       {@const stampBlockTimestamp = blockTimestamps.get(stamp.blockNumber)}
       {@const stampBeeExpiry = beeExpiryMs.get(stamp.batchID.toHex())}
-      {@const expiryMs = getExpiryMs(
-        stamp,
-        pricePerGBPerMonth,
-        stampBlockTimestamp,
-        stampBeeExpiry,
-      )}
-      {#if expiryMs !== undefined}
-        {@const expired = isExpired(expiryMs)}
-        {@const expiringSoon = !expired && isExpiringSoon(stamp, expiryMs, pricePerGBPerMonth)}
+      {@const expiry = getExpiry(stamp, pricePerGBPerMonth, stampBlockTimestamp, stampBeeExpiry)}
+      {#if expiry !== undefined}
+        {@const expired = isExpired(expiry.expiryMs)}
+        {@const expiringSoon =
+          !expired && isExpiringSoon(stamp, expiry.expiryMs, pricePerGBPerMonth)}
         <Horizontal --horizontal-justify-content="space-between" --horizontal-align-items="center">
           <Typography>Expiry date</Typography>
           <Horizontal --horizontal-gap="var(--half-padding)" --horizontal-align-items="center">
             <Typography
               --typography-color={expired || expiringSoon ? 'var(--colors-red)' : undefined}
             >
-              {formatExpiryDate(expiryMs)}
+              {formatExpiryDate(expiry.expiryMs, expiry.estimated)}
             </Typography>
+            {#if expiry.estimated}
+              <Typography variant="small">(estimated)</Typography>
+            {/if}
             {#if expired}
               <Badge variant="error" dimension="small">
                 <WarningAltFilled size={16} />Expired

--- a/swarm-ui/src/routes/(app)/identity/[id]/stamps/+page.svelte
+++ b/swarm-ui/src/routes/(app)/identity/[id]/stamps/+page.svelte
@@ -24,7 +24,7 @@
   import { onMount } from 'svelte'
   import { SvelteMap } from 'svelte/reactivity'
   import WarningAltFilled from 'carbon-icons-svelte/lib/WarningAltFilled.svelte'
-  import { getBlockTimestamp, fetchBatchTTL } from '@snaha/swarm-id'
+  import { calculateTTLSeconds, fetchBatchTTL, getBlockTimestamp } from '@snaha/swarm-id'
   import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
 
   const BATCH_ID_PREVIEW_LENGTH = 8
@@ -33,26 +33,11 @@
   const BYTES_PER_MB = BYTES_PER_KB * BYTES_PER_KB
   const BYTES_PER_GB = BYTES_PER_MB * BYTES_PER_KB
   const MS_PER_SECOND = 1000
+  const SECONDS_PER_MONTH = 2592000
   const MAX_UTILIZATION_PERCENT = 100
   const SWARMSCAN_STATS_URL = 'https://api.swarmscan.io/v1/postage-stamps/stats'
-  const CHUNKS_PER_GB = 262144n
-  const SECONDS_PER_MONTH = 2592000n
   const EXPIRY_SOON_LIFETIME_FRACTION = 0.1
-  const PLUR_DECIMALS = 16
   const BEEPORT_TOPUP_URL = 'https://beeport.eth.limo/?topup='
-
-  function bzzToPlur(bzz: number): bigint {
-    const str = bzz.toFixed(PLUR_DECIMALS)
-    const [intPart, decPart = ''] = str.split('.')
-    const paddedDec = decPart.padEnd(PLUR_DECIMALS, '0').slice(0, PLUR_DECIMALS)
-    return BigInt(intPart + paddedDec)
-  }
-
-  function calculateBatchDurationSeconds(amount: bigint, pricePerGBPerMonth: number): number {
-    const perChunkPerMonthCost = bzzToPlur(pricePerGBPerMonth) / CHUNKS_PER_GB
-    if (perChunkPerMonthCost === 0n) return 0
-    return Number((amount * SECONDS_PER_MONTH) / perChunkPerMonthCost)
-  }
 
   const identityId = $derived(page.params.id)
   const identity = $derived(identityId ? identitiesStore.getIdentity(identityId) : undefined)
@@ -156,7 +141,7 @@
     if (price === undefined) {
       return undefined
     }
-    const durationSeconds = calculateBatchDurationSeconds(stamp.amount, price)
+    const durationSeconds = calculateTTLSeconds(stamp.amount, price)
     const startTimeMs =
       blockTimestamp !== undefined ? blockTimestamp * MS_PER_SECOND : stamp.createdAt
     return startTimeMs + durationSeconds * MS_PER_SECOND
@@ -178,12 +163,12 @@
     const remainingMs = expiryMs - Date.now()
     if (remainingMs <= 0) return false
 
-    const oneMonthMs = Number(SECONDS_PER_MONTH) * MS_PER_SECOND
+    const oneMonthMs = SECONDS_PER_MONTH * MS_PER_SECOND
     if (remainingMs < oneMonthMs) return true
 
     // If we have a price, also flag stamps in the last 10% of their estimated lifetime.
     if (price === undefined) return false
-    const totalLifetimeMs = calculateBatchDurationSeconds(stamp.amount, price) * MS_PER_SECOND
+    const totalLifetimeMs = calculateTTLSeconds(stamp.amount, price) * MS_PER_SECOND
     return totalLifetimeMs > 0 && remainingMs < totalLifetimeMs * EXPIRY_SOON_LIFETIME_FRACTION
   }
 </script>

--- a/swarm-ui/src/routes/(app)/identity/[id]/stamps/+page.svelte
+++ b/swarm-ui/src/routes/(app)/identity/[id]/stamps/+page.svelte
@@ -24,7 +24,7 @@
   import { onMount } from 'svelte'
   import { SvelteMap } from 'svelte/reactivity'
   import WarningAltFilled from 'carbon-icons-svelte/lib/WarningAltFilled.svelte'
-  import { getBlockTimestamp } from '@snaha/swarm-id'
+  import { getBlockTimestamp, fetchBatchTTL } from '@snaha/swarm-id'
   import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
 
   const BATCH_ID_PREVIEW_LENGTH = 8
@@ -70,6 +70,10 @@
 
   let pricePerGBPerMonth = $state<number | undefined>(undefined)
   const blockTimestamps = new SvelteMap<number, number>()
+  // Map of batchID hex → { expiry timestamp in ms, sourced from Bee node /stamps/{id} }.
+  // The Bee node computes batchTTL from current chain state, so it accounts for
+  // price changes since stamp creation that the Swarmscan approximation cannot.
+  const beeExpiryMs = new SvelteMap<string, number>()
 
   async function fetchBlockTimestamp(blockNumber: number): Promise<number | undefined> {
     if (blockTimestamps.has(blockNumber)) {
@@ -88,6 +92,13 @@
     }
   }
 
+  async function fetchStampExpiryFromBee(stamp: PostageStamp): Promise<void> {
+    const ttlSeconds = await fetchBatchTTL(networkSettingsStore.beeNodeUrl, stamp.batchID.toHex())
+    if (ttlSeconds !== undefined) {
+      beeExpiryMs.set(stamp.batchID.toHex(), Date.now() + ttlSeconds * MS_PER_SECOND)
+    }
+  }
+
   onMount(async () => {
     // Fetch Swarmscan price
     try {
@@ -98,12 +109,13 @@
       // Silently fail — expiry date just won't render
     }
 
-    // Fetch block timestamps for stamps
+    // Fetch block timestamps and authoritative batchTTL for stamps
     const stamps = [accountStamp, identityStamp].filter(Boolean) as PostageStamp[]
     for (const stamp of stamps) {
       if (stamp.blockNumber > 0) {
         fetchBlockTimestamp(stamp.blockNumber)
       }
+      fetchStampExpiryFromBee(stamp)
     }
   })
 
@@ -126,39 +138,53 @@
     return batchId.toHex().slice(0, BATCH_ID_PREVIEW_LENGTH)
   }
 
-  function formatExpiryDate(
+  /**
+   * Resolves a stamp's expiry timestamp in ms.
+   * Prefers the Bee node's batchTTL (which uses live chain state) over the
+   * Swarmscan-price approximation, which assumes price has been constant since
+   * stamp creation and produces dates in the past once the chain price rises.
+   */
+  function getExpiryMs(
     stamp: PostageStamp,
-    price: number,
+    price: number | undefined,
     blockTimestamp: number | undefined,
-  ): string {
+    beeExpiry: number | undefined,
+  ): number | undefined {
+    if (beeExpiry !== undefined) {
+      return beeExpiry
+    }
+    if (price === undefined) {
+      return undefined
+    }
     const durationSeconds = calculateBatchDurationSeconds(stamp.amount, price)
-
-    // Use block timestamp if available, otherwise fall back to createdAt
     const startTimeMs =
       blockTimestamp !== undefined ? blockTimestamp * MS_PER_SECOND : stamp.createdAt
+    return startTimeMs + durationSeconds * MS_PER_SECOND
+  }
 
-    return new Date(startTimeMs + durationSeconds * MS_PER_SECOND).toLocaleDateString()
+  function formatExpiryDate(expiryMs: number): string {
+    return new Date(expiryMs).toLocaleDateString()
+  }
+
+  function isExpired(expiryMs: number): boolean {
+    return expiryMs <= Date.now()
   }
 
   function isExpiringSoon(
     stamp: PostageStamp,
-    price: number,
-    blockTimestamp: number | undefined,
+    expiryMs: number,
+    price: number | undefined,
   ): boolean {
-    const totalLifetimeMs = calculateBatchDurationSeconds(stamp.amount, price) * MS_PER_SECOND
+    const remainingMs = expiryMs - Date.now()
+    if (remainingMs <= 0) return false
 
-    // Use block timestamp if available, otherwise fall back to createdAt
-    const startTimeMs =
-      blockTimestamp !== undefined ? blockTimestamp * MS_PER_SECOND : stamp.createdAt
-
-    const expiryTimestamp = startTimeMs + totalLifetimeMs
-    const remainingMs = expiryTimestamp - Date.now()
     const oneMonthMs = Number(SECONDS_PER_MONTH) * MS_PER_SECOND
+    if (remainingMs < oneMonthMs) return true
 
-    return (
-      remainingMs > 0 &&
-      (remainingMs < oneMonthMs || remainingMs < totalLifetimeMs * EXPIRY_SOON_LIFETIME_FRACTION)
-    )
+    // If we have a price, also flag stamps in the last 10% of their estimated lifetime.
+    if (price === undefined) return false
+    const totalLifetimeMs = calculateBatchDurationSeconds(stamp.amount, price) * MS_PER_SECOND
+    return totalLifetimeMs > 0 && remainingMs < totalLifetimeMs * EXPIRY_SOON_LIFETIME_FRACTION
   }
 </script>
 
@@ -210,19 +236,33 @@
         </div>
       </Horizontal>
 
-      {#if pricePerGBPerMonth}
-        {@const stampBlockTimestamp = blockTimestamps.get(stamp.blockNumber)}
-        {@const expiringSoon = isExpiringSoon(stamp, pricePerGBPerMonth, stampBlockTimestamp)}
+      {@const stampBlockTimestamp = blockTimestamps.get(stamp.blockNumber)}
+      {@const stampBeeExpiry = beeExpiryMs.get(stamp.batchID.toHex())}
+      {@const expiryMs = getExpiryMs(
+        stamp,
+        pricePerGBPerMonth,
+        stampBlockTimestamp,
+        stampBeeExpiry,
+      )}
+      {#if expiryMs !== undefined}
+        {@const expired = isExpired(expiryMs)}
+        {@const expiringSoon = !expired && isExpiringSoon(stamp, expiryMs, pricePerGBPerMonth)}
         <Horizontal --horizontal-justify-content="space-between" --horizontal-align-items="center">
           <Typography>Expiry date</Typography>
           <Horizontal --horizontal-gap="var(--half-padding)" --horizontal-align-items="center">
-            <Typography --typography-color={expiringSoon ? 'var(--colors-red)' : undefined}>
-              {formatExpiryDate(stamp, pricePerGBPerMonth, stampBlockTimestamp)}
+            <Typography
+              --typography-color={expired || expiringSoon ? 'var(--colors-red)' : undefined}
+            >
+              {formatExpiryDate(expiryMs)}
             </Typography>
-            {#if expiringSoon}
-              <Badge variant="error" dimension="small"
-                ><WarningAltFilled size={16} />Expires soon</Badge
-              >
+            {#if expired}
+              <Badge variant="error" dimension="small">
+                <WarningAltFilled size={16} />Expired
+              </Badge>
+            {:else if expiringSoon}
+              <Badge variant="error" dimension="small">
+                <WarningAltFilled size={16} />Expires soon
+              </Badge>
             {/if}
           </Horizontal>
         </Horizontal>

--- a/swarm-ui/src/routes/(app)/identity/[id]/stamps/+page.svelte
+++ b/swarm-ui/src/routes/(app)/identity/[id]/stamps/+page.svelte
@@ -89,17 +89,9 @@
     }
   }
 
-  onMount(async () => {
-    // Fetch Swarmscan price
-    try {
-      pricePerGBPerMonth = await fetchSwarmPrice()
-    } catch {
-      // Silently fail — only the constant-price fallback and the "expires
-      // soon" heuristic become unavailable. The Bee batchTTL path can still
-      // render an accurate expiry date without it.
-    }
-
-    // Fetch block timestamps and authoritative batchTTL for stamps
+  onMount(() => {
+    // Start the authoritative Bee batchTTL + block-timestamp fetches first;
+    // they don't depend on the Swarmscan price and shouldn't wait on it.
     const stamps = [accountStamp, identityStamp].filter(Boolean) as PostageStamp[]
     for (const stamp of stamps) {
       if (stamp.blockNumber > 0) {
@@ -107,6 +99,15 @@
       }
       fetchStampExpiryFromBee(stamp)
     }
+
+    // Swarmscan price feeds only the constant-price fallback and the
+    // "expires soon" heuristic, so run it in parallel and let it fail
+    // silently — the Bee batchTTL path can still render an accurate date.
+    fetchSwarmPrice()
+      .then((price) => {
+        pricePerGBPerMonth = price
+      })
+      .catch(() => {})
   })
 
   function formatBytes(bytes: number): string {


### PR DESCRIPTION
## Summary
- The stamps page projected expiry as `creationTime + amount / currentPrice`, assuming the chain's per-block price had been constant since purchase. When the price changes — or on dev clusters whose chain price differs from mainnet — this puts the date in the past even for stamps that are still valid on-chain. Fixes [#279](https://github.com/snaha/swarm-id/issues/279).
- Adds `fetchBatchTTL(beeUrl, batchId)` in `@snaha/swarm-id` and uses it on the stamps page and in `SwarmIdProxy.handleGetPostageBatch`. Bee computes `batchTTL` from live chain state (`batch.Value - state.TotalAmount`) and `state.CurrentPrice`, so it stays accurate as the price moves.
- Falls back to the existing Swarmscan-price approximation when the configured Bee node does not know about the batch (e.g. the public gateway).
- Surfaces an explicit **Expired** badge in the UI instead of rendering a confusing past date.

## Test plan
- [x] `pnpm check:all` passes (lib format/lint/typecheck/test + swarm-ui lint/check/knip)
- [x] `vitest` covers `fetchBatchTTL`: success, trailing-slash URL, 404, missing/non-number `batchTTL`, negative TTL clamped to 0, fetch rejection, JSON parse error
- [x] Manual: on a local `bee-compose` cluster, add a stamp via the dev page and confirm the stamps page now shows the Bee node's TTL (not the Swarmscan approximation)
- [x] Manual: with the gateway as the Bee URL, confirm the fallback approximation still renders
- [x] Manual: confirm an expired stamp shows the **Expired** badge instead of a past date

🤖 Generated with [Claude Code](https://claude.com/claude-code)