### PR TITLE
feat(stamps): compute dev-page stamp amount from chainstate

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -461,9 +461,13 @@ export {
   getBlockTimestamp,
   calculateExpiryTimestamp,
   fetchSwarmPrice,
+  fetchChainState,
+  calculateStampAmountForDays,
   SWARMSCAN_STATS_URL,
   GNOSIS_BLOCK_TIME,
+  BLOCKS_PER_DAY,
 } from "./utils/ttl"
+export type { ChainState } from "./utils/ttl"
 
 // Postage stamp <-> account/identity association
 export {

--- a/lib/src/utils/ttl.test.ts
+++ b/lib/src/utils/ttl.test.ts
@@ -1,0 +1,101 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { calculateStampAmountForDays, fetchChainState } from "./ttl"
+
+describe("calculateStampAmountForDays", () => {
+  // bee-compose default PriceOracle floor: 24_000 PLUR/chunk/block
+  //   24_000 * 17_280 blocks/day = 414_720_000 PLUR/chunk for 24h
+  // This is the exact "minimum amount" Bee reports in the
+  // "insufficient validity" error on POST /stamps.
+  const BEE_COMPOSE_PRICE = 24_000n
+  const BEE_COMPOSE_24H_MIN = 414_720_000n
+
+  it("matches Bee's reported 24h minimum at the bee-compose price", () => {
+    expect(calculateStampAmountForDays(BEE_COMPOSE_PRICE, 1)).toBe(
+      BEE_COMPOSE_24H_MIN,
+    )
+  })
+
+  it("scales linearly with days", () => {
+    expect(calculateStampAmountForDays(BEE_COMPOSE_PRICE, 7)).toBe(
+      7n * BEE_COMPOSE_24H_MIN,
+    )
+  })
+
+  it("returns 0n for non-integer, zero, or negative days", () => {
+    expect(calculateStampAmountForDays(BEE_COMPOSE_PRICE, 0)).toBe(0n)
+    expect(calculateStampAmountForDays(BEE_COMPOSE_PRICE, -1)).toBe(0n)
+    expect(calculateStampAmountForDays(BEE_COMPOSE_PRICE, 1.5)).toBe(0n)
+    expect(calculateStampAmountForDays(BEE_COMPOSE_PRICE, NaN)).toBe(0n)
+  })
+
+  it("returns 0n for non-positive price", () => {
+    expect(calculateStampAmountForDays(0n, 1)).toBe(0n)
+    expect(calculateStampAmountForDays(-1n, 1)).toBe(0n)
+  })
+})
+
+describe("fetchChainState", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch")
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  function mockResponse(body: unknown, ok = true, status = 200): Response {
+    return {
+      ok,
+      status,
+      json: () => Promise.resolve(body),
+    } as Response
+  }
+
+  it("parses block and currentPrice from /chainstate", async () => {
+    fetchSpy.mockResolvedValue(
+      mockResponse({ block: 12_345, currentPrice: "24000" }),
+    )
+
+    const state = await fetchChainState("http://localhost:1633")
+
+    expect(state).toEqual({ block: 12_345, currentPrice: 24_000n })
+    expect(fetchSpy).toHaveBeenCalledWith("http://localhost:1633/chainstate")
+  })
+
+  it("strips a trailing slash from the Bee URL", async () => {
+    fetchSpy.mockResolvedValue(mockResponse({ block: 1, currentPrice: "1" }))
+
+    await fetchChainState("http://localhost:1633/")
+
+    expect(fetchSpy).toHaveBeenCalledWith("http://localhost:1633/chainstate")
+  })
+
+  it("throws when the response is not ok", async () => {
+    fetchSpy.mockResolvedValue(mockResponse({}, false, 500))
+
+    await expect(fetchChainState("http://localhost:1633")).rejects.toThrow(
+      /500/,
+    )
+  })
+
+  it("throws when currentPrice is missing", async () => {
+    fetchSpy.mockResolvedValue(mockResponse({ block: 1 }))
+
+    await expect(fetchChainState("http://localhost:1633")).rejects.toThrow(
+      /currentPrice/,
+    )
+  })
+
+  it("throws when block is missing", async () => {
+    fetchSpy.mockResolvedValue(mockResponse({ currentPrice: "24000" }))
+
+    await expect(fetchChainState("http://localhost:1633")).rejects.toThrow(
+      /block/,
+    )
+  })
+})

--- a/lib/src/utils/ttl.test.ts
+++ b/lib/src/utils/ttl.test.ts
@@ -91,6 +91,18 @@ describe("fetchChainState", () => {
     )
   })
 
+  it("throws when currentPrice is a number, not a string", async () => {
+    // Bee always serialises currentPrice as a string. If a non-Bee server
+    // returns a JSON number, JSON.parse may have already rounded it past
+    // Number.MAX_SAFE_INTEGER, so we refuse it rather than silently widening
+    // a corrupted value to BigInt.
+    fetchSpy.mockResolvedValue(mockResponse({ block: 1, currentPrice: 24_000 }))
+
+    await expect(fetchChainState("http://localhost:1633")).rejects.toThrow(
+      /currentPrice/,
+    )
+  })
+
   it("throws when block is missing", async () => {
     fetchSpy.mockResolvedValue(mockResponse({ currentPrice: "24000" }))
 

--- a/lib/src/utils/ttl.ts
+++ b/lib/src/utils/ttl.ts
@@ -11,6 +11,13 @@
 export const GNOSIS_BLOCK_TIME = 5
 
 /**
+ * Blocks per day on Gnosis Chain (24h / 5s block time = 17280). BigInt so it
+ * composes with the PLUR-denominated price math in
+ * {@link calculateStampAmountForDays} without precision loss.
+ */
+export const BLOCKS_PER_DAY = (24n * 60n * 60n) / BigInt(GNOSIS_BLOCK_TIME)
+
+/**
  * Time constants
  */
 const SECONDS_PER_MINUTE = 60
@@ -129,4 +136,72 @@ export function calculateExpiryTimestamp(
   ttlSeconds: number,
 ): number {
   return blockTimestamp + ttlSeconds
+}
+
+/**
+ * Snapshot of Bee's view of the chain, from `GET /chainstate`.
+ *
+ * `currentPrice` is PLUR per chunk per block — the per-block storage rent rate
+ * Bee charges against a stamp's deposit. Bee returns it as a decimal string
+ * because Gnosis prices can exceed `Number.MAX_SAFE_INTEGER` on high-traffic
+ * chains, so we keep it BigInt all the way through to the stamp-amount math.
+ */
+export interface ChainState {
+  block: number
+  currentPrice: bigint
+}
+
+/**
+ * Fetches the current chain state (block + per-chunk-per-block price) from a
+ * Bee node. Used to size new stamp amounts: Bee rejects `POST /stamps` calls
+ * whose amount does not cover at least 24h of storage at `currentPrice`.
+ *
+ * @param beeUrl - Bee node URL
+ * @returns Parsed chain state with `currentPrice` as BigInt
+ * @throws if the request fails, returns non-OK, or omits required fields.
+ *         Callers (e.g. the dev page) surface this directly to the user.
+ */
+export async function fetchChainState(beeUrl: string): Promise<ChainState> {
+  const base = beeUrl.replace(/\/$/, "")
+  const response = await fetch(`${base}/chainstate`)
+  if (!response.ok) {
+    throw new Error(`Failed to fetch chainstate: HTTP ${response.status}`)
+  }
+  const data: unknown = await response.json()
+  if (typeof data !== "object" || data === null) {
+    throw new Error("Invalid chainstate response")
+  }
+  const obj = data as { block?: unknown; currentPrice?: unknown }
+  if (typeof obj.block !== "number") {
+    throw new Error("chainstate response missing block")
+  }
+  if (
+    typeof obj.currentPrice !== "string" &&
+    typeof obj.currentPrice !== "number"
+  ) {
+    throw new Error("chainstate response missing currentPrice")
+  }
+  return {
+    block: obj.block,
+    currentPrice: BigInt(obj.currentPrice),
+  }
+}
+
+/**
+ * Minimum stamp amount (PLUR per chunk) that covers `days` days of validity
+ * at the given per-block price. Bee enforces a 24h floor on `POST /stamps`, so
+ * passing `days = 1` returns the exact minimum that will be accepted.
+ *
+ * @param currentPrice - Per-chunk-per-block price in PLUR (from {@link fetchChainState})
+ * @param days - Positive integer number of days of validity to fund
+ * @returns Amount in PLUR per chunk, or `0n` for non-positive / non-integer inputs
+ */
+export function calculateStampAmountForDays(
+  currentPrice: bigint,
+  days: number,
+): bigint {
+  if (currentPrice <= 0n || !Number.isInteger(days) || days <= 0) {
+    return 0n
+  }
+  return currentPrice * BLOCKS_PER_DAY * BigInt(days)
 }

--- a/lib/src/utils/ttl.ts
+++ b/lib/src/utils/ttl.ts
@@ -175,11 +175,17 @@ export async function fetchChainState(beeUrl: string): Promise<ChainState> {
   if (typeof obj.block !== "number") {
     throw new Error("chainstate response missing block")
   }
-  if (
-    typeof obj.currentPrice !== "string" &&
-    typeof obj.currentPrice !== "number"
-  ) {
-    throw new Error("chainstate response missing currentPrice")
+  // Require a string. Bee always serialises currentPrice as a decimal string
+  // because high-traffic chains can exceed Number.MAX_SAFE_INTEGER (2^53), and
+  // JSON.parse rounds anything above that *before* we get a chance to widen it
+  // to BigInt — so accepting a `number` here would silently corrupt the price
+  // and defeat the precision the rest of this module guarantees.
+  if (typeof obj.currentPrice !== "string") {
+    throw new Error(
+      "chainstate response missing or non-string currentPrice (got " +
+        typeof obj.currentPrice +
+        ")",
+    )
   }
   return {
     block: obj.block,

--- a/swarm-ui/src/routes/(app)/dev/+page.svelte
+++ b/swarm-ui/src/routes/(app)/dev/+page.svelte
@@ -23,7 +23,14 @@
   import Divider from '$lib/components/ui/divider.svelte'
   import routes from '$lib/routes'
   import { BatchId, EthAddress, PrivateKey, Utils } from '@ethersphere/bee-js'
+  import { calculateStampAmountForDays, fetchChainState } from '@snaha/swarm-id'
   import { SvelteMap } from 'svelte/reactivity'
+
+  // How many days of validity to fund by default when auto-filling the
+  // stamp amount from current chain price. Bee enforces a 24h minimum on
+  // POST /stamps; 7 days gives comfortable headroom for dev testing without
+  // re-buying constantly.
+  const DEFAULT_STAMP_DAYS = 7
 
   // Tab state
   type Tab = 'overview' | 'stamps' | 'sync'
@@ -43,11 +50,17 @@
 
   // Stamp buying state
   let beeUrl = $state('http://localhost:1633')
-  let stampAmount = $state('500000000')
+  // Amount starts empty — autofilled from chain price on first chainstate
+  // load (see loadChainState). Hardcoding a default is fragile across chain
+  // configs: bee-compose's PriceOracle floor (24_000 PLUR/chunk/block) needs
+  // ≥ 414_720_000 PLUR/chunk for 24h, and other chains have different floors.
+  let stampAmount = $state('')
   let stampDepth = $state('20')
   let buying = $state(false)
   let stampResult = $state<{ batchID: string; txHash: string } | undefined>(undefined)
   let stampError = $state('')
+  let currentPrice = $state<bigint | undefined>(undefined)
+  let chainStateError = $state('')
   let assignMessage = $state('')
   let assignError = $state('')
   let selectedStampId = $state<string | undefined>(undefined)
@@ -313,9 +326,27 @@ Check console logs for details:
     }
   }
 
+  async function loadChainState() {
+    chainStateError = ''
+    try {
+      const state = await fetchChainState(beeUrl)
+      currentPrice = state.currentPrice
+      // Only autofill if the user hasn't typed (or pre-typed) a value yet.
+      // After the first fill, the user owns this field — switching bee URLs
+      // updates the displayed price but does not clobber their input.
+      if (stampAmount === '') {
+        stampAmount = calculateStampAmountForDays(state.currentPrice, DEFAULT_STAMP_DAYS).toString()
+      }
+    } catch (error) {
+      chainStateError = error instanceof Error ? error.message : String(error)
+      currentPrice = undefined
+    }
+  }
+
   $effect(() => {
     if (activeTab === 'stamps' && beeUrl && beeUrl !== lastBeeUrl && !beeStampsLoading) {
       loadBeeStamps()
+      loadChainState()
     }
   })
 
@@ -602,10 +633,21 @@ Check console logs for details:
           <Input label="Amount" bind:value={stampAmount} style="flex: 1;" />
           <Input label="Depth (17-40)" bind:value={stampDepth} style="width: 120px;" />
         </Horizontal>
+        {#if currentPrice !== undefined}
+          {@const minAmount = calculateStampAmountForDays(currentPrice, 1)}
+          <Typography variant="small" style="color: var(--colors-medium);">
+            Chain price: {currentPrice.toLocaleString()} PLUR/chunk/block · 24h min: {minAmount.toLocaleString()}
+            PLUR · default fills {DEFAULT_STAMP_DAYS}d validity
+          </Typography>
+        {:else if chainStateError}
+          <Typography variant="small" style="color: var(--colors-error);">
+            Could not fetch chainstate from Bee: {chainStateError}
+          </Typography>
+        {/if}
         <Select label="Signer Key" items={KNOWN_SIGNERS} bind:value={selectedSigner} />
       </Vertical>
 
-      <Button onclick={buyStamp} busy={buying} disabled={buying}>
+      <Button onclick={buyStamp} busy={buying} disabled={buying || !stampAmount}>
         {buying ? 'Buying...' : 'Buy Stamp'}
       </Button>
 


### PR DESCRIPTION
## Summary

- Replace the hardcoded \`500_000_000\` default amount on the dev page with one derived live from Bee's \`GET /chainstate\`. The old default silently failed against bee-compose (PriceOracle floor of \`24_000\` PLUR/chunk/block requires \`≥ 414_720_000\` PLUR/chunk for 24h) and would break again on any chain with a different price config.
- Add \`fetchChainState\` and \`calculateStampAmountForDays\` to \`@snaha/swarm-id\` so callers compute the right amount from the chain instead of hand-bumping a magic number.
- Surface the current chain price and Bee's 24h minimum in the dev UI so the constraint is visible, not a cryptic 400.

## Why

User hit \`insufficient initial balance for 24h minimum validity. balance 100000000, minimum amount: 414720000\` on bee-compose after switching from fdp-play. Root cause is that the dev page never asks Bee what the chain price actually is — it sends a baked-in number. The fix is to read \`currentPrice\` from \`/chainstate\` and size the deposit so it clears Bee's enforced 24h floor.

## What's in the lib

- \`fetchChainState(beeUrl)\` — parses \`block\` + \`currentPrice\` (BigInt, since Gnosis values can exceed \`Number.MAX_SAFE_INTEGER\`). Throws on missing fields so callers can surface the error.
- \`calculateStampAmountForDays(currentPrice, days)\` — \`currentPrice * BLOCKS_PER_DAY * days\`. \`days = 1\` returns exactly Bee's reported minimum.
- \`BLOCKS_PER_DAY\` constant (\`17280n\`) and \`ChainState\` type exported.
- 10 new unit tests, including one pinning the bee-compose minimum (\`24_000n × 17_280n = 414_720_000n\`) against Bee's actual error message.

## What's in the dev page

- Amount input starts empty; on first chainstate load, autofills with 7 days' worth at the current price. Subsequent Bee URL changes refresh the displayed price but don't clobber user edits.
- Helper line under Amount: \`Chain price: X PLUR/chunk/block · 24h min: Y PLUR · default fills 7d validity\`, or a red error if \`/chainstate\` fails (e.g. Bee unreachable).
- Buy button is disabled when the amount field is empty.

## Test plan

- [x] \`pnpm check:all\` clean (485 lib tests pass; svelte-check, eslint, prettier, knip all green)
- [ ] Reviewer: with bee-compose running, open \`/dev\` → Stamps tab → confirm Amount autofills to \`2,903,040,000\` and the buy succeeds
- [ ] Reviewer: kill bee node, switch Bee URL → confirm helper text flips to red error message
- [ ] Reviewer: edit Amount manually, then change Bee URL → confirm the manual value is preserved (chain price line updates, input does not)

🤖 Generated with [Claude Code](https://claude.com/claude-code)