### PR TITLE
fix!: uint16 utilization counter

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -43,6 +43,8 @@ export {
   assignChunksToBuckets,
   serializeUint32Array,
   deserializeUint32Array,
+  serializeUint16Array,
+  deserializeUint16Array,
   splitIntoChunks,
   reconstructFromChunks,
   calculateMaxSlotsPerBucket,
@@ -50,12 +52,14 @@ export {
   createStamper,
   prepareBucketState,
   UtilizationAwareStamper,
+  getChunkLayout,
   NUM_BUCKETS,
   BUCKET_DEPTH,
   UTILIZATION_SLOTS_PER_BUCKET,
   DATA_COUNTER_START,
   CHUNK_SIZE,
   DEFAULT_BATCH_DEPTH,
+  UINT16_COUNTER_MAX_DEPTH,
 } from "./utils/batch-utilization"
 
 // Utilization storage (IndexedDB cache)
@@ -327,6 +331,7 @@ export {
 // Batch utilization types
 export type {
   BatchUtilizationState,
+  ChunkLayout,
   ChunkWithBucket,
   UtilizationUpdate,
 } from "./utils/batch-utilization"

--- a/lib/src/storage/utilization-store.ts
+++ b/lib/src/storage/utilization-store.ts
@@ -5,8 +5,8 @@
  * IndexedDB Cache for Batch Utilization Chunks
  *
  * Provides fast local caching of 4KB utilization chunks to avoid
- * repeated Swarm downloads. Each chunk is 4096 bytes containing
- * 1024 bucket counters (uint32).
+ * repeated Swarm downloads. Each chunk is 4096 bytes containing either
+ * 2048 uint16 or 1024 uint32 bucket counters, depending on batch depth.
  */
 
 import { Binary } from "cafe-utility"
@@ -22,7 +22,7 @@ export interface ChunkCacheEntry {
   /** Batch ID (hex string) */
   batchId: string
 
-  /** Chunk index (0-63) */
+  /** Chunk index within the depth-dependent layout */
   chunkIndex: number
 
   /** Serialized chunk data (4KB) */
@@ -54,7 +54,9 @@ export interface BatchMetadata {
 const DB_NAME = "swarm-utilization-store"
 /**
  * v2: switch on-disk counter codec from uint32 to uint16 for depth ≤ 31.
- * Upgrade drops legacy chunks/metadata — counters rebuild on first save.
+ * The chunk layout (count and byte width) changed, so legacy rows cannot
+ * be reinterpreted — the upgrade drops both stores. Cached utilization
+ * tracking is lost and re-initialized to defaults on next use.
  *
  * Issue: https://github.com/snaha/swarm-id/issues/243
  */
@@ -81,8 +83,22 @@ export class UtilizationStoreDB {
         reject(new Error(`Failed to open IndexedDB: ${request.error}`))
       }
 
+      // Fires when an upgrade is held up by another open connection (e.g.
+      // a second tab on the trusted domain). The upgrade proceeds once that
+      // connection closes — see the onversionchange handler below.
+      request.onblocked = () => {
+        console.warn(
+          "[UtilizationStore] IndexedDB upgrade blocked by another open connection; waiting for it to close",
+        )
+      }
+
       request.onsuccess = () => {
         this.db = request.result
+        // Release this connection if another tab needs to upgrade, so its
+        // open() does not block indefinitely on us.
+        this.db.onversionchange = () => {
+          this.close()
+        }
         resolve()
       }
 
@@ -90,7 +106,9 @@ export class UtilizationStoreDB {
         const db = (event.target as IDBOpenDBRequest).result
 
         // v1 → v2: chunk layout changed (uint32 → uint16 for depth ≤ 31).
-        // Drop and recreate both stores; counters will rebuild on next save.
+        // Legacy rows are unreadable under the new layout, so drop and
+        // recreate both stores; utilization tracking re-initializes to
+        // defaults on next use.
         if (db.objectStoreNames.contains(CHUNKS_STORE)) {
           db.deleteObjectStore(CHUNKS_STORE)
         }
@@ -119,7 +137,7 @@ export class UtilizationStoreDB {
   /**
    * Get a chunk from cache
    * @param batchId - Batch ID (hex string)
-   * @param chunkIndex - Chunk index (0-63)
+   * @param chunkIndex - Chunk index
    * @returns Cache entry or undefined if not found
    */
   async getChunk(
@@ -245,7 +263,7 @@ export class UtilizationStoreDB {
   /**
    * Update lastAccess timestamp for a chunk
    * @param batchId - Batch ID (hex string)
-   * @param chunkIndex - Chunk index (0-63)
+   * @param chunkIndex - Chunk index
    */
   private async touchChunk(batchId: string, chunkIndex: number): Promise<void> {
     await this.open()
@@ -332,7 +350,7 @@ export interface CacheEvictionPolicy {
   /** Maximum age in milliseconds (default: 7 days) */
   maxAge?: number
 
-  /** Maximum number of chunks to keep (default: 640 = 10 batches) */
+  /** Maximum number of chunks to keep (default: 640) */
   maxChunks?: number
 }
 
@@ -346,7 +364,7 @@ export async function evictOldEntries(
   policy: CacheEvictionPolicy = {},
 ): Promise<void> {
   const maxAge = policy.maxAge ?? 7 * 24 * 60 * 60 * 1000 // 7 days
-  const maxChunks = policy.maxChunks ?? 640 // 10 batches × 64 chunks
+  const maxChunks = policy.maxChunks ?? 640 // ≈10–20 batches depending on depth
 
   await cache.open()
 

--- a/lib/src/storage/utilization-store.ts
+++ b/lib/src/storage/utilization-store.ts
@@ -52,7 +52,13 @@ export interface BatchMetadata {
 // ============================================================================
 
 const DB_NAME = "swarm-utilization-store"
-const DB_VERSION = 1
+/**
+ * v2: switch on-disk counter codec from uint32 to uint16 for depth ≤ 31.
+ * Upgrade drops legacy chunks/metadata — counters rebuild on first save.
+ *
+ * Issue: https://github.com/snaha/swarm-id/issues/243
+ */
+const DB_VERSION = 2
 const CHUNKS_STORE = "chunks"
 const METADATA_STORE = "metadata"
 
@@ -83,25 +89,29 @@ export class UtilizationStoreDB {
       request.onupgradeneeded = (event) => {
         const db = (event.target as IDBOpenDBRequest).result
 
-        // Create chunks store with compound key
-        if (!db.objectStoreNames.contains(CHUNKS_STORE)) {
-          const chunksStore = db.createObjectStore(CHUNKS_STORE, {
-            keyPath: ["batchId", "chunkIndex"],
-          })
-
-          // Index for querying by batchId
-          chunksStore.createIndex("batchId", "batchId", { unique: false })
-
-          // Index for eviction by lastAccess
-          chunksStore.createIndex("lastAccess", "lastAccess", {
-            unique: false,
-          })
+        // v1 → v2: chunk layout changed (uint32 → uint16 for depth ≤ 31).
+        // Drop and recreate both stores; counters will rebuild on next save.
+        if (db.objectStoreNames.contains(CHUNKS_STORE)) {
+          db.deleteObjectStore(CHUNKS_STORE)
+        }
+        if (db.objectStoreNames.contains(METADATA_STORE)) {
+          db.deleteObjectStore(METADATA_STORE)
         }
 
-        // Create metadata store
-        if (!db.objectStoreNames.contains(METADATA_STORE)) {
-          db.createObjectStore(METADATA_STORE, { keyPath: "batchId" })
-        }
+        const chunksStore = db.createObjectStore(CHUNKS_STORE, {
+          keyPath: ["batchId", "chunkIndex"],
+        })
+
+        // Index for querying by batchId
+        chunksStore.createIndex("batchId", "batchId", { unique: false })
+
+        // Index for eviction by lastAccess
+        chunksStore.createIndex("lastAccess", "lastAccess", {
+          unique: false,
+        })
+
+        // Metadata store
+        db.createObjectStore(METADATA_STORE, { keyPath: "batchId" })
       }
     })
   }

--- a/lib/src/utils/batch-utilization.test.ts
+++ b/lib/src/utils/batch-utilization.test.ts
@@ -13,8 +13,11 @@ import {
   deserializeUint16Array,
   deserializeUint32Array,
   extractChunk,
+  getChunkIndexForBucket,
   getChunkLayout,
   initializeBatchUtilization,
+  makeBatchUtilizationTopic,
+  makeChunkIdentifier,
   mergeChunk,
   serializeUint16Array,
   serializeUint32Array,
@@ -179,6 +182,49 @@ describe("calculateUtilizationUpdate (chunk count by depth)", () => {
       depth,
     )
     expect(utilizationChunks.length).toBe(64)
+  })
+})
+
+describe("getChunkIndexForBucket (depth-dependent layout)", () => {
+  it("maps buckets to chunks using the uint16 layout at depth 24", () => {
+    expect(getChunkIndexForBucket(0, 24)).toBe(0)
+    expect(getChunkIndexForBucket(2047, 24)).toBe(0)
+    expect(getChunkIndexForBucket(2048, 24)).toBe(1)
+    expect(getChunkIndexForBucket(NUM_BUCKETS - 1, 24)).toBe(31)
+  })
+
+  it("maps buckets to chunks using the uint32 layout at depth 32", () => {
+    expect(getChunkIndexForBucket(0, 32)).toBe(0)
+    expect(getChunkIndexForBucket(1023, 32)).toBe(0)
+    expect(getChunkIndexForBucket(1024, 32)).toBe(1)
+    expect(getChunkIndexForBucket(NUM_BUCKETS - 1, 32)).toBe(63)
+  })
+
+  it("rejects an out-of-range bucket index", () => {
+    expect(() => getChunkIndexForBucket(-1, 24)).toThrow(/Invalid bucket index/)
+    expect(() => getChunkIndexForBucket(NUM_BUCKETS, 24)).toThrow(
+      /Invalid bucket index/,
+    )
+  })
+})
+
+describe("makeChunkIdentifier (depth-dependent chunk count)", () => {
+  const topic = makeBatchUtilizationTopic(TEST_BATCH_ID)
+
+  it("is deterministic for the same topic, index, and depth", () => {
+    const a = makeChunkIdentifier(topic, 5, 24)
+    const b = makeChunkIdentifier(topic, 5, 24)
+    expect(a.toHex()).toBe(b.toHex())
+  })
+
+  it("rejects an index outside the uint16 layout but accepts it for uint32", () => {
+    expect(() => makeChunkIdentifier(topic, 32, 24)).toThrow(
+      /Invalid chunk index/,
+    )
+    expect(() => makeChunkIdentifier(topic, 32, 32)).not.toThrow()
+    expect(() => makeChunkIdentifier(topic, 64, 32)).toThrow(
+      /Invalid chunk index/,
+    )
   })
 })
 

--- a/lib/src/utils/batch-utilization.test.ts
+++ b/lib/src/utils/batch-utilization.test.ts
@@ -1,0 +1,193 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest"
+import { BatchId } from "@ethersphere/bee-js"
+import { makeContentAddressedChunk } from "../chunk"
+import {
+  CHUNK_SIZE,
+  DATA_COUNTER_START,
+  NUM_BUCKETS,
+  UINT16_COUNTER_MAX_DEPTH,
+  calculateUtilizationUpdate,
+  deserializeUint16Array,
+  deserializeUint32Array,
+  extractChunk,
+  getChunkLayout,
+  initializeBatchUtilization,
+  mergeChunk,
+  serializeUint16Array,
+  serializeUint32Array,
+} from "./batch-utilization"
+
+const TEST_BATCH_ID = new BatchId("00".repeat(32))
+
+describe("getChunkLayout", () => {
+  it("uses uint16 codec for depth <= UINT16_COUNTER_MAX_DEPTH", () => {
+    const layout = getChunkLayout(24)
+    expect(layout.counterByteSize).toBe(2)
+    expect(layout.bucketsPerChunk).toBe(2048)
+    expect(layout.numUtilizationChunks).toBe(32)
+  })
+
+  it("uses uint16 codec at the boundary (depth = UINT16_COUNTER_MAX_DEPTH)", () => {
+    expect(UINT16_COUNTER_MAX_DEPTH).toBe(31)
+    const layout = getChunkLayout(UINT16_COUNTER_MAX_DEPTH)
+    expect(layout.counterByteSize).toBe(2)
+    expect(layout.numUtilizationChunks).toBe(32)
+  })
+
+  it("falls back to uint32 codec for depth > UINT16_COUNTER_MAX_DEPTH", () => {
+    const layout = getChunkLayout(32)
+    expect(layout.counterByteSize).toBe(4)
+    expect(layout.bucketsPerChunk).toBe(1024)
+    expect(layout.numUtilizationChunks).toBe(64)
+  })
+
+  it("returns a chunk size that covers all NUM_BUCKETS in both layouts", () => {
+    expect(getChunkLayout(24).bucketsPerChunk * 32).toBe(NUM_BUCKETS)
+    expect(getChunkLayout(32).bucketsPerChunk * 64).toBe(NUM_BUCKETS)
+    expect(getChunkLayout(24).bucketsPerChunk * 2).toBe(CHUNK_SIZE)
+    expect(getChunkLayout(32).bucketsPerChunk * 4).toBe(CHUNK_SIZE)
+  })
+})
+
+describe("serializeUint16Array / deserializeUint16Array", () => {
+  it("round-trips representative values", () => {
+    const source = new Uint32Array([0, 1, 255, 256, 32768, 65535])
+    const bytes = serializeUint16Array(source)
+    expect(bytes.byteLength).toBe(source.length * 2)
+    const decoded = deserializeUint16Array(bytes)
+    expect(Array.from(decoded)).toEqual(Array.from(source))
+  })
+
+  it("round-trips a full-bucket random fill", () => {
+    const source = new Uint32Array(2048)
+    for (let i = 0; i < source.length; i++) {
+      source[i] = Math.floor(Math.random() * 0x10000)
+    }
+    const bytes = serializeUint16Array(source)
+    expect(bytes.byteLength).toBe(CHUNK_SIZE)
+    const decoded = deserializeUint16Array(bytes)
+    expect(Array.from(decoded)).toEqual(Array.from(source))
+  })
+
+  it("rejects values that exceed uint16 range", () => {
+    const source = new Uint32Array([0, 0x10000])
+    expect(() => serializeUint16Array(source)).toThrow(/uint16 range/)
+  })
+
+  it("rejects odd-length byte input on deserialize", () => {
+    expect(() => deserializeUint16Array(new Uint8Array(3))).toThrow(
+      /multiple of 2/,
+    )
+  })
+})
+
+describe("extractChunk / mergeChunk", () => {
+  it("round-trips a full dataCounters at depth 24 (uint16 layout)", () => {
+    const depth = 24
+    const { numUtilizationChunks } = getChunkLayout(depth)
+    const source = new Uint32Array(NUM_BUCKETS)
+    for (let i = 0; i < source.length; i++) {
+      source[i] = i % 0xffff
+    }
+
+    const target = new Uint32Array(NUM_BUCKETS)
+    for (let i = 0; i < numUtilizationChunks; i++) {
+      const chunk = extractChunk(source, i, depth)
+      expect(chunk.byteLength).toBe(CHUNK_SIZE)
+      mergeChunk(target, i, chunk, depth)
+    }
+
+    expect(Array.from(target)).toEqual(Array.from(source))
+  })
+
+  it("round-trips a full dataCounters at depth 32 (uint32 layout)", () => {
+    const depth = 32
+    const { numUtilizationChunks } = getChunkLayout(depth)
+    const source = new Uint32Array(NUM_BUCKETS)
+    for (let i = 0; i < source.length; i++) {
+      source[i] = (i * 1664525 + 1013904223) >>> 0
+    }
+
+    const target = new Uint32Array(NUM_BUCKETS)
+    for (let i = 0; i < numUtilizationChunks; i++) {
+      const chunk = extractChunk(source, i, depth)
+      expect(chunk.byteLength).toBe(CHUNK_SIZE)
+      mergeChunk(target, i, chunk, depth)
+    }
+
+    expect(Array.from(target)).toEqual(Array.from(source))
+  })
+
+  it("rejects an out-of-range chunk index", () => {
+    const counters = new Uint32Array(NUM_BUCKETS)
+    expect(() => extractChunk(counters, 32, 24)).toThrow(/Invalid chunk index/)
+    expect(() => extractChunk(counters, 64, 32)).toThrow(/Invalid chunk index/)
+  })
+
+  it("rejects a chunk whose byte length is not CHUNK_SIZE", () => {
+    const counters = new Uint32Array(NUM_BUCKETS)
+    expect(() => mergeChunk(counters, 0, new Uint8Array(100), 24)).toThrow(
+      /Invalid chunk data length/,
+    )
+  })
+})
+
+describe("initializeBatchUtilization", () => {
+  it("seeds dataCounters at DATA_COUNTER_START and matches the layout's chunk count", () => {
+    const state = initializeBatchUtilization(TEST_BATCH_ID, 24)
+    expect(state.batchDepth).toBe(24)
+    expect(state.dataCounters.length).toBe(NUM_BUCKETS)
+    expect(state.dataCounters[0]).toBe(DATA_COUNTER_START)
+    expect(state.dataCounters[NUM_BUCKETS - 1]).toBe(DATA_COUNTER_START)
+    expect(state.chunks.length).toBe(32)
+  })
+
+  it("uses the 64-chunk layout at depth 32", () => {
+    const state = initializeBatchUtilization(TEST_BATCH_ID, 32)
+    expect(state.batchDepth).toBe(32)
+    expect(state.chunks.length).toBe(64)
+  })
+})
+
+describe("calculateUtilizationUpdate (chunk count by depth)", () => {
+  const dataChunks = [
+    makeContentAddressedChunk(new Uint8Array(4096).fill(1)),
+    makeContentAddressedChunk(new Uint8Array(4096).fill(2)),
+    makeContentAddressedChunk(new Uint8Array(4096).fill(3)),
+  ]
+
+  it("produces 32 utilization chunks at depth 24 (uint16 codec)", () => {
+    const depth = 24
+    const state = initializeBatchUtilization(TEST_BATCH_ID, depth)
+    const { utilizationChunks } = calculateUtilizationUpdate(
+      state,
+      dataChunks,
+      depth,
+    )
+    expect(utilizationChunks.length).toBe(32)
+  })
+
+  it("produces 64 utilization chunks at depth 32 (uint32 codec)", () => {
+    const depth = 32
+    const state = initializeBatchUtilization(TEST_BATCH_ID, depth)
+    const { utilizationChunks } = calculateUtilizationUpdate(
+      state,
+      dataChunks,
+      depth,
+    )
+    expect(utilizationChunks.length).toBe(64)
+  })
+})
+
+describe("regression: serializeUint32Array round-trip", () => {
+  it("round-trips a uint32 buffer", () => {
+    const source = new Uint32Array([0, 1, 0xdeadbeef, 0xffffffff])
+    const bytes = serializeUint32Array(source)
+    expect(bytes.byteLength).toBe(source.length * 4)
+    const decoded = deserializeUint32Array(bytes)
+    expect(Array.from(decoded)).toEqual(Array.from(source))
+  })
+})

--- a/lib/src/utils/batch-utilization.ts
+++ b/lib/src/utils/batch-utilization.ts
@@ -72,6 +72,9 @@ const COUNTER_BYTES_UINT16 = 2
 /** uint32 serialization size in bytes */
 const COUNTER_BYTES_UINT32 = 4
 
+/** Largest value representable in an unsigned 16-bit integer */
+const UINT16_MAX = 0xffff
+
 /**
  * Per-batch-depth chunk layout for the utilization state.
  *
@@ -111,7 +114,7 @@ export function getChunkLayout(batchDepth: number): ChunkLayout {
  * Metadata for a single utilization chunk
  */
 export interface ChunkMetadata {
-  /** Chunk index (0-63) */
+  /** Chunk index within the depth-dependent layout */
   index: number
 
   /**
@@ -130,8 +133,9 @@ export interface ChunkMetadata {
 /**
  * Utilization state for a postage batch
  *
- * This new version stores utilization data as 64 chunks on Swarm
- * with IndexedDB caching for performance.
+ * Utilization data is stored as 32 chunks (uint16 codec, depth ≤ 31) or
+ * 64 chunks (uint32 codec, depth ≥ 32) on Swarm, with IndexedDB caching
+ * for performance.
  */
 export interface BatchUtilizationState {
   /** Batch ID this state belongs to */
@@ -241,26 +245,6 @@ export function getChunkIndexForBucket(
 }
 
 /**
- * Calculate the offset of a bucket within its chunk.
- *
- * @param bucketIndex - Bucket index (0-65535)
- * @param batchDepth - Batch depth, drives the chunk layout
- * @returns Offset within chunk, in counters (not bytes)
- */
-export function getBucketOffsetInChunk(
-  bucketIndex: number,
-  batchDepth: number,
-): number {
-  if (bucketIndex < 0 || bucketIndex >= NUM_BUCKETS) {
-    throw new Error(
-      `Invalid bucket index: ${bucketIndex} (must be 0-${NUM_BUCKETS - 1})`,
-    )
-  }
-  const { bucketsPerChunk } = getChunkLayout(batchDepth)
-  return bucketIndex % bucketsPerChunk
-}
-
-/**
  * Extract a CHUNK_SIZE-byte chunk from the dataCounters array using the
  * codec implied by the batch depth.
  *
@@ -365,7 +349,7 @@ export class DirtyChunkTracker {
 
   /**
    * Mark a chunk as clean (uploaded successfully)
-   * @param chunkIndex - Chunk index (0-63)
+   * @param chunkIndex - Chunk index
    */
   markClean(chunkIndex: number): void {
     this.dirtyChunks.delete(chunkIndex)
@@ -466,7 +450,7 @@ export function makeChunkIdentifier(
  *
  * @param bee - Bee client instance
  * @param stamper - Stamper for signing
- * @param chunkIndex - Chunk index (0-63)
+ * @param chunkIndex - Chunk index
  * @param data - Chunk data to upload (4KB)
  * @param encryptionKey - Encryption key (32 bytes)
  * @returns CAC reference
@@ -629,7 +613,7 @@ export function serializeUint16Array(arr: Uint32Array): Uint8Array {
 
   for (let i = 0; i < arr.length; i++) {
     const v = arr[i]
-    if (v > 0xffff) {
+    if (v > UINT16_MAX) {
       throw new Error(
         `Counter at index ${i} (${v}) exceeds uint16 range; use uint32 codec`,
       )
@@ -914,7 +898,7 @@ export function utilizationToBucketState(
  * Load utilization state with cache hierarchy
  *
  * Load order:
- * 1. Try IndexedDB cache (all 64 chunks)
+ * 1. Try IndexedDB cache (all chunks for the depth's layout)
  * 2. If incomplete, download missing chunks from Swarm
  * 3. If not found, initialize new state
  * 4. Cache downloaded chunks in IndexedDB
@@ -937,7 +921,8 @@ export async function loadUtilizationState(
   // TODO: Use bee, owner, encryptionKey when state feed is implemented
   const { bee: _bee, owner: _owner, encryptionKey: _encryptionKey } = options
 
-  const { bucketsPerChunk, numUtilizationChunks } = getChunkLayout(batchDepth)
+  const { counterByteSize, bucketsPerChunk, numUtilizationChunks } =
+    getChunkLayout(batchDepth)
 
   // Step 1: Try loading from IndexedDB cache
   const cachedChunks = await cache.getAllChunks(batchId.toHex())
@@ -984,7 +969,6 @@ export async function loadUtilizationState(
   // Seed a default chunk's worth of counters once; reused via mergeChunk
   const defaultCounters = new Uint32Array(bucketsPerChunk)
   defaultCounters.fill(DATA_COUNTER_START)
-  const { counterByteSize } = getChunkLayout(batchDepth)
   const defaultChunkData =
     counterByteSize === COUNTER_BYTES_UINT16
       ? serializeUint16Array(defaultCounters)

--- a/lib/src/utils/batch-utilization.ts
+++ b/lib/src/utils/batch-utilization.ts
@@ -55,6 +55,54 @@ export const CHUNK_SIZE = 4096
 /** Batch depth for N=256 slots per bucket with 65536 buckets */
 export const DEFAULT_BATCH_DEPTH = 24
 
+/**
+ * Maximum batch depth at which a uint16 per-bucket counter is sufficient.
+ *
+ * At depth D the post-stamp counter caps at 2^(D-16). uint16 can hold
+ * 0..65535; depth 31 → 32768 (fits), depth 32 → 65536 (overflows).
+ * For depth > UINT16_COUNTER_MAX_DEPTH the serializer falls back to uint32.
+ *
+ * Issue: https://github.com/snaha/swarm-id/issues/243
+ */
+export const UINT16_COUNTER_MAX_DEPTH = 31
+
+/** uint16 serialization size in bytes */
+const COUNTER_BYTES_UINT16 = 2
+
+/** uint32 serialization size in bytes */
+const COUNTER_BYTES_UINT32 = 4
+
+/**
+ * Per-batch-depth chunk layout for the utilization state.
+ *
+ * The on-chunk counter representation switches between uint16 and uint32
+ * based on whether the maximum slot index for the given batch depth fits
+ * in 16 bits. Each utilization chunk is always CHUNK_SIZE bytes; the
+ * number of buckets it covers — and thus the number of chunks needed —
+ * doubles when counters shrink from 4 bytes to 2.
+ */
+export interface ChunkLayout {
+  /** Bytes per per-bucket counter on disk / on the wire */
+  counterByteSize: 2 | 4
+  /** Number of buckets packed into a single CHUNK_SIZE-byte chunk */
+  bucketsPerChunk: number
+  /** Total number of utilization chunks for one batch */
+  numUtilizationChunks: number
+}
+
+/**
+ * Pick the on-disk chunk layout for a given batch depth.
+ */
+export function getChunkLayout(batchDepth: number): ChunkLayout {
+  const counterByteSize =
+    batchDepth <= UINT16_COUNTER_MAX_DEPTH
+      ? COUNTER_BYTES_UINT16
+      : COUNTER_BYTES_UINT32
+  const bucketsPerChunk = CHUNK_SIZE / counterByteSize
+  const numUtilizationChunks = NUM_BUCKETS / bucketsPerChunk
+  return { counterByteSize, bucketsPerChunk, numUtilizationChunks }
+}
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -89,11 +137,17 @@ export interface BatchUtilizationState {
   /** Batch ID this state belongs to */
   batchId: BatchId
 
-  /** Data counters (65,536 uint32 values) */
+  /** Batch depth — determines on-disk chunk layout (uint16 vs uint32) */
+  batchDepth: number
+
+  /**
+   * Data counters (65,536 entries). Always uint32 in memory regardless of
+   * the on-disk codec; narrowing happens at the serialize boundary.
+   */
   dataCounters: Uint32Array // [65536]
 
-  /** Metadata for each of the 64 utilization chunks */
-  chunks: ChunkMetadata[] // [64]
+  /** Metadata for each utilization chunk (32 for uint16, 64 for uint32) */
+  chunks: ChunkMetadata[]
 
   /** Topic for SOC storage */
   topic: Topic
@@ -167,80 +221,99 @@ export function assignChunksToBuckets(
 // ============================================================================
 
 /**
- * Number of utilization chunks (64 chunks of 4KB each = 262KB total)
- * Each chunk contains 1,024 buckets (1,024 × 4 bytes = 4,096 bytes)
- */
-export const NUM_UTILIZATION_CHUNKS = 64
-export const BUCKETS_PER_CHUNK = 1024
-
-/**
- * Calculate which utilization chunk a bucket belongs to
+ * Calculate which utilization chunk a bucket belongs to.
+ *
  * @param bucketIndex - Bucket index (0-65535)
- * @returns Chunk index (0-63)
+ * @param batchDepth - Batch depth, drives the chunk layout
+ * @returns Chunk index in the layout for this depth
  */
-export function getChunkIndexForBucket(bucketIndex: number): number {
+export function getChunkIndexForBucket(
+  bucketIndex: number,
+  batchDepth: number,
+): number {
   if (bucketIndex < 0 || bucketIndex >= NUM_BUCKETS) {
     throw new Error(
       `Invalid bucket index: ${bucketIndex} (must be 0-${NUM_BUCKETS - 1})`,
     )
   }
-  return Math.floor(bucketIndex / BUCKETS_PER_CHUNK)
+  const { bucketsPerChunk } = getChunkLayout(batchDepth)
+  return Math.floor(bucketIndex / bucketsPerChunk)
 }
 
 /**
- * Calculate the offset of a bucket within its chunk
+ * Calculate the offset of a bucket within its chunk.
+ *
  * @param bucketIndex - Bucket index (0-65535)
- * @returns Offset within chunk (0-1023)
+ * @param batchDepth - Batch depth, drives the chunk layout
+ * @returns Offset within chunk, in counters (not bytes)
  */
-export function getBucketOffsetInChunk(bucketIndex: number): number {
+export function getBucketOffsetInChunk(
+  bucketIndex: number,
+  batchDepth: number,
+): number {
   if (bucketIndex < 0 || bucketIndex >= NUM_BUCKETS) {
     throw new Error(
       `Invalid bucket index: ${bucketIndex} (must be 0-${NUM_BUCKETS - 1})`,
     )
   }
-  return bucketIndex % BUCKETS_PER_CHUNK
+  const { bucketsPerChunk } = getChunkLayout(batchDepth)
+  return bucketIndex % bucketsPerChunk
 }
 
 /**
- * Extract a 4KB chunk from the dataCounters array
- * @param dataCounters - Full array of 65,536 counters
- * @param chunkIndex - Index of chunk to extract (0-63)
- * @returns 4KB Uint8Array containing serialized counters for this chunk
+ * Extract a CHUNK_SIZE-byte chunk from the dataCounters array using the
+ * codec implied by the batch depth.
+ *
+ * @param dataCounters - Full array of 65,536 counters (kept as Uint32Array
+ *   in memory regardless of serialization size)
+ * @param chunkIndex - Index of chunk to extract
+ * @param batchDepth - Batch depth, drives the chunk layout
+ * @returns CHUNK_SIZE byte Uint8Array containing serialized counters
  */
 export function extractChunk(
   dataCounters: Uint32Array,
   chunkIndex: number,
+  batchDepth: number,
 ): Uint8Array {
-  if (chunkIndex < 0 || chunkIndex >= NUM_UTILIZATION_CHUNKS) {
+  const { counterByteSize, bucketsPerChunk, numUtilizationChunks } =
+    getChunkLayout(batchDepth)
+
+  if (chunkIndex < 0 || chunkIndex >= numUtilizationChunks) {
     throw new Error(
-      `Invalid chunk index: ${chunkIndex} (must be 0-${NUM_UTILIZATION_CHUNKS - 1})`,
+      `Invalid chunk index: ${chunkIndex} (must be 0-${numUtilizationChunks - 1})`,
     )
   }
 
-  const startBucket = chunkIndex * BUCKETS_PER_CHUNK
-  const endBucket = startBucket + BUCKETS_PER_CHUNK
-
-  // Extract the slice of counters for this chunk
+  const startBucket = chunkIndex * bucketsPerChunk
+  const endBucket = startBucket + bucketsPerChunk
   const chunkCounters = dataCounters.slice(startBucket, endBucket)
 
-  // Serialize to little-endian bytes
-  return serializeUint32Array(chunkCounters)
+  return counterByteSize === COUNTER_BYTES_UINT16
+    ? serializeUint16Array(chunkCounters)
+    : serializeUint32Array(chunkCounters)
 }
 
 /**
- * Merge a 4KB chunk back into the dataCounters array
+ * Merge a CHUNK_SIZE-byte chunk back into the dataCounters array using the
+ * codec implied by the batch depth.
+ *
  * @param dataCounters - Full array of 65,536 counters (modified in place)
- * @param chunkIndex - Index of chunk to merge (0-63)
- * @param chunkData - 4KB Uint8Array containing serialized counters
+ * @param chunkIndex - Index of chunk to merge
+ * @param chunkData - CHUNK_SIZE byte Uint8Array containing serialized counters
+ * @param batchDepth - Batch depth, drives the chunk layout
  */
 export function mergeChunk(
   dataCounters: Uint32Array,
   chunkIndex: number,
   chunkData: Uint8Array,
+  batchDepth: number,
 ): void {
-  if (chunkIndex < 0 || chunkIndex >= NUM_UTILIZATION_CHUNKS) {
+  const { counterByteSize, bucketsPerChunk, numUtilizationChunks } =
+    getChunkLayout(batchDepth)
+
+  if (chunkIndex < 0 || chunkIndex >= numUtilizationChunks) {
     throw new Error(
-      `Invalid chunk index: ${chunkIndex} (must be 0-${NUM_UTILIZATION_CHUNKS - 1})`,
+      `Invalid chunk index: ${chunkIndex} (must be 0-${numUtilizationChunks - 1})`,
     )
   }
 
@@ -250,17 +323,18 @@ export function mergeChunk(
     )
   }
 
-  // Deserialize the chunk data
-  const chunkCounters = deserializeUint32Array(chunkData)
+  const chunkCounters =
+    counterByteSize === COUNTER_BYTES_UINT16
+      ? deserializeUint16Array(chunkData)
+      : deserializeUint32Array(chunkData)
 
-  if (chunkCounters.length !== BUCKETS_PER_CHUNK) {
+  if (chunkCounters.length !== bucketsPerChunk) {
     throw new Error(
-      `Invalid chunk counters length: ${chunkCounters.length} (expected ${BUCKETS_PER_CHUNK})`,
+      `Invalid chunk counters length: ${chunkCounters.length} (expected ${bucketsPerChunk})`,
     )
   }
 
-  // Merge back into dataCounters
-  const startBucket = chunkIndex * BUCKETS_PER_CHUNK
+  const startBucket = chunkIndex * bucketsPerChunk
   dataCounters.set(chunkCounters, startBucket)
 }
 
@@ -273,9 +347,11 @@ export function mergeChunk(
  */
 export class DirtyChunkTracker {
   private dirtyChunks: Set<number>
+  private batchDepth: number
 
-  constructor() {
+  constructor(batchDepth: number) {
     this.dirtyChunks = new Set()
+    this.batchDepth = batchDepth
   }
 
   /**
@@ -283,7 +359,7 @@ export class DirtyChunkTracker {
    * @param bucketIndex - Bucket index (0-65535)
    */
   markDirty(bucketIndex: number): void {
-    const chunkIndex = getChunkIndexForBucket(bucketIndex)
+    const chunkIndex = getChunkIndexForBucket(bucketIndex, this.batchDepth)
     this.dirtyChunks.add(chunkIndex)
   }
 
@@ -350,16 +426,19 @@ export function makeBatchUtilizationTopic(batchId: BatchId): Topic {
  * Identifier: Keccak256(topic || chunkIndex)
  *
  * @param topic - Batch utilization topic
- * @param chunkIndex - Chunk index (0-63)
+ * @param chunkIndex - Chunk index
+ * @param batchDepth - Batch depth, drives the chunk count
  * @returns Identifier for this chunk
  */
 export function makeChunkIdentifier(
   topic: Topic,
   chunkIndex: number,
+  batchDepth: number,
 ): Identifier {
-  if (chunkIndex < 0 || chunkIndex >= NUM_UTILIZATION_CHUNKS) {
+  const { numUtilizationChunks } = getChunkLayout(batchDepth)
+  if (chunkIndex < 0 || chunkIndex >= numUtilizationChunks) {
     throw new Error(
-      `Invalid chunk index: ${chunkIndex} (must be 0-${NUM_UTILIZATION_CHUNKS - 1})`,
+      `Invalid chunk index: ${chunkIndex} (must be 0-${numUtilizationChunks - 1})`,
     )
   }
 
@@ -539,6 +618,49 @@ export function deserializeUint32Array(bytes: Uint8Array): Uint32Array {
 }
 
 /**
+ * Serialize a Uint32Array to bytes as little-endian uint16 values.
+ *
+ * Counters exceeding uint16 throw — callers must use the uint32 codec
+ * (i.e. batchDepth >= UINT16_COUNTER_MAX_DEPTH + 1) for those depths.
+ */
+export function serializeUint16Array(arr: Uint32Array): Uint8Array {
+  const buffer = new ArrayBuffer(arr.length * COUNTER_BYTES_UINT16)
+  const view = new DataView(buffer)
+
+  for (let i = 0; i < arr.length; i++) {
+    const v = arr[i]
+    if (v > 0xffff) {
+      throw new Error(
+        `Counter at index ${i} (${v}) exceeds uint16 range; use uint32 codec`,
+      )
+    }
+    view.setUint16(i * COUNTER_BYTES_UINT16, v, true) // true = little-endian
+  }
+
+  return new Uint8Array(buffer)
+}
+
+/**
+ * Deserialize little-endian uint16 bytes back into a Uint32Array (the
+ * in-memory representation stays uint32 even when the on-disk codec is
+ * narrower).
+ */
+export function deserializeUint16Array(bytes: Uint8Array): Uint32Array {
+  if (bytes.length % COUNTER_BYTES_UINT16 !== 0) {
+    throw new Error("Byte array length must be a multiple of 2")
+  }
+
+  const arr = new Uint32Array(bytes.length / COUNTER_BYTES_UINT16)
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+
+  for (let i = 0; i < arr.length; i++) {
+    arr[i] = view.getUint16(i * COUNTER_BYTES_UINT16, true) // true = little-endian
+  }
+
+  return arr
+}
+
+/**
  * Split data into 4KB chunks
  */
 export function splitIntoChunks(data: Uint8Array): ContentAddressedChunk[] {
@@ -595,6 +717,7 @@ export function reconstructFromChunks(
  */
 export function initializeBatchUtilization(
   batchId: BatchId,
+  batchDepth: number,
 ): BatchUtilizationState {
   const dataCounters = new Uint32Array(NUM_BUCKETS)
 
@@ -602,9 +725,11 @@ export function initializeBatchUtilization(
   // Slots 0-3 are reserved for utilization metadata chunks
   dataCounters.fill(DATA_COUNTER_START)
 
-  // Initialize metadata for all 64 chunks
+  const { numUtilizationChunks } = getChunkLayout(batchDepth)
+
+  // Initialize metadata for all utilization chunks
   const chunks: ChunkMetadata[] = []
-  for (let i = 0; i < NUM_UTILIZATION_CHUNKS; i++) {
+  for (let i = 0; i < numUtilizationChunks; i++) {
     chunks.push({
       index: i,
       contentHash: "", // Will be set on first upload
@@ -618,6 +743,7 @@ export function initializeBatchUtilization(
 
   return {
     batchId,
+    batchDepth,
     dataCounters,
     chunks,
     topic,
@@ -689,8 +815,12 @@ export function calculateUtilizationUpdate(
     newDataCounters[bucket]++
   }
 
-  // Step 3: Serialize updated data counters
-  const serialized = serializeUint32Array(newDataCounters)
+  // Step 3: Serialize updated data counters using the codec for this depth
+  const { counterByteSize } = getChunkLayout(batchDepth)
+  const serialized =
+    counterByteSize === COUNTER_BYTES_UINT16
+      ? serializeUint16Array(newDataCounters)
+      : serializeUint32Array(newDataCounters)
   const utilizationChunksRaw = splitIntoChunks(serialized)
 
   // Step 4: Calculate bucket assignments for utilization chunks
@@ -795,6 +925,7 @@ export function utilizationToBucketState(
  */
 export async function loadUtilizationState(
   batchId: BatchId,
+  batchDepth: number,
   options: {
     bee: Bee
     owner: EthAddress
@@ -806,18 +937,20 @@ export async function loadUtilizationState(
   // TODO: Use bee, owner, encryptionKey when state feed is implemented
   const { bee: _bee, owner: _owner, encryptionKey: _encryptionKey } = options
 
+  const { bucketsPerChunk, numUtilizationChunks } = getChunkLayout(batchDepth)
+
   // Step 1: Try loading from IndexedDB cache
   const cachedChunks = await cache.getAllChunks(batchId.toHex())
 
   // Step 2: If we have all chunks in cache, reconstruct state
-  if (cachedChunks.length === NUM_UTILIZATION_CHUNKS) {
+  if (cachedChunks.length === numUtilizationChunks) {
     try {
       const dataCounters = new Uint32Array(NUM_BUCKETS)
       const chunks: ChunkMetadata[] = []
 
       // Reconstruct dataCounters from cached chunks
       for (const cached of cachedChunks) {
-        mergeChunk(dataCounters, cached.chunkIndex, cached.data)
+        mergeChunk(dataCounters, cached.chunkIndex, cached.data, batchDepth)
 
         chunks.push({
           index: cached.chunkIndex,
@@ -831,6 +964,7 @@ export async function loadUtilizationState(
 
       return {
         batchId,
+        batchDepth,
         dataCounters,
         chunks,
         topic,
@@ -847,13 +981,22 @@ export async function loadUtilizationState(
   const dataCounters = new Uint32Array(NUM_BUCKETS)
   const chunks: ChunkMetadata[] = []
 
-  for (let i = 0; i < NUM_UTILIZATION_CHUNKS; i++) {
+  // Seed a default chunk's worth of counters once; reused via mergeChunk
+  const defaultCounters = new Uint32Array(bucketsPerChunk)
+  defaultCounters.fill(DATA_COUNTER_START)
+  const { counterByteSize } = getChunkLayout(batchDepth)
+  const defaultChunkData =
+    counterByteSize === COUNTER_BYTES_UINT16
+      ? serializeUint16Array(defaultCounters)
+      : serializeUint32Array(defaultCounters)
+
+  for (let i = 0; i < numUtilizationChunks; i++) {
     // Check if we have this chunk in cache
     const cached = cachedChunks.find((c) => c.chunkIndex === i)
 
     if (cached) {
       // Use cached chunk
-      mergeChunk(dataCounters, i, cached.data)
+      mergeChunk(dataCounters, i, cached.data, batchDepth)
 
       chunks.push({
         index: i,
@@ -866,11 +1009,7 @@ export async function loadUtilizationState(
 
     // TODO: Download from Swarm using state feed (not yet implemented)
     // For now, initialize with defaults
-    const defaultCounters = new Uint32Array(BUCKETS_PER_CHUNK)
-    defaultCounters.fill(DATA_COUNTER_START)
-
-    const chunkData = serializeUint32Array(defaultCounters)
-    mergeChunk(dataCounters, i, chunkData)
+    mergeChunk(dataCounters, i, defaultChunkData, batchDepth)
 
     chunks.push({
       index: i,
@@ -884,6 +1023,7 @@ export async function loadUtilizationState(
 
   return {
     batchId,
+    batchDepth,
     dataCounters,
     chunks,
     topic,
@@ -923,7 +1063,11 @@ export async function saveUtilizationState(
     const chunkMetadata = state.chunks[chunkIndex]
 
     // Extract chunk data from dataCounters
-    const chunkData = extractChunk(state.dataCounters, chunkIndex)
+    const chunkData = extractChunk(
+      state.dataCounters,
+      chunkIndex,
+      state.batchDepth,
+    )
 
     try {
       // Upload to Swarm as encrypted CAC
@@ -1004,10 +1148,10 @@ export async function updateAfterWrite(
   tracker: DirtyChunkTracker
 }> {
   // Load current state
-  const state = await loadUtilizationState(batchId, options)
+  const state = await loadUtilizationState(batchId, batchDepth, options)
 
   // Create tracker for dirty chunks
-  const tracker = new DirtyChunkTracker()
+  const tracker = new DirtyChunkTracker(batchDepth)
 
   // Assign buckets and slots to data chunks
   for (const chunk of dataChunks) {
@@ -1128,22 +1272,23 @@ export class UtilizationAwareStamper implements Stamper {
     _encryptionKey: Uint8Array,
   ): Promise<UtilizationAwareStamper> {
     // Initialize utilization state (always, since owner is now required)
-    const utilizationState = initializeBatchUtilization(batchId)
+    const utilizationState = initializeBatchUtilization(batchId, depth)
     let bucketState: Uint32Array
 
     // Try to load utilization state from cache
     try {
       const cachedChunks = await cache.getAllChunks(batchId.toHex())
-      if (cachedChunks.length > 0) {
-        // Merge cached chunks into state
-        for (const cached of cachedChunks) {
-          mergeChunk(
-            utilizationState.dataCounters,
-            cached.chunkIndex,
-            cached.data,
-          )
-        }
-      } else {
+      const { numUtilizationChunks } = getChunkLayout(depth)
+      // Merge cached chunks into state; ignore any that fall outside the
+      // current depth's layout (e.g. stale entries from a different depth)
+      for (const cached of cachedChunks) {
+        if (cached.chunkIndex >= numUtilizationChunks) continue
+        mergeChunk(
+          utilizationState.dataCounters,
+          cached.chunkIndex,
+          cached.data,
+          depth,
+        )
       }
     } catch (error) {
       console.warn(
@@ -1218,17 +1363,9 @@ export class UtilizationAwareStamper implements Stamper {
     // Mark utilization chunks as dirty for the affected buckets
     const dirtyChunkIndexes = new Set<number>()
     for (const bucket of this.dirtyBuckets) {
-      const chunkIndex = getChunkIndexForBucket(bucket)
+      const chunkIndex = getChunkIndexForBucket(bucket, this.depth)
       dirtyChunkIndexes.add(chunkIndex)
       this.utilizationState.chunks[chunkIndex].dirty = true
-    }
-
-    // Create dirty chunk tracker
-    const tracker = new DirtyChunkTracker()
-    for (const chunkIndex of dirtyChunkIndexes) {
-      // Mark any bucket in this chunk as dirty (the tracker groups by chunk)
-      const firstBucket = chunkIndex * BUCKETS_PER_CHUNK
-      tracker.markDirty(firstBucket)
     }
 
     // Save dirty chunks to cache
@@ -1240,6 +1377,7 @@ export class UtilizationAwareStamper implements Stamper {
         const chunkData = extractChunk(
           this.utilizationState.dataCounters,
           chunkIndex,
+          this.depth,
         )
 
         await this.cache.putChunk({

--- a/swarm-ui/src/routes/(app)/dev/+page.svelte
+++ b/swarm-ui/src/routes/(app)/dev/+page.svelte
@@ -22,7 +22,7 @@
   import StatusDot from './status-dot.svelte'
   import Divider from '$lib/components/ui/divider.svelte'
   import routes from '$lib/routes'
-  import { BatchId, EthAddress, PrivateKey } from '@ethersphere/bee-js'
+  import { BatchId, EthAddress, PrivateKey, Utils } from '@ethersphere/bee-js'
   import { SvelteMap } from 'svelte/reactivity'
 
   // Tab state
@@ -353,7 +353,11 @@ Check console logs for details:
           {
             batchID: batchId,
             signerKey: signerKeyToUse,
-            utilization: beeStamp.utilization,
+            utilization: Utils.getStampUsage(
+              beeStamp.utilization,
+              beeStamp.depth,
+              beeStamp.bucketDepth,
+            ),
             usable: beeStamp.usable,
             depth: beeStamp.depth,
             amount: BigInt(beeStamp.amount),
@@ -426,7 +430,11 @@ Check console logs for details:
           {
             batchID: batchId,
             signerKey: signerKeyToUse,
-            utilization: beeStamp.utilization,
+            utilization: Utils.getStampUsage(
+              beeStamp.utilization,
+              beeStamp.depth,
+              beeStamp.bucketDepth,
+            ),
             usable: beeStamp.usable,
             depth: beeStamp.depth,
             amount: BigInt(beeStamp.amount),


### PR DESCRIPTION
Fixes #243.

`uint32` per-bucket utilization counters are wasteful — a regular-size batch never exceeds `2^(depth-16)` slots, which fits in `uint16`. Using `uint16` halves the utilization chunks written per state update for typical batches (depth-24: 32 chunks instead of 64).

## What changed

- New `getChunkLayout(batchDepth)` picks the counter codec:
  - **depth ≤ 31** → `uint16`, 32 chunks of 2048 buckets
  - **depth ≥ 32** → `uint32`, 64 chunks of 1024 buckets
- Counters stay `Uint32Array` in memory; narrowing happens only at the serialize boundary. `batchDepth` is threaded through all layout-dependent functions.
- `UtilizationStoreDB` releases its connection on `versionchange` and logs on `blocked`, so a second tab's upgrade can't hang.

## Breaking changes

- **IndexedDB cache (v1 → v2):** the upgrade drops all cached chunks — the layout changed, so old rows can't be reinterpreted. Cached utilization tracking is lost and re-initializes to defaults on next use.
- **Utilization chunk format:** chunks for depth ≤ 31 are now `uint16`-encoded; utilization data persisted by older code is incompatible.
