### PR TITLE
ci: deploy latest main commit to DigitalOcean

### DIFF
--- a/.github/workflows/deploy-do.yml
+++ b/.github/workflows/deploy-do.yml
@@ -33,12 +33,14 @@ jobs:
             echo "✓ Demo app created and deployed successfully"
           else
             echo "Updating demo app (ID: $APP_ID)..."
-            doctl apps update $APP_ID --spec .do/swarm-demo-app.yaml --wait
-            echo "✓ Demo app spec updated successfully"
+            doctl apps update $APP_ID --spec .do/swarm-demo-app.yaml
+            echo "✓ Demo app spec updated"
 
-            echo "Triggering rebuild and deployment for demo app..."
-            doctl apps create-deployment $APP_ID --force-rebuild --wait
-            echo "✓ Demo app rebuild completed"
+            # Pulls and deploys the latest commit on main. Avoid --force-rebuild
+            # here: it redeploys the last built commit instead of the latest.
+            echo "Deploying latest commit for demo app..."
+            doctl apps create-deployment $APP_ID --wait
+            echo "✓ Demo app deployed"
           fi
 
       - name: Deploy Identity App
@@ -54,10 +56,12 @@ jobs:
             echo "✓ Identity app created and deployed successfully"
           else
             echo "Updating identity app (ID: $APP_ID)..."
-            doctl apps update $APP_ID --spec .do/swarm-id-app.yaml --wait
-            echo "✓ Identity app spec updated successfully"
+            doctl apps update $APP_ID --spec .do/swarm-id-app.yaml
+            echo "✓ Identity app spec updated"
 
-            echo "Triggering rebuild and deployment for identity app..."
-            doctl apps create-deployment $APP_ID --force-rebuild --wait
-            echo "✓ Identity app rebuild completed"
+            # Pulls and deploys the latest commit on main. Avoid --force-rebuild
+            # here: it redeploys the last built commit instead of the latest.
+            echo "Deploying latest commit for identity app..."
+            doctl apps create-deployment $APP_ID --wait
+            echo "✓ Identity app deployed"
           fi


### PR DESCRIPTION
## Problem

The DO deploy after #328 failed with `ERR_PNPM_UNSUPPORTED_ENGINE — Expected 10.x, Got 11.5.0`. The #328 code is fine (builds with pnpm 11.5.0 on Node 22 and 24); DO was building a **stale commit** (`8a538aca`, before the #328 merge) whose `package.json` still declares `engines.pnpm: 10.x`, against the new corepack/pnpm-11 spec.

Root cause: the workflow deployed with `doctl apps create-deployment --force-rebuild`, which **redeploys the last deployed commit** instead of pulling the latest. (A manual deployment from the DO console, which pulls the latest commit, builds green.)

## Fix

One file, `deploy-do.yml`, deployments stay GitHub-Actions-driven:

- **Drop `--force-rebuild`** → `create-deployment` pulls and deploys main's latest commit.
- **Drop `--wait` on `apps update --spec`** → the run gates on `create-deployment`, not on a spec-update deploy that can lag HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)