### PR TITLE
fix(test): raise integration stamp-usable timeout to 240s

### DIFF
--- a/lib/test/integration/cluster.ts
+++ b/lib/test/integration/cluster.ts
@@ -36,7 +36,13 @@ export const TEST_STAMP_AMOUNT = "500000000"
 const HTTP_OK = 200
 const HTTP_TOO_MANY_REQUESTS = 429
 const STAMP_USABLE_POLL_INTERVAL_MS = 1500
-const STAMP_USABLE_TIMEOUT_MS = 90_000
+// A batch only reports `usable: true` once its creation tx is mined and Bee has
+// seen enough block confirmations. On a freshly started bee-compose chain that
+// settling can occasionally take well over a minute, so 90s was flaky in CI
+// (the stamp buy itself can also eat ~10s). This runs in globalSetup, which is
+// not bound by vitest's test/hook timeouts, and the CI job has a 20-min budget,
+// so a generous ceiling here just buys robustness without slowing the happy path.
+const STAMP_USABLE_TIMEOUT_MS = 240_000
 const STAMP_BUY_RETRIES = 15
 const STAMP_BUY_RETRY_DELAY_MS = 2000
 


### PR DESCRIPTION
## Problem

The cluster integration suite intermittently fails in CI with:

```
Error: Stamp <id> did not become usable within 90000ms
  ❯ waitForUsableStamp test/integration/cluster.ts:116:9
  ❯ buyUsableStamp test/integration/cluster.ts:155:3
```

(e.g. [this run](https://github.com/snaha/swarm-id/actions/runs/26820988438/job/79075224880))

## Cause

A postage batch only reports `usable: true` once its creation tx is mined **and** Bee has seen enough block confirmations. On a freshly started `bee-compose` chain that settling can occasionally take well over a minute, and the stamp buy itself can eat ~10s — so the previous 90s ceiling was too tight.

## Fix

Raise `STAMP_USABLE_TIMEOUT_MS` from 90s → 240s.

This wait runs in `globalSetup`, which is **not** bound by vitest's `testTimeout`/`hookTimeout`, and the integration-tests job has a 20-minute budget — so the larger ceiling only adds robustness against slow confirmations without slowing down the happy path (polling stops as soon as the stamp is usable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)