### PR TITLE
Explore: account-as-aggregate (SyncedAccount) for sync triggering

### DIFF
--- a/swarm-ui/src/lib/components/add-postage-stamp.svelte
+++ b/swarm-ui/src/lib/components/add-postage-stamp.svelte
@@ -13,7 +13,7 @@
   import Polycon from '$lib/components/polycon.svelte'
   import Launch from 'carbon-icons-svelte/lib/Launch.svelte'
   import ArrowRight from 'carbon-icons-svelte/lib/ArrowRight.svelte'
-  import { postageStampsStore } from '$lib/stores/postage-stamps.svelte'
+  import { getSyncedAccount } from '$lib/domain/synced-account'
   import { BatchId, PrivateKey } from '@ethersphere/bee-js'
   import { openStampPurchaseWidget, type BatchEvent } from '$lib/services/multichain-widget'
   import { derivePostageSignerKey, hexToUint8Array } from '@snaha/swarm-id'
@@ -87,21 +87,18 @@
     submitError = undefined
 
     try {
-      const stamp = postageStampsStore.addStamp(
-        {
-          batchID: new BatchId(batchID),
-          signerKey: new PrivateKey(signerKey),
-          utilization: 0,
-          usable: true,
-          depth,
-          amount,
-          bucketDepth: 16,
-          blockNumber,
-          immutableFlag: false,
-          exists: true,
-        },
-        accountId,
-      )
+      const stamp = getSyncedAccount(new EthAddress(accountId)).addStamp({
+        batchID: new BatchId(batchID),
+        signerKey: new PrivateKey(signerKey),
+        utilization: 0,
+        usable: true,
+        depth,
+        amount,
+        bucketDepth: 16,
+        blockNumber,
+        immutableFlag: false,
+        exists: true,
+      })
 
       onSuccess(stamp)
     } catch (error) {
@@ -147,21 +144,18 @@
 
     try {
       // Create postage stamp from widget response
-      const stamp = postageStampsStore.addStamp(
-        {
-          batchID: new BatchId(batch.batchId),
-          signerKey: new PrivateKey(signerKeyBytes),
-          depth: batch.depth,
-          amount: BigInt(batch.amount),
-          blockNumber: parseInt(batch.blockNumber, HEX_BASE),
-          utilization: 0,
-          usable: true,
-          bucketDepth: 16,
-          immutableFlag: false,
-          exists: true,
-        },
-        accountId,
-      )
+      const stamp = getSyncedAccount(new EthAddress(accountId)).addStamp({
+        batchID: new BatchId(batch.batchId),
+        signerKey: new PrivateKey(signerKeyBytes),
+        depth: batch.depth,
+        amount: BigInt(batch.amount),
+        blockNumber: parseInt(batch.blockNumber, HEX_BASE),
+        utilization: 0,
+        usable: true,
+        bucketDepth: 16,
+        immutableFlag: false,
+        exists: true,
+      })
 
       // In auto-navigate mode, call onSuccess immediately (skip success screen)
       if (autoNavigateOnSuccess) {

--- a/swarm-ui/src/lib/components/app-list.svelte
+++ b/swarm-ui/src/lib/components/app-list.svelte
@@ -9,7 +9,7 @@
   import Typography from '$lib/components/ui/typography.svelte'
   import type { ConnectedApp, Identity } from '$lib/types'
   import { DEFAULT_SESSION_DURATION } from '@snaha/swarm-id'
-  import { connectedAppsStore } from '$lib/stores/connected-apps.svelte'
+  import { getSyncedAccount } from '$lib/domain/synced-account'
   import Badge from './ui/badge.svelte'
   import Dropdown from './ui/dropdown.svelte'
   import { OverflowMenuVertical, TrashCan, Unlink } from 'carbon-icons-svelte'
@@ -36,7 +36,7 @@
   }
 
   function disconnectApp(app: ConnectedApp) {
-    connectedAppsStore.disconnectApp(app.appUrl, app.identityId)
+    getSyncedAccount(identity.accountId).disconnectApp(app.appUrl, app.identityId)
     localStorage.removeItem(`${SWARM_SECRET_PREFIX}${app.appUrl}`)
   }
 
@@ -47,7 +47,7 @@
 
   function revokeApp(app: ConnectedApp) {
     disconnectApp(app)
-    connectedAppsStore.removeApp(app.appUrl, app.identityId)
+    getSyncedAccount(identity.accountId).removeApp(app.appUrl, app.identityId)
   }
 </script>
 

--- a/swarm-ui/src/lib/components/drawer.svelte
+++ b/swarm-ui/src/lib/components/drawer.svelte
@@ -44,6 +44,7 @@
   } from '@snaha/swarm-id'
   import { connectedAppsStore } from '$lib/stores/connected-apps.svelte'
   import { postageStampsStore } from '$lib/stores/postage-stamps.svelte'
+  import { getSyncedAccount } from '$lib/domain/synced-account'
   import type { Account, Identity, PostageStamp } from '$lib/types'
   import type { Bytes } from '@ethersphere/bee-js'
   import { deriveSecretSeedEncryptionKey, decryptSecretSeed } from '$lib/utils/encryption'
@@ -120,23 +121,11 @@
   }
 
   function onAccountNameChange() {
-    accountsStore.setAccountName(account.id, accountName)
+    getSyncedAccount(account.id).rename(accountName)
   }
 
   async function performAccountDeletion() {
-    const accountId = account.id
-    const accountIdentities = identitiesStore.getIdentitiesByAccount(accountId)
-    // Collect stamp batch ids before removing identities, since the
-    // association is derived from the account/identity pointers.
-    const stampBatchIds = collectAccountStampBatchIds(account, accountIdentities)
-    for (const identity of accountIdentities) {
-      connectedAppsStore.removeAppsByIdentityId(identity.id)
-      identitiesStore.removeIdentity(identity.id)
-    }
-    for (const batchId of stampBatchIds) {
-      postageStampsStore.removeStamp(batchId, accountId.toHex())
-    }
-    accountsStore.removeAccount(accountId)
+    getSyncedAccount(account.id).delete()
     sessionStore.clearAccount()
     showDeleteModal = false
     drawerOpen = false
@@ -239,24 +228,12 @@
   }
 
   async function handleSignOut() {
-    const accountId = account.id
-    const accountIdentities = identitiesStore.getIdentitiesByAccount(accountId)
-    // Collect stamp batch ids before removing identities, since the
-    // association is derived from the account/identity pointers.
-    const stampBatchIds = collectAccountStampBatchIds(account, accountIdentities)
-
-    for (const identity of accountIdentities) {
-      const apps = connectedAppsStore.getAppsByIdentityId(identity.id)
-      for (const app of apps) {
-        localStorage.removeItem(`${SWARM_SECRET_PREFIX}${app.appUrl}`)
-      }
-      connectedAppsStore.removeAppsByIdentityId(identity.id)
-      identitiesStore.removeIdentity(identity.id)
+    const aggregate = getSyncedAccount(account.id)
+    // Drop cached app secrets for this account's apps before deleting it.
+    for (const app of aggregate.apps) {
+      localStorage.removeItem(`${SWARM_SECRET_PREFIX}${app.appUrl}`)
     }
-    for (const batchId of stampBatchIds) {
-      postageStampsStore.removeStamp(batchId, accountId.toHex())
-    }
-    accountsStore.removeAccount(accountId)
+    aggregate.delete()
 
     sessionStore.clearAccount()
     drawerOpen = false

--- a/swarm-ui/src/lib/domain/synced-account.ts
+++ b/swarm-ui/src/lib/domain/synced-account.ts
@@ -4,18 +4,17 @@
 /**
  * SyncedAccount — aggregate root for one account.
  *
- * PROTOTYPE: demonstrates the "accounts handle their own change" model as an
- * alternative to the sync coordinator. The account is the single entry point
- * for mutating its identities / apps / stamps, so each method *declares its own
- * sync intent*: meaningful changes call #sync(); volatile ones (utilization)
- * and deletion do not. No fingerprinting, no central diff — the method knows
- * what it changed.
+ * The account is the single entry point for mutating its identities / apps /
+ * stamps, so each method *declares its own sync intent*: meaningful changes
+ * call #sync(); volatile ones (utilization) and deletion do not. No
+ * fingerprinting, no central diff — the method knows what it changed. All
+ * swarm-ui mutation call sites route through this aggregate; the stores
+ * underneath are pure persistence.
  *
- * This is a thin reactive facade over the existing flat stores: it owns the
- * behavior and persists *through* the stores, so the localStorage shape (and
- * the iframe proxy that reads it) is unchanged. A full aggregate would also own
- * persistence; that's a larger migration into the shared lib and is out of
- * scope for this prototype.
+ * This is a reactive facade over the flat stores: it owns the behavior and
+ * persists *through* the stores, so the localStorage shape (and the iframe
+ * proxy that reads it) is unchanged. Promoting it to a true aggregate that also
+ * owns persistence is a follow-up that reaches into the shared lib.
  */
 
 import { EthAddress, BatchId } from '@ethersphere/bee-js'

--- a/swarm-ui/src/lib/domain/synced-account.ts
+++ b/swarm-ui/src/lib/domain/synced-account.ts
@@ -1,0 +1,227 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * SyncedAccount — aggregate root for one account.
+ *
+ * PROTOTYPE: demonstrates the "accounts handle their own change" model as an
+ * alternative to the sync coordinator. The account is the single entry point
+ * for mutating its identities / apps / stamps, so each method *declares its own
+ * sync intent*: meaningful changes call #sync(); volatile ones (utilization)
+ * and deletion do not. No fingerprinting, no central diff — the method knows
+ * what it changed.
+ *
+ * This is a thin reactive facade over the existing flat stores: it owns the
+ * behavior and persists *through* the stores, so the localStorage shape (and
+ * the iframe proxy that reads it) is unchanged. A full aggregate would also own
+ * persistence; that's a larger migration into the shared lib and is out of
+ * scope for this prototype.
+ */
+
+import { EthAddress, BatchId } from '@ethersphere/bee-js'
+import {
+  collectAccountStampBatchIds,
+  type Account,
+  type Identity,
+  type ConnectedApp,
+  type PostageStamp,
+  type Device,
+} from '@snaha/swarm-id'
+import { accountsStore } from '$lib/stores/accounts.svelte'
+import { identitiesStore } from '$lib/stores/identities.svelte'
+import { connectedAppsStore } from '$lib/stores/connected-apps.svelte'
+import { postageStampsStore } from '$lib/stores/postage-stamps.svelte'
+import { triggerSync } from '$lib/utils/sync-hooks'
+
+type ConnectAppInput = Omit<ConnectedApp, 'lastConnectedAt'> & {
+  appIcon?: string
+  appDescription?: string
+  appSecret?: string
+}
+
+export class SyncedAccount {
+  readonly id: EthAddress
+
+  constructor(id: EthAddress) {
+    this.id = id
+  }
+
+  // --------------------------------------------------------------------------
+  // Reactive reads (delegate to the stores — reactivity flows through)
+  // --------------------------------------------------------------------------
+
+  get raw(): Account | undefined {
+    return accountsStore.getAccount(this.id)
+  }
+
+  get exists(): boolean {
+    return this.raw !== undefined
+  }
+
+  get name(): string {
+    return this.raw?.name ?? ''
+  }
+
+  get defaultStamp(): BatchId | undefined {
+    return this.raw?.defaultPostageStampBatchID
+  }
+
+  get identities(): Identity[] {
+    return identitiesStore.getIdentitiesByAccount(this.id)
+  }
+
+  get apps(): ConnectedApp[] {
+    return this.identities.flatMap((identity) =>
+      connectedAppsStore.getAppsByIdentityId(identity.id),
+    )
+  }
+
+  get stamps(): PostageStamp[] {
+    const account = this.raw
+    if (!account) return []
+    return collectAccountStampBatchIds(account, this.identities)
+      .map((batchId) => postageStampsStore.getStamp(batchId))
+      .filter((stamp): stamp is PostageStamp => stamp !== undefined)
+  }
+
+  // --------------------------------------------------------------------------
+  // Account-level mutations
+  // --------------------------------------------------------------------------
+
+  rename(name: string): void {
+    accountsStore.setAccountName(this.id, name)
+    this.#sync()
+  }
+
+  setDefaultStamp(batchID: BatchId | undefined): void {
+    accountsStore.setDefaultStamp(this.id, batchID)
+    this.#sync()
+  }
+
+  updateDevices(devices: Device[]): void {
+    accountsStore.updateDevices(this.id, devices)
+    this.#sync()
+  }
+
+  // --------------------------------------------------------------------------
+  // Identity mutations
+  // --------------------------------------------------------------------------
+
+  addIdentity(identity: Omit<Identity, 'createdAt'>): Identity {
+    const created = identitiesStore.addIdentity(identity)
+    this.#sync()
+    return created
+  }
+
+  removeIdentity(identityId: string): void {
+    identitiesStore.removeIdentity(identityId)
+    this.#sync()
+  }
+
+  updateIdentity(identityId: string, update: Partial<Identity>): void {
+    identitiesStore.updateIdentity(identityId, update)
+    this.#sync()
+  }
+
+  setIdentityDefaultStamp(identityId: string, batchID: BatchId | undefined): void {
+    identitiesStore.setDefaultStamp(identityId, batchID)
+    this.#sync()
+  }
+
+  // --------------------------------------------------------------------------
+  // Connected app mutations
+  // --------------------------------------------------------------------------
+
+  connectApp(appData: ConnectAppInput, defaultConnectionTime: number | undefined): ConnectedApp {
+    const app = connectedAppsStore.addOrUpdateApp(appData, defaultConnectionTime)
+    this.#sync()
+    return app
+  }
+
+  removeApp(appUrl: string, identityId: string): void {
+    connectedAppsStore.removeApp(appUrl, identityId)
+    this.#sync()
+  }
+
+  disconnectApp(appUrl: string, identityId: string): void {
+    connectedAppsStore.disconnectApp(appUrl, identityId)
+    this.#sync()
+  }
+
+  // --------------------------------------------------------------------------
+  // Stamp mutations
+  // --------------------------------------------------------------------------
+
+  addStamp(stamp: Omit<PostageStamp, 'createdAt'>): PostageStamp {
+    const added = postageStampsStore.addStamp(stamp)
+    this.#sync()
+    return added
+  }
+
+  removeStamp(batchID: BatchId): void {
+    postageStampsStore.removeStamp(batchID)
+    this.#sync()
+  }
+
+  /**
+   * Volatile: sync writes utilization back, so this must NOT trigger a sync —
+   * otherwise sync → utilization write → sync would loop. Expressing that here
+   * is simply "this method doesn't call #sync()", with no fingerprint exclusion.
+   */
+  updateStampUtilization(batchID: BatchId, utilization: number): void {
+    postageStampsStore.updateStampUtilization(batchID, utilization)
+  }
+
+  // --------------------------------------------------------------------------
+  // Deletion — local-only, never syncs (leaves the Swarm backup intact)
+  // --------------------------------------------------------------------------
+
+  delete(): void {
+    const account = this.raw
+    const identities = this.identities
+    // Collect stamp batch ids before removing identities, since the
+    // association is derived from the account/identity pointers.
+    const stampBatchIds = account ? collectAccountStampBatchIds(account, identities) : []
+
+    for (const identity of identities) {
+      connectedAppsStore.removeAppsByIdentityId(identity.id)
+      identitiesStore.removeIdentity(identity.id)
+    }
+    for (const batchId of stampBatchIds) {
+      postageStampsStore.removeStamp(batchId)
+    }
+    accountsStore.removeAccount(this.id)
+    // Intentionally no #sync(): deletion is local-only.
+  }
+
+  #sync(): void {
+    triggerSync(this.id.toHex())
+  }
+}
+
+// Stable instance per account id, so callers and Svelte get referential identity.
+const cache = new Map<string, SyncedAccount>()
+
+/**
+ * Get the aggregate for an account id (creating a stable instance on first use).
+ */
+export function getSyncedAccount(id: EthAddress): SyncedAccount {
+  const key = id.toHex()
+  let account = cache.get(key)
+  if (!account) {
+    account = new SyncedAccount(id)
+    cache.set(key, account)
+  }
+  return account
+}
+
+/**
+ * Create a brand-new account and return its aggregate. Mirrors the data path of
+ * accountsStore.addAccount, then syncs (a no-op until the account has a stamp).
+ */
+export function createSyncedAccount(account: Account): SyncedAccount {
+  accountsStore.addAccount(account)
+  const aggregate = getSyncedAccount(account.id)
+  triggerSync(account.id.toHex())
+  return aggregate
+}

--- a/swarm-ui/src/lib/stores/accounts.svelte.ts
+++ b/swarm-ui/src/lib/stores/accounts.svelte.ts
@@ -4,7 +4,6 @@
 import { browser } from '$app/environment'
 import { EthAddress, BatchId } from '@ethersphere/bee-js'
 import { createAccountsStorageManager, type Account, type Device } from '@snaha/swarm-id'
-import { triggerSync } from '$lib/utils/sync-hooks'
 
 // ============================================================================
 // Storage Manager
@@ -50,7 +49,6 @@ export const accountsStore = {
   setAccountName(id: EthAddress, name: string) {
     accounts = accounts.map((account) => (account.id.equals(id) ? { ...account, name } : account))
     saveAccounts(accounts)
-    triggerSync(id.toHex())
   },
 
   updateDevices(id: EthAddress, devices: Device[]) {
@@ -70,7 +68,6 @@ export const accountsStore = {
         : account,
     )
     saveAccounts(accounts)
-    triggerSync(id.toHex())
   },
 
   clear() {

--- a/swarm-ui/src/lib/stores/connected-apps.svelte.ts
+++ b/swarm-ui/src/lib/stores/connected-apps.svelte.ts
@@ -3,9 +3,6 @@
 
 import { browser } from '$app/environment'
 import { createConnectedAppsStorageManager, type ConnectedApp } from '@snaha/swarm-id'
-import { triggerSync } from '$lib/utils/sync-hooks'
-import { sessionStore } from './session.svelte'
-import { identitiesStore } from './identities.svelte'
 
 // ============================================================================
 // Storage Manager
@@ -20,15 +17,6 @@ function loadConnectedApps(): ConnectedApp[] {
 
 function saveConnectedApps(data: ConnectedApp[]): void {
   storageManager.save(data)
-
-  // Trigger Swarm sync for current identity's account
-  const currentIdentityId = sessionStore.data.currentIdentityId
-  if (currentIdentityId) {
-    const identity = identitiesStore.getIdentity(currentIdentityId)
-    if (identity) {
-      triggerSync(identity.accountId.toHex())
-    }
-  }
 }
 
 // ============================================================================

--- a/swarm-ui/src/lib/stores/identities.svelte.ts
+++ b/swarm-ui/src/lib/stores/identities.svelte.ts
@@ -4,8 +4,6 @@
 import { browser } from '$app/environment'
 import { EthAddress, BatchId } from '@ethersphere/bee-js'
 import { createIdentitiesStorageManager, type Identity } from '@snaha/swarm-id'
-import { triggerSync } from '$lib/utils/sync-hooks'
-import { sessionStore } from './session.svelte'
 
 // ============================================================================
 // Storage Manager
@@ -20,15 +18,6 @@ function loadIdentities(): Identity[] {
 
 function saveIdentities(data: Identity[]): void {
   storageManager.save(data)
-
-  // Trigger Swarm sync for current identity's account
-  const currentIdentityId = sessionStore.data.currentIdentityId
-  if (currentIdentityId) {
-    const identity = data.find((i) => i.id === currentIdentityId)
-    if (identity) {
-      triggerSync(identity.accountId.toHex())
-    }
-  }
 }
 
 // ============================================================================

--- a/swarm-ui/src/lib/stores/postage-stamps.svelte.ts
+++ b/swarm-ui/src/lib/stores/postage-stamps.svelte.ts
@@ -9,7 +9,6 @@ import {
   UtilizationAwareStamper,
   UtilizationStoreDB,
 } from '@snaha/swarm-id'
-import { triggerSync } from '$lib/utils/sync-hooks'
 
 // ============================================================================
 // Storage Manager
@@ -37,13 +36,8 @@ function loadPostageStamps(): PostageStamp[] {
   return storageManager.load()
 }
 
-function savePostageStamps(data: PostageStamp[], skipSync = false, accountId?: string): void {
+function savePostageStamps(data: PostageStamp[]): void {
   storageManager.save(data)
-
-  // Trigger Swarm sync (unless explicitly skipped)
-  if (!skipSync && accountId) {
-    triggerSync(accountId)
-  }
 }
 
 // ============================================================================
@@ -57,7 +51,7 @@ export const postageStampsStore = {
     return postageStamps
   },
 
-  addStamp(stamp: Omit<PostageStamp, 'createdAt'>, accountId: string): PostageStamp {
+  addStamp(stamp: Omit<PostageStamp, 'createdAt'>): PostageStamp {
     // Check for duplicate batch ID
     const existingStamp = postageStamps.find((s) => s.batchID.equals(stamp.batchID))
     if (existingStamp) {
@@ -69,13 +63,13 @@ export const postageStampsStore = {
       createdAt: Date.now(),
     }
     postageStamps = [...postageStamps, newStamp]
-    savePostageStamps(postageStamps, false, accountId)
+    savePostageStamps(postageStamps)
     return newStamp
   },
 
-  removeStamp(batchID: BatchId, accountId: string) {
+  removeStamp(batchID: BatchId) {
     postageStamps = postageStamps.filter((s) => !s.batchID.equals(batchID))
-    savePostageStamps(postageStamps, false, accountId)
+    savePostageStamps(postageStamps)
   },
 
   getStamp(batchID: BatchId): PostageStamp | undefined {
@@ -117,8 +111,7 @@ export const postageStampsStore = {
     // Update utilization
     stamp.utilization = newUtilization
 
-    // Save without triggering sync (to avoid infinite loop)
-    savePostageStamps(postageStamps, true)
+    savePostageStamps(postageStamps)
   },
 
   clear() {

--- a/swarm-ui/src/lib/utils/restore-account.ts
+++ b/swarm-ui/src/lib/utils/restore-account.ts
@@ -3,10 +3,7 @@
 
 import type { Account, Identity, ConnectedApp, PostageStamp, Device } from '@snaha/swarm-id'
 import { mergeDevices, getOrCreateDeviceId } from '@snaha/swarm-id'
-import { accountsStore } from '$lib/stores/accounts.svelte'
-import { identitiesStore } from '$lib/stores/identities.svelte'
-import { connectedAppsStore } from '$lib/stores/connected-apps.svelte'
-import { postageStampsStore } from '$lib/stores/postage-stamps.svelte'
+import { createSyncedAccount } from '$lib/domain/synced-account'
 
 interface RestoreData {
   account: Account
@@ -18,22 +15,22 @@ interface RestoreData {
 
 export function restoreAccountToStores(data: RestoreData): Account {
   const devices = mergeDevices(data.devices ?? [], getOrCreateDeviceId())
-  accountsStore.addAccount({ ...data.account, devices })
+  const account = createSyncedAccount({ ...data.account, devices })
 
   for (const identity of data.identities) {
-    identitiesStore.addIdentity(identity)
+    account.addIdentity(identity)
   }
 
   for (const app of data.connectedApps) {
     // Reset connectedUntil — the session has logically expired by the time
     // a backup is restored, so apps appear as "previously connected" but
     // require the user to reconnect (which re-establishes the session timer).
-    connectedAppsStore.addOrUpdateApp({ ...app, connectedUntil: undefined }, undefined)
+    account.connectApp({ ...app, connectedUntil: undefined }, undefined)
   }
 
   for (const stamp of data.postageStamps) {
     try {
-      postageStampsStore.addStamp(stamp, data.account.id.toHex())
+      account.addStamp(stamp)
     } catch (err) {
       console.warn('Skipping duplicate stamp:', err)
     }

--- a/swarm-ui/src/routes/(app)/(create)/agent/new/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/agent/new/+page.svelte
@@ -24,9 +24,10 @@
   import { navigateToConnectOrHome } from '$lib/utils/navigation'
   import { sessionStore } from '$lib/stores/session.svelte'
   import { accountsStore } from '$lib/stores/accounts.svelte'
+  import { createSyncedAccount } from '$lib/domain/synced-account'
   import { createAgentAccount, validateSeedPhrase, countSeedPhraseWords } from '$lib/agent-account'
   import { deriveAccountDerivationKey, getOrCreateDeviceId, mergeDevices } from '@snaha/swarm-id'
-  import type { AccountSyncType } from '$lib/types'
+  import type { AccountSyncType, Account } from '$lib/types'
 
   let showTypeTooltip = $state(false)
   let accountName = $state('Agent')
@@ -92,14 +93,15 @@
       const derivationKey = await deriveAccountDerivationKey(masterKey.toHex())
 
       // Store account (seed phrase is NOT stored - must be re-entered each time)
-      const newAccount = accountsStore.addAccount({
+      const newAccount: Account = {
         id: account.id,
         name: account.name,
         createdAt: account.createdAt,
         type: 'agent',
         derivationKey,
         devices: mergeDevices([], getOrCreateDeviceId()),
-      })
+      }
+      createSyncedAccount(newAccount)
       sessionStore.setAccount(newAccount)
       sessionStore.setSyncedCreation(accountType === 'synced')
 

--- a/swarm-ui/src/routes/(app)/(create)/eth/new/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/eth/new/+page.svelte
@@ -24,6 +24,7 @@
   import { connectAndSign, deriveMasterKey } from '$lib/ethereum'
   import { sessionStore } from '$lib/stores/session.svelte'
   import { accountsStore } from '$lib/stores/accounts.svelte'
+  import { createSyncedAccount } from '$lib/domain/synced-account'
   import {
     generateEncryptionSalt,
     deriveEncryptionKey,
@@ -37,7 +38,7 @@
   import Confirmation from '$lib/components/confirmation.svelte'
   import { onMount } from 'svelte'
   import { deriveAccountDerivationKey, getOrCreateDeviceId, mergeDevices } from '@snaha/swarm-id'
-  import type { AccountSyncType } from '$lib/types'
+  import type { AccountSyncType, Account } from '$lib/types'
 
   let showTypeTooltip = $state(false)
   let showSeedTooltip = $state(false)
@@ -108,7 +109,7 @@
       const encryptedSecretSeed = await encryptSecretSeed(secretSeed, secretSeedEncryptionKey)
 
       // Store account with encrypted masterKey and encrypted secret seed
-      const newAccount = accountsStore.addAccount({
+      const newAccount: Account = {
         id: masterAddress,
         createdAt: Date.now(),
         name: accountName.trim(),
@@ -119,7 +120,8 @@
         encryptedSecretSeed: encryptedSecretSeed,
         derivationKey,
         devices: mergeDevices([], getOrCreateDeviceId()),
-      })
+      }
+      createSyncedAccount(newAccount)
       sessionStore.setAccount(newAccount)
       sessionStore.setSyncedCreation(accountType === 'synced')
 

--- a/swarm-ui/src/routes/(app)/(create)/identity/new/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/identity/new/+page.svelte
@@ -22,6 +22,7 @@
   import { sessionStore } from '$lib/stores/session.svelte'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { identitiesStore } from '$lib/stores/identities.svelte'
+  import { getSyncedAccount } from '$lib/domain/synced-account'
   import type { Identity, Account } from '$lib/types'
   import { HDNodeWallet } from 'ethers'
   import { Bytes } from '@ethersphere/bee-js'
@@ -108,7 +109,7 @@
     }
 
     // Create the identity with custom name (identity stamp will be set on the identity stamp page)
-    const identity = identitiesStore.addIdentity({
+    const identity = getSyncedAccount(account.id).addIdentity({
       ...derivedIdentity,
       name: idName || derivedIdentity.name,
     })

--- a/swarm-ui/src/routes/(app)/(create)/passkey/new/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/passkey/new/+page.svelte
@@ -20,13 +20,14 @@
   import CreationLayout from '$lib/components/creation-layout.svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
   import { accountsStore } from '$lib/stores/accounts.svelte'
+  import { createSyncedAccount } from '$lib/domain/synced-account'
   import { keccak256 } from 'ethers'
   import { Bytes } from '@ethersphere/bee-js'
   import Confirmation from '$lib/components/confirmation.svelte'
   import { onMount } from 'svelte'
   import ErrorMessage from '$lib/components/ui/error-message.svelte'
   import { deriveAccountDerivationKey, getOrCreateDeviceId, mergeDevices } from '@snaha/swarm-id'
-  import type { AccountSyncType } from '$lib/types'
+  import type { AccountSyncType, Account } from '$lib/types'
 
   let accountName = $state('Passkey')
   let accountType = $state<AccountSyncType>('local')
@@ -76,7 +77,7 @@
       const derivationKey = await deriveAccountDerivationKey(account.masterKey.toHex())
 
       // Store account WITHOUT masterKey (passkey accounts never persist masterKey)
-      const newAccount = accountsStore.addAccount({
+      const newAccount: Account = {
         id: account.ethereumAddress,
         createdAt: Date.now(),
         name: accountName.trim(),
@@ -84,7 +85,8 @@
         credentialId: account.credentialId,
         derivationKey,
         devices: mergeDevices([], getOrCreateDeviceId()),
-      })
+      }
+      createSyncedAccount(newAccount)
       sessionStore.setAccount(newAccount)
       sessionStore.setSyncedCreation(accountType === 'synced')
 

--- a/swarm-ui/src/routes/(app)/(create)/stamps/account/new/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/stamps/account/new/+page.svelte
@@ -15,7 +15,7 @@
   import { resolve } from '$app/paths'
   import routes from '$lib/routes'
   import { navigateToConnectOrHome } from '$lib/utils/navigation'
-  import { accountsStore } from '$lib/stores/accounts.svelte'
+  import { getSyncedAccount } from '$lib/domain/synced-account'
   import { identitiesStore } from '$lib/stores/identities.svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
   import type { PostageStamp } from '@snaha/swarm-id'
@@ -51,7 +51,7 @@
     if (!account) return
 
     // Set as default stamp for the account
-    accountsStore.setDefaultStamp(account.id, stamp.batchID)
+    getSyncedAccount(account.id).setDefaultStamp(stamp.batchID)
 
     // If user chose separate stamps, go to identity stamp page next
     if (sessionStore.data.selectedStampOption === 'separate') {

--- a/swarm-ui/src/routes/(app)/(create)/stamps/identity/new/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/stamps/identity/new/+page.svelte
@@ -13,6 +13,7 @@
   import AddPostageStampButtons from '$lib/components/add-postage-stamp-buttons.svelte'
   import { navigateToConnectOrHome } from '$lib/utils/navigation'
   import { identitiesStore } from '$lib/stores/identities.svelte'
+  import { getSyncedAccount } from '$lib/domain/synced-account'
   import { sessionStore } from '$lib/stores/session.svelte'
   import type { PostageStamp } from '@snaha/swarm-id'
 
@@ -40,10 +41,10 @@
   }
 
   function handleSuccess(stamp: PostageStamp) {
-    if (!currentIdentityId) return
+    if (!currentIdentityId || !identity) return
 
     // Set as default stamp for the identity
-    identitiesStore.setDefaultStamp(currentIdentityId, stamp.batchID)
+    getSyncedAccount(identity.accountId).setIdentityDefaultStamp(currentIdentityId, stamp.batchID)
 
     navigateToConnectOrHome()
   }

--- a/swarm-ui/src/routes/(app)/connect/+page.svelte
+++ b/swarm-ui/src/routes/(app)/connect/+page.svelte
@@ -22,6 +22,7 @@
   import { AppDataSchema } from '$lib/types'
   import type { Account, Identity } from '$lib/types'
   import { connectedAppsStore } from '$lib/stores/connected-apps.svelte'
+  import { getSyncedAccount } from '$lib/domain/synced-account'
   import Polycon from '$lib/components/polycon.svelte'
   import { ArrowRight } from 'carbon-icons-svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
@@ -195,7 +196,7 @@
 
     // Write to localStorage - this triggers storage events in the iframe
     // which will detect the new connection and authenticate
-    connectedAppsStore.addOrUpdateApp(
+    getSyncedAccount(selectedIdentity.accountId).connectApp(
       {
         appUrl: sessionStore.data.appOrigin,
         appName: sessionStore.data.appData.appName,

--- a/swarm-ui/src/routes/(app)/dev/+page.svelte
+++ b/swarm-ui/src/routes/(app)/dev/+page.svelte
@@ -482,11 +482,14 @@ Check console logs for details:
   function removeIdentityStamp() {
     assignError = ''
     assignMessage = ''
-    if (!selectedIdentityId) {
+    if (!selectedIdentityId || !selectedIdentity) {
       assignError = 'Select an identity first.'
       return
     }
-    identitiesStore.setDefaultStamp(selectedIdentityId, undefined)
+    getSyncedAccount(selectedIdentity.accountId).setIdentityDefaultStamp(
+      selectedIdentityId,
+      undefined,
+    )
     assignMessage = `✅ Removed identity stamp from ${selectedIdentityId.slice(0, 8)}…`
   }
 
@@ -501,7 +504,7 @@ Check console logs for details:
       assignError = 'Remove identity stamp first before removing account stamp.'
       return
     }
-    accountsStore.setDefaultStamp(new EthAddress(selectedAccountId), undefined)
+    getSyncedAccount(new EthAddress(selectedAccountId)).setDefaultStamp(undefined)
     assignMessage = `✅ Removed account stamp from ${selectedAccountId.slice(0, 8)}…`
   }
 </script>

--- a/swarm-ui/src/routes/(app)/dev/+page.svelte
+++ b/swarm-ui/src/routes/(app)/dev/+page.svelte
@@ -15,6 +15,7 @@
   import { identitiesStore } from '$lib/stores/identities.svelte'
   import { postageStampsStore } from '$lib/stores/postage-stamps.svelte'
   import { connectedAppsStore } from '$lib/stores/connected-apps.svelte'
+  import { getSyncedAccount } from '$lib/domain/synced-account'
   import { syncStore } from '$lib/stores/sync.svelte'
   import { devSettingsStore, type MockStampResult } from '$lib/stores/dev-settings.svelte'
   import Tabs from './tabs.svelte'
@@ -367,6 +368,7 @@ Check console logs for details:
     try {
       const batchId = new BatchId(selectedStampId)
       const accountId = new EthAddress(selectedAccountId)
+      const account = getSyncedAccount(accountId)
 
       // Determine which signer key to use
       const signerKeyToUse =
@@ -380,25 +382,22 @@ Check console logs for details:
           assignError = 'Stamp data not found. Reload stamps first.'
           return
         }
-        postageStampsStore.addStamp(
-          {
-            batchID: batchId,
-            signerKey: signerKeyToUse,
-            utilization: Utils.getStampUsage(
-              beeStamp.utilization,
-              beeStamp.depth,
-              beeStamp.bucketDepth,
-            ),
-            usable: beeStamp.usable,
-            depth: beeStamp.depth,
-            amount: BigInt(beeStamp.amount),
-            bucketDepth: beeStamp.bucketDepth,
-            blockNumber: beeStamp.blockNumber,
-            immutableFlag: beeStamp.immutableFlag,
-            exists: beeStamp.exists,
-          },
-          selectedAccountId,
-        )
+        account.addStamp({
+          batchID: batchId,
+          signerKey: signerKeyToUse,
+          utilization: Utils.getStampUsage(
+            beeStamp.utilization,
+            beeStamp.depth,
+            beeStamp.bucketDepth,
+          ),
+          usable: beeStamp.usable,
+          depth: beeStamp.depth,
+          amount: BigInt(beeStamp.amount),
+          bucketDepth: beeStamp.bucketDepth,
+          blockNumber: beeStamp.blockNumber,
+          immutableFlag: beeStamp.immutableFlag,
+          exists: beeStamp.exists,
+        })
       } else if (useCustomSigner) {
         const beeStamp = postageStampsStore.getStamp(batchId)
         if (!beeStamp) {
@@ -406,18 +405,15 @@ Check console logs for details:
           return
         }
         if (beeStamp.signerKey !== signerKeyToUse) {
-          postageStampsStore.removeStamp(batchId, selectedAccountId)
-          postageStampsStore.addStamp(
-            {
-              ...beeStamp,
-              signerKey: signerKeyToUse,
-            },
-            selectedAccountId,
-          )
+          account.removeStamp(batchId)
+          account.addStamp({
+            ...beeStamp,
+            signerKey: signerKeyToUse,
+          })
         }
       }
 
-      accountsStore.setDefaultStamp(accountId, batchId)
+      account.setDefaultStamp(batchId)
       assignMessage = `✅ Set account stamp for ${accountId.toHex().slice(0, 8)}…`
     } catch (error) {
       assignError = error instanceof Error ? error.message : String(error)
@@ -444,6 +440,7 @@ Check console logs for details:
 
     try {
       const batchId = new BatchId(selectedStampId)
+      const account = getSyncedAccount(new EthAddress(selectedAccountId))
 
       // Determine which signer key to use
       const signerKeyToUse =
@@ -457,28 +454,25 @@ Check console logs for details:
           assignError = 'Stamp data not found. Reload stamps first.'
           return
         }
-        postageStampsStore.addStamp(
-          {
-            batchID: batchId,
-            signerKey: signerKeyToUse,
-            utilization: Utils.getStampUsage(
-              beeStamp.utilization,
-              beeStamp.depth,
-              beeStamp.bucketDepth,
-            ),
-            usable: beeStamp.usable,
-            depth: beeStamp.depth,
-            amount: BigInt(beeStamp.amount),
-            bucketDepth: beeStamp.bucketDepth,
-            blockNumber: beeStamp.blockNumber,
-            immutableFlag: beeStamp.immutableFlag,
-            exists: beeStamp.exists,
-          },
-          selectedAccountId,
-        )
+        account.addStamp({
+          batchID: batchId,
+          signerKey: signerKeyToUse,
+          utilization: Utils.getStampUsage(
+            beeStamp.utilization,
+            beeStamp.depth,
+            beeStamp.bucketDepth,
+          ),
+          usable: beeStamp.usable,
+          depth: beeStamp.depth,
+          amount: BigInt(beeStamp.amount),
+          bucketDepth: beeStamp.bucketDepth,
+          blockNumber: beeStamp.blockNumber,
+          immutableFlag: beeStamp.immutableFlag,
+          exists: beeStamp.exists,
+        })
       }
 
-      identitiesStore.setDefaultStamp(selectedIdentityId, batchId)
+      account.setIdentityDefaultStamp(selectedIdentityId, batchId)
       assignMessage = `✅ Set identity stamp for ${selectedIdentityId.slice(0, 8)}…`
     } catch (error) {
       assignError = error instanceof Error ? error.message : String(error)

--- a/swarm-ui/src/routes/(app)/identity/[id]/apps/+page.svelte
+++ b/swarm-ui/src/routes/(app)/identity/[id]/apps/+page.svelte
@@ -13,6 +13,7 @@
   import Grid from '$lib/components/ui/grid.svelte'
   import Select from '$lib/components/ui/select/select.svelte'
   import { identitiesStore } from '$lib/stores/identities.svelte'
+  import { getSyncedAccount } from '$lib/domain/synced-account'
 
   const identityId = $derived(page.params.id)
   const apps = $derived(identityId ? connectedAppsStore.getAppsByIdentityId(identityId) : [])
@@ -30,7 +31,7 @@
   function onSessionDurationChange() {
     if (identity) {
       const appSessionDuration = valueToSessionDuration(sessionDurationValue)
-      identitiesStore.updateIdentity(identity.id, {
+      getSyncedAccount(identity.accountId).updateIdentity(identity.id, {
         settings: {
           ...identity.settings,
           appSessionDuration,

--- a/swarm-ui/src/routes/(app)/identity/[id]/settings/+page.svelte
+++ b/swarm-ui/src/routes/(app)/identity/[id]/settings/+page.svelte
@@ -13,6 +13,7 @@
   import Input from '$lib/components/ui/input/input.svelte'
   import { page } from '$app/state'
   import { identitiesStore } from '$lib/stores/identities.svelte'
+  import { getSyncedAccount } from '$lib/domain/synced-account'
   import Polycon from '$lib/components/polycon.svelte'
   import CopyButton from '$lib/components/copy-button.svelte'
   import Divider from '$lib/components/ui/divider.svelte'
@@ -34,7 +35,7 @@
 
   function onNameChange() {
     if (identity) {
-      identitiesStore.updateIdentity(identity.id, { name: identityName })
+      getSyncedAccount(identity.accountId).updateIdentity(identity.id, { name: identityName })
     }
   }
 </script>

--- a/swarm-ui/src/routes/(app)/identity/[id]/stamps/new/+page@.svelte
+++ b/swarm-ui/src/routes/(app)/identity/[id]/stamps/new/+page@.svelte
@@ -18,6 +18,7 @@
   import routes from '$lib/routes'
   import { identitiesStore } from '$lib/stores/identities.svelte'
   import { accountsStore } from '$lib/stores/accounts.svelte'
+  import { getSyncedAccount } from '$lib/domain/synced-account'
   import { sessionStore } from '$lib/stores/session.svelte'
   import type { PostageStamp } from '@snaha/swarm-id'
 
@@ -66,9 +67,9 @@
     // If this account already has a default stamp, set this as the identity's default
     // Otherwise make it the account's default
     if (account.defaultPostageStampBatchID) {
-      identitiesStore.setDefaultStamp(identity.id, stamp.batchID)
+      getSyncedAccount(account.id).setIdentityDefaultStamp(identity.id, stamp.batchID)
     } else {
-      accountsStore.setDefaultStamp(account.id, stamp.batchID)
+      getSyncedAccount(account.id).setDefaultStamp(stamp.batchID)
     }
 
     navigateBack()


### PR DESCRIPTION
> **Exploration / RFC, not a merge candidate as-is.** This branch explores *how accounts could be structured in code* so that syncing — and account-data mutation in general — has a single, obvious owner. Opening as a draft to evaluate the shape against the alternatives and against #313.

## Why

[#209](https://github.com/snaha/swarm-id/issues/209) ("sync should be triggered when a new identity is added") is really a symptom: sync was triggered ad-hoc from individual store methods, and which account to sync was inferred from the *session's* current identity rather than from the data that changed. So several meaningful mutations silently skipped sync, and the new-identity case in particular synced the wrong account (or none).

Rather than patch each call site, this explores making the **account an aggregate root** that owns its identities / apps / stamps and its own sync lifecycle.

## The shape

`lib/domain/synced-account.ts` — a `SyncedAccount` whose every mutation method *declares its own sync intent*:

```ts
rename(name)                  { accountsStore.setAccountName(this.id, name); this.#sync() }
addIdentity(i)                { const x = identitiesStore.addIdentity(i); this.#sync(); return x }
updateStampUtilization(b, u)  { postageStampsStore.updateStampUtilization(b, u) }  // volatile — no sync
delete()                      { /* cascade */ }                                     // local-only — no sync
```

- **No fingerprinting, no central diff** — the method knows what it changed. The utilization-loop problem is just "this method doesn't call `#sync()`", and account-vs-data attribution is never in question (you hold the instance).
- The stores underneath become **pure persistence**. Every swarm-ui mutation call site now routes through the aggregate; nothing outside `synced-account.ts` calls a store mutator.
- It's currently a **reactive facade** over the existing flat stores — the localStorage shape (and the iframe proxy that reads it) is unchanged. Reactivity is preserved because the migration is mutation-only; reactive reads still hit the stores' `$state` directly, and writes still reassign those signals.

## Relationship to #313 — should be done together

[#313](https://github.com/snaha/swarm-id/issues/313) ("consider having only identity level") questions whether the account level should exist at all. That directly determines the right aggregate root here:

- If the account level stays → `SyncedAccount` (this branch).
- If we collapse to identity-only (#313) → the aggregate root becomes the *identity*, and this structure reshapes accordingly.

Promoting the facade to a **true aggregate that also owns persistence** is the natural next step, and it reaches into the shared `lib/` and the proxy's storage reads — which is exactly the surface #313 would also touch. So this exploration and #313 should be decided/attempted together rather than landing one and then reworking it.

## Alternatives considered (for shipping #209 sooner)

Two lighter branches exist that fix #209 without the structural change:

- `fix/sync-explicit-triggers` — explicit `triggerSync(accountId)` per mutation, data-derived. Lowest risk, ~12 call sites.
- `feat/sync-coordinator` — a central coordinator that diffs per-account fingerprints (excludes volatile fields) and syncs on real change. No store-level sync calls, but carries a fingerprint-projection.

## Status

- `pnpm check:all` green (format, lint, typecheck, knip, 532 lib tests).
- **Not** manually verified end-to-end yet (create → add stamp → rename → connect → delete).
- Scope note: facade over stores, not true ownership; see the relationship to #313 above.

Relates to #209, #313.