### PR TITLE
fix: don't silently discard a real stamp purchase on popup close

### DIFF
--- a/swarm-ui/src/lib/components/add-postage-stamp.svelte
+++ b/swarm-ui/src/lib/components/add-postage-stamp.svelte
@@ -24,11 +24,18 @@
   import { resolve } from '$app/paths'
   import routes from '$lib/routes'
 
-  const HEX_BASE = 16
   const POLYCON_SIZE = 80
 
+  // Parse a block number that may arrive as a 0x-hex string ("0x2a828b8") or a
+  // decimal string/number from the widget. `Number()` handles both 0x-prefixed
+  // hex and decimal; fall back to 0 if it isn't parseable.
+  function parseBlockNumber(value: string): number {
+    const n = Number(value)
+    return Number.isFinite(n) ? n : 0
+  }
+
   export type PageState = 'select' | 'purchase' | 'manual'
-  export type PurchaseState = 'waiting' | 'success' | 'error'
+  export type PurchaseState = 'waiting' | 'success' | 'error' | 'unconfirmed'
   export type StampVariant = 'account-creation' | 'dashboard' | 'external-app'
 
   interface Props {
@@ -78,6 +85,10 @@
 
   // Purchase flow state
   let signerKeyBytes = $state<Uint8Array | undefined>(undefined)
+  // Derived signer key (hex) for the just-attempted purchase, so an unconfirmed
+  // close can pre-fill the manual recovery form — the user only needs the batch
+  // ID the widget showed, not the (derived) signer key.
+  let derivedSignerKeyHex = $state('')
 
   export function goToSelect() {
     pageState = 'select'
@@ -119,6 +130,7 @@
     }
     const signerKeyHex = await derivePostageSignerKey(account.derivationKey, identityId)
     signerKeyBytes = hexToUint8Array(signerKeyHex)
+    derivedSignerKeyHex = signerKeyHex
     const signerKeyPrivate = new PrivateKey(signerKeyBytes)
 
     // Derive destination address from signer key
@@ -134,6 +146,7 @@
       onSuccess: handleWidgetSuccess,
       onError: handleWidgetError,
       onCancel: handleWidgetCancel,
+      onUnconfirmedClose: handleWidgetUnconfirmedClose,
       mocked: devSettingsStore.data.mockStampEnabled,
       mockError: devSettingsStore.data.mockStampResult === 'error',
     })
@@ -153,7 +166,7 @@
           signerKey: new PrivateKey(signerKeyBytes),
           depth: batch.depth,
           amount: BigInt(batch.amount),
-          blockNumber: parseInt(batch.blockNumber, HEX_BASE),
+          blockNumber: parseBlockNumber(batch.blockNumber),
           utilization: 0,
           usable: true,
           bucketDepth: 16,
@@ -192,8 +205,23 @@
   }
 
   function handleWidgetCancel() {
-    // User cancelled - go back to select state
+    // User explicitly backed out of the widget - go back to select state.
     pageState = 'select'
+  }
+
+  function handleWidgetUnconfirmedClose() {
+    // The popup closed without a recognized batch event. The on-chain purchase
+    // may have succeeded (e.g. the widget didn't auto-close and the user closed
+    // it manually), so do NOT silently revert to 'select' and discard it —
+    // surface a recovery state instead.
+    purchaseState = 'unconfirmed'
+  }
+
+  function goToManualRecovery() {
+    // Pre-fill the derived signer key so the user only needs the batch ID the
+    // widget showed for the just-attempted purchase.
+    signerKey = derivedSignerKeyHex
+    pageState = 'manual'
   }
 </script>
 
@@ -287,6 +315,32 @@
     >
       <Typography variant="h4" center>‼️ Something went wrong</Typography>
       <Typography center>An unexpected error occurred. Please try again.</Typography>
+    </Vertical>
+  {:else if purchaseState === 'unconfirmed'}
+    <Vertical
+      --vertical-gap="var(--padding)"
+      --vertical-align-items="center"
+      --vertical-justify-content="center"
+      style="flex: 1;"
+    >
+      <Typography variant="h4" center>⚠️ Purchase not confirmed</Typography>
+      <Typography center>
+        The window closed before we could confirm your purchase. If you completed it, your stamp was
+        created — add it here using the batch ID the widget showed.
+      </Typography>
+      <Horizontal --horizontal-gap="var(--padding)">
+        <Button variant="strong" dimension="compact" flexGrow onclick={goToManualRecovery}>
+          Enter batch ID
+        </Button>
+        <Button
+          variant="secondary"
+          dimension="compact"
+          flexGrow
+          onclick={() => (pageState = 'select')}
+        >
+          Back to options
+        </Button>
+      </Horizontal>
     </Vertical>
   {/if}
 {:else if pageState === 'manual'}

--- a/swarm-ui/src/lib/services/multichain-widget.test.ts
+++ b/swarm-ui/src/lib/services/multichain-widget.test.ts
@@ -1,0 +1,116 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from 'vitest'
+import { parseBatchEvent } from './multichain-widget'
+
+const BATCH_ID = 'ab'.repeat(32) // 64 hex chars
+
+describe('parseBatchEvent', () => {
+  it('parses a well-formed object payload and strips the 0x prefix', () => {
+    const event = parseBatchEvent({
+      event: 'batch',
+      batchId: `0x${BATCH_ID}`,
+      depth: 21,
+      amount: '10453363201',
+      blockNumber: '0x2a828b8',
+    })
+    expect(event).toEqual({
+      event: 'batch',
+      batchId: BATCH_ID,
+      depth: 21,
+      amount: '10453363201',
+      blockNumber: '0x2a828b8',
+    })
+  })
+
+  it('accepts a batchId without the 0x prefix', () => {
+    expect(
+      parseBatchEvent({
+        event: 'batch',
+        batchId: BATCH_ID,
+        depth: 21,
+        amount: '1',
+        blockNumber: '0x1',
+      })?.batchId,
+    ).toBe(BATCH_ID)
+  })
+
+  it('parses a JSON-string payload (not just structured-clone objects)', () => {
+    const event = parseBatchEvent(
+      JSON.stringify({
+        event: 'batch',
+        batchId: BATCH_ID,
+        depth: 20,
+        amount: '500',
+        blockNumber: '0x10',
+      }),
+    )
+    expect(event?.depth).toBe(20)
+    expect(event?.amount).toBe('500')
+  })
+
+  it('coerces numeric fields that arrive as the "wrong" type', () => {
+    const event = parseBatchEvent({
+      event: 'batch',
+      batchId: BATCH_ID,
+      depth: '21', // string instead of number
+      amount: 10453363201, // number instead of string
+      blockNumber: 44475576, // number instead of hex string
+    })
+    expect(event).toEqual({
+      event: 'batch',
+      batchId: BATCH_ID,
+      depth: 21,
+      amount: '10453363201',
+      blockNumber: '44475576',
+    })
+  })
+
+  it('returns undefined for a non-batch event', () => {
+    expect(parseBatchEvent({ event: 'finish' })).toBeUndefined()
+    expect(parseBatchEvent({ event: 'error', message: 'boom' })).toBeUndefined()
+  })
+
+  it('returns undefined for an invalid batchId', () => {
+    expect(
+      parseBatchEvent({
+        event: 'batch',
+        batchId: 'not-hex',
+        depth: 21,
+        amount: '1',
+        blockNumber: '0x1',
+      }),
+    ).toBeUndefined()
+    // Wrong length (63 chars)
+    expect(
+      parseBatchEvent({
+        event: 'batch',
+        batchId: 'a'.repeat(63),
+        depth: 21,
+        amount: '1',
+        blockNumber: '0x1',
+      }),
+    ).toBeUndefined()
+  })
+
+  it('returns undefined when a numeric field is unparseable', () => {
+    expect(
+      parseBatchEvent({
+        event: 'batch',
+        batchId: BATCH_ID,
+        depth: 'NaN',
+        amount: '1',
+        blockNumber: '0x1',
+      }),
+    ).toBeUndefined()
+  })
+
+  it('returns undefined for non-object / non-JSON payloads', () => {
+    expect(parseBatchEvent(undefined)).toBeUndefined()
+    expect(parseBatchEvent(null)).toBeUndefined()
+    expect(parseBatchEvent(42)).toBeUndefined()
+    expect(parseBatchEvent('not json')).toBeUndefined()
+    expect(parseBatchEvent('"a string"')).toBeUndefined()
+  })
+})

--- a/swarm-ui/src/lib/services/multichain-widget.ts
+++ b/swarm-ui/src/lib/services/multichain-widget.ts
@@ -30,7 +30,14 @@ export interface PurchaseStampOptions {
   destination: string // Batch owner address (0x...)
   onSuccess: (batch: BatchEvent) => void
   onError: (error: Error) => void
+  // The user explicitly backed out of the widget (a `finish` event) without
+  // completing a purchase.
   onCancel: () => void
+  // The popup closed without us receiving a recognized batch event — ambiguous,
+  // because the on-chain purchase may have succeeded but its message was missed
+  // (e.g. the widget didn't auto-close and the user closed it manually). The
+  // caller MUST NOT treat this as a clean cancel that discards the purchase.
+  onUnconfirmedClose: () => void
   mocked?: boolean // For testing - returns dummy batches
   mockError?: boolean // For testing - simulate error instead of success
 }
@@ -61,25 +68,69 @@ function isAllowedOrigin(origin: string): boolean {
 }
 
 /**
- * Parse and validate a batch event from the widget
+ * Coerce a postMessage payload into a plain object for inspection. The widget
+ * may post a structured-clone object OR a JSON string; both are accepted.
  */
-function parseBatchEvent(data: unknown): BatchEvent | undefined {
-  if (typeof data !== 'object' || data === undefined || data === null) {
+function coerceObject(data: unknown): Record<string, unknown> | undefined {
+  let value = data
+  if (typeof value === 'string') {
+    try {
+      value = JSON.parse(value)
+    } catch {
+      return undefined
+    }
+  }
+  return typeof value === 'object' && value !== null
+    ? (value as Record<string, unknown>)
+    : undefined
+}
+
+/**
+ * Coerce a value that may arrive as a number or a numeric string into a finite
+ * number, else `undefined`. The real widget's message-field types are not
+ * contractually guaranteed, so we accept either form.
+ */
+function toFiniteNumber(value: unknown): number | undefined {
+  if (typeof value === 'number') return Number.isFinite(value) ? value : undefined
+  if (typeof value === 'string' && value.trim() !== '') {
+    const n = Number(value)
+    return Number.isFinite(n) ? n : undefined
+  }
+  return undefined
+}
+
+/**
+ * Coerce a value that may arrive as a string, number, or bigint into its string
+ * form (used for `amount`/`blockNumber`, which downstream re-parse as BigInt /
+ * integer).
+ */
+function toStringField(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.trim() !== '') return value
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value)
+  if (typeof value === 'bigint') return value.toString()
+  return undefined
+}
+
+/**
+ * Parse and validate a batch event from the widget.
+ *
+ * Tolerant by design: the external widget's exact message shape is not a
+ * documented contract, so we accept the payload as an object OR a JSON string,
+ * and accept numeric fields (`depth`/`amount`/`blockNumber`) as either numbers
+ * or numeric strings. A too-strict parser silently drops a successful purchase
+ * (the message is ignored, then the popup-close path reverts the UI).
+ */
+export function parseBatchEvent(data: unknown): BatchEvent | undefined {
+  const obj = coerceObject(data)
+  if (!obj || obj.event !== 'batch') {
     return undefined
   }
 
-  const obj = data as Record<string, unknown>
+  const depth = toFiniteNumber(obj.depth)
+  const amount = toStringField(obj.amount)
+  const blockNumber = toStringField(obj.blockNumber)
 
-  if (obj.event !== 'batch') {
-    return undefined
-  }
-
-  if (
-    typeof obj.batchId !== 'string' ||
-    typeof obj.depth !== 'number' ||
-    typeof obj.amount !== 'string' ||
-    typeof obj.blockNumber !== 'string'
-  ) {
+  if (typeof obj.batchId !== 'string' || depth === undefined || !amount || !blockNumber) {
     return undefined
   }
 
@@ -92,9 +143,9 @@ function parseBatchEvent(data: unknown): BatchEvent | undefined {
   return {
     event: 'batch',
     batchId: batchIdHex, // Store without 0x prefix
-    depth: obj.depth,
-    amount: obj.amount,
-    blockNumber: obj.blockNumber,
+    depth,
+    amount,
+    blockNumber,
   }
 }
 
@@ -104,7 +155,8 @@ function parseBatchEvent(data: unknown): BatchEvent | undefined {
  * @param options - Purchase options including destination address and callbacks
  */
 export function openStampPurchaseWidget(options: PurchaseStampOptions): void {
-  const { destination, onSuccess, onError, onCancel, mocked, mockError } = options
+  const { destination, onSuccess, onError, onCancel, onUnconfirmedClose, mocked, mockError } =
+    options
 
   const url = buildWidgetUrl(destination, mocked)
   const popup = window.open(url, 'stamp-purchase', POPUP_FEATURES)
@@ -114,8 +166,14 @@ export function openStampPurchaseWidget(options: PurchaseStampOptions): void {
     return
   }
 
+  // How long to keep listening for a trailing `batch` message after the popup
+  // is observed closed, before concluding the close was unconfirmed. The widget
+  // can post the result just before/after closing its window.
+  const CLOSE_GRACE_MS = 1_500
+
   let completed = false
   let mockTimeout: ReturnType<typeof setTimeout> | undefined
+  let closeGraceTimer: ReturnType<typeof setTimeout> | undefined
 
   // Handle messages from the widget
   const handleMessage = (event: MessageEvent) => {
@@ -136,34 +194,55 @@ export function openStampPurchaseWidget(options: PurchaseStampOptions): void {
       return
     }
 
-    // Check for error event
-    if ((typeof data === 'object' && data !== undefined) || data !== null) {
-      const obj = data as Record<string, unknown>
-      if (obj.event === 'error') {
-        completed = true
-        cleanup()
-        popup.close()
-        onError(new Error(String(obj.message || 'Widget error')))
-        return
-      }
+    const obj = coerceObject(data)
 
-      // Check for finish event (user closed widget without completing)
-      if (obj.event === 'finish') {
-        completed = true
-        cleanup()
-        popup.close()
-        onCancel()
-        return
-      }
+    // Check for error event
+    if (obj?.event === 'error') {
+      completed = true
+      cleanup()
+      popup.close()
+      onError(new Error(String(obj.message || 'Widget error')))
+      return
     }
+
+    // Check for finish event (user explicitly closed the widget without
+    // completing a purchase) — a genuine cancel.
+    if (obj?.event === 'finish') {
+      completed = true
+      cleanup()
+      popup.close()
+      onCancel()
+      return
+    }
+
+    // An allowed-origin message we didn't recognize. Leave a breadcrumb so a
+    // future "purchase succeeded but the UI didn't update" report can be
+    // diagnosed without special capture effort.
+    console.warn('[multichain-widget] unrecognized message from widget origin', {
+      origin: event.origin,
+      data,
+    })
+  }
+
+  // Conclude an ambiguous popup close: the on-chain purchase may have succeeded
+  // but its message was never recognized (e.g. the widget didn't auto-close and
+  // the user closed it manually). NOT a clean cancel — the caller must not
+  // discard a possible purchase.
+  const concludeUnconfirmedClose = () => {
+    if (completed) return
+    completed = true
+    cleanup()
+    onUnconfirmedClose()
   }
 
   // Check if popup was closed
   const checkClosed = setInterval(() => {
-    if (popup.closed && !completed) {
-      completed = true
-      cleanup()
-      onCancel()
+    if (popup.closed && !completed && closeGraceTimer === undefined) {
+      // Stop polling but keep the message listener alive for the grace window,
+      // so a `batch`/`finish` message arriving right as the popup closes is
+      // still handled.
+      clearInterval(checkClosed)
+      closeGraceTimer = setTimeout(concludeUnconfirmedClose, CLOSE_GRACE_MS)
     }
   }, 500)
 
@@ -173,6 +252,9 @@ export function openStampPurchaseWidget(options: PurchaseStampOptions): void {
     clearInterval(checkClosed)
     if (mockTimeout) {
       clearTimeout(mockTimeout)
+    }
+    if (closeGraceTimer) {
+      clearTimeout(closeGraceTimer)
     }
   }
 


### PR DESCRIPTION
Buying a real (non-mock) identity postage stamp could leave the UI on the "Purchase new stamp / Use existing one" screen even though the purchase succeeded on-chain. The external fund.bzz.limo widget didn't auto-close; when the user closed the popup manually, the popup-closed poller saw `popup.closed && !completed` and called onCancel -> pageState='select', discarding the purchase. The success message was never recognized because parseBatchEvent enforced a strict, unverified shape the real widget likely doesn't match.

- multichain-widget.ts:
  - Make parseBatchEvent tolerant (export it): accept an object OR a JSON string, and depth/amount/blockNumber as numbers OR numeric strings.
  - Treat a popup close as ambiguous via a new onUnconfirmedClose callback (the explicit `finish` event stays a genuine onCancel), so a possibly successful purchase is never silently dropped.
  - Keep the message listener alive for a short grace window after the popup closes to catch a trailing batch/finish message.
  - Fix an always-true guard; warn on unrecognized allowed-origin messages.
- add-postage-stamp.svelte: add an 'unconfirmed' recovery screen (Enter batch ID -> manual form pre-filled with the derived signer key / Back to options) instead of reverting to the two-button screen; tolerant blockNumber parse.
- Add unit tests for parseBatchEvent.

Fixes #342