### PR TITLE
fix(stamps): compute stamp expiry from the PostageStamp contract

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -523,6 +523,8 @@ export {
   fetchOnChainBatchState,
   fetchBatchTTLFromContract,
   fetchAuthoritativeBatchTTL,
+  resolveBatchStatus,
+  resolvePostageStampContractAddress,
   calculateContractTTLSeconds,
   decodeBatches,
   decodeUint,
@@ -531,6 +533,8 @@ export {
 export type {
   OnChainPostageBatch,
   OnChainBatchState,
+  OnChainBatchResult,
+  BatchResolution,
 } from "./utils/postage-contract"
 
 // Postage stamp <-> account/identity association

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -13,6 +13,7 @@ export { SwarmIdClient } from "./swarm-id-client"
 
 // Proxy for iframe
 export { SwarmIdProxy, initProxy } from "./swarm-id-proxy"
+export type { ProxyConfig } from "./swarm-id-proxy"
 
 // Key derivation utilities
 export {

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -517,6 +517,21 @@ export {
 } from "./utils/ttl"
 export type { ChainState } from "./utils/ttl"
 
+// On-chain postage batch reads (PostageStamp contract, ground-truth TTL)
+export {
+  fetchOnChainBatchState,
+  fetchBatchTTLFromContract,
+  fetchAuthoritativeBatchTTL,
+  calculateContractTTLSeconds,
+  decodeBatches,
+  decodeUint,
+  POSTAGE_STAMP_CONTRACT_ADDRESS,
+} from "./utils/postage-contract"
+export type {
+  OnChainPostageBatch,
+  OnChainBatchState,
+} from "./utils/postage-contract"
+
 // Postage stamp <-> account/identity association
 export {
   resolveStampForIdentity,

--- a/lib/src/swarm-id-proxy.ts
+++ b/lib/src/swarm-id-proxy.ts
@@ -120,9 +120,11 @@ import {
   fetchBatchDetails,
   fetchSwarmPrice,
 } from "./utils/ttl"
+import { fetchAuthoritativeBatchTTL } from "./utils/postage-contract"
 import { tryCreateTag } from "./utils/tag"
 import {
   DEFAULT_BEE_NODE_URL,
+  DEFAULT_GNOSIS_RPC_URL,
   UtilizationUpdateMessageSchema,
   type AccountStateSnapshot,
 } from "./schemas"
@@ -183,6 +185,7 @@ export class SwarmIdProxy {
     | undefined
   private utilizationStore: UtilizationStoreDB | undefined
   private beeApiUrl: string
+  private gnosisRpcUrl: string
   private authButtonContainer: HTMLElement | undefined
   private currentStyles: ButtonStyles | undefined
   private buttonConfig: ButtonConfig | undefined
@@ -230,6 +233,7 @@ export class SwarmIdProxy {
     // Load Bee API URL from network settings, falling back to default
     const networkSettings = createNetworkSettingsStorageManager().load()
     this.beeApiUrl = networkSettings?.beeNodeUrl || DEFAULT_BEE_NODE_URL
+    this.gnosisRpcUrl = networkSettings?.gnosisRpcUrl || DEFAULT_GNOSIS_RPC_URL
     this.bee = new Bee(this.beeApiUrl)
     this.setupMessageListener()
     this.setupStorageListeners()
@@ -3887,17 +3891,25 @@ export class SwarmIdProxy {
       return
     }
 
-    // Prefer the Bee node's authoritative batch details (computed from live
-    // chain state) — the stored stamp's `usable`/`exists` are a snapshot from
-    // assignment time and can be stale (e.g. a batch assigned during its ~30s
-    // warm-up stays `usable: false` in storage forever). Fall back to the
-    // stored values / Swarmscan-price TTL approximation when the Bee node
-    // does not know about this batch (e.g. public gateway).
+    // The stored stamp's `usable`/`exists` are a snapshot from assignment time
+    // and can be stale (e.g. a batch assigned during its ~30s warm-up stays
+    // `usable: false` in storage forever), so read live batch details from the
+    // Bee node for those fields.
     const details = await fetchBatchDetails(
       this.beeApiUrl,
       stamp.batchID.toHex(),
     )
-    let batchTTL = details?.batchTTL
+
+    // Resolve TTL from live chain state: the PostageStamp contract first
+    // (ground truth for any batch, even one this Bee node has never seen), then
+    // the Bee node's batchTTL. Fall back to the Swarmscan-price approximation
+    // only when neither authoritative source can answer (e.g. RPC unreachable
+    // and a public gateway that does not track the batch).
+    let batchTTL: number | undefined = await fetchAuthoritativeBatchTTL(
+      this.gnosisRpcUrl,
+      this.beeApiUrl,
+      stamp.batchID.toHex(),
+    )
     if (batchTTL === undefined) {
       try {
         const pricePerGBPerMonth = await fetchSwarmPrice()

--- a/lib/src/swarm-id-proxy.ts
+++ b/lib/src/swarm-id-proxy.ts
@@ -120,7 +120,10 @@ import {
   fetchBatchDetails,
   fetchSwarmPrice,
 } from "./utils/ttl"
-import { fetchAuthoritativeBatchTTL } from "./utils/postage-contract"
+import {
+  fetchAuthoritativeBatchTTL,
+  POSTAGE_STAMP_CONTRACT_ADDRESS,
+} from "./utils/postage-contract"
 import { tryCreateTag } from "./utils/tag"
 import {
   DEFAULT_BEE_NODE_URL,
@@ -186,6 +189,7 @@ export class SwarmIdProxy {
   private utilizationStore: UtilizationStoreDB | undefined
   private beeApiUrl: string
   private gnosisRpcUrl: string
+  private postageStampContractAddress: string
   private authButtonContainer: HTMLElement | undefined
   private currentStyles: ButtonStyles | undefined
   private buttonConfig: ButtonConfig | undefined
@@ -229,11 +233,16 @@ export class SwarmIdProxy {
    */
   private deviceId: string | undefined
 
-  constructor() {
+  constructor(config?: ProxyConfig) {
     // Load Bee API URL from network settings, falling back to default
     const networkSettings = createNetworkSettingsStorageManager().load()
     this.beeApiUrl = networkSettings?.beeNodeUrl || DEFAULT_BEE_NODE_URL
     this.gnosisRpcUrl = networkSettings?.gnosisRpcUrl || DEFAULT_GNOSIS_RPC_URL
+    // PostageStamp contract address for on-chain TTL reads. The host app
+    // supplies this from a build-time env so local dev can point at the
+    // bee-compose anvil deployment; defaults to the Gnosis mainnet contract.
+    this.postageStampContractAddress =
+      config?.postageStampContractAddress || POSTAGE_STAMP_CONTRACT_ADDRESS
     this.bee = new Bee(this.beeApiUrl)
     this.setupMessageListener()
     this.setupStorageListeners()
@@ -3909,6 +3918,7 @@ export class SwarmIdProxy {
       this.gnosisRpcUrl,
       this.beeApiUrl,
       stamp.batchID.toHex(),
+      this.postageStampContractAddress,
     )
     if (batchTTL === undefined) {
       try {
@@ -4002,8 +4012,20 @@ export class SwarmIdProxy {
 }
 
 /**
+ * Optional configuration for the proxy, supplied by the host trusted-domain app.
+ */
+export interface ProxyConfig {
+  /**
+   * PostageStamp contract address for on-chain stamp-TTL reads. Defaults to the
+   * Gnosis mainnet deployment; set this (from a build-time env) to the local
+   * bee-compose anvil address when developing against a local chain.
+   */
+  postageStampContractAddress?: string
+}
+
+/**
  * Initialize the proxy (called from HTML page)
  */
-export function initProxy(): SwarmIdProxy {
-  return new SwarmIdProxy()
+export function initProxy(config?: ProxyConfig): SwarmIdProxy {
+  return new SwarmIdProxy(config)
 }

--- a/lib/src/utils/json-rpc.ts
+++ b/lib/src/utils/json-rpc.ts
@@ -1,0 +1,31 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Minimal JSON-RPC-over-HTTP transport shared by the chain-reading utilities:
+ * block-timestamp lookups in {@link ./ttl} and PostageStamp contract reads in
+ * {@link ./postage-contract}.
+ *
+ * It handles the POST envelope and HTTP-level errors only. Callers interpret
+ * the JSON-RPC `result`/`error` payload themselves, because the single-call and
+ * batch response shapes differ (one object vs an array matched back by id).
+ *
+ * @param rpcUrl - JSON-RPC endpoint URL
+ * @param body - the request payload (a single call object or an array of them)
+ * @returns the parsed JSON response, as `unknown` for the caller to narrow
+ * @throws if the transport fails or the endpoint returns a non-OK status
+ */
+export async function postJsonRpc(
+  rpcUrl: string,
+  body: unknown,
+): Promise<unknown> {
+  const response = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+  if (!response.ok) {
+    throw new Error(`RPC request failed: HTTP ${response.status}`)
+  }
+  return response.json()
+}

--- a/lib/src/utils/postage-contract.test.ts
+++ b/lib/src/utils/postage-contract.test.ts
@@ -9,7 +9,10 @@ import {
   fetchAuthoritativeBatchTTL,
   fetchBatchTTLFromContract,
   fetchOnChainBatchState,
+  fetchOnChainBatchStateResult,
+  resolveBatchStatus,
   POSTAGE_STAMP_CONTRACT_ADDRESS,
+  resolvePostageStampContractAddress,
   type OnChainBatchState,
 } from "./postage-contract"
 
@@ -372,5 +375,154 @@ describe("fetchAuthoritativeBatchTTL", () => {
     const ttl = await fetchAuthoritativeBatchTTL(RPC, BEE, BATCH_ID)
 
     expect(ttl).toBeUndefined()
+  })
+})
+
+describe("resolvePostageStampContractAddress", () => {
+  const LOCAL = "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512"
+
+  it("honours the local override only for a local RPC", () => {
+    expect(
+      resolvePostageStampContractAddress("http://localhost:9545", LOCAL),
+    ).toBe(LOCAL)
+    expect(
+      resolvePostageStampContractAddress("http://127.0.0.1:9545", LOCAL),
+    ).toBe(LOCAL)
+  })
+
+  it("ignores the local override for a remote RPC (mainnet)", () => {
+    expect(
+      resolvePostageStampContractAddress(
+        "https://xdai.fairdatasociety.org/",
+        LOCAL,
+      ),
+    ).toBe(POSTAGE_STAMP_CONTRACT_ADDRESS)
+  })
+
+  it("falls back to mainnet when no override is given", () => {
+    expect(resolvePostageStampContractAddress("http://localhost:9545")).toBe(
+      POSTAGE_STAMP_CONTRACT_ADDRESS,
+    )
+  })
+})
+
+const ZERO_TUPLE = "0x" + "0".repeat(64 * 6)
+
+describe("fetchOnChainBatchStateResult", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch")
+  })
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it("reports found with the decoded state", async () => {
+    fetchSpy.mockResolvedValue(batchResponse(FULL_RESPONSE))
+    const result = await fetchOnChainBatchStateResult(
+      "https://rpc.example",
+      BATCH_ID,
+    )
+    expect(result.status).toBe("found")
+    if (result.status === "found") {
+      expect(result.state.lastPrice).toBe(LAST_PRICE)
+    }
+  })
+
+  it("reports not-found for a zero-owner tuple", async () => {
+    fetchSpy.mockResolvedValue(
+      batchResponse({
+        0: { result: ZERO_TUPLE },
+        1: { result: OUT_PAYMENT_RESULT },
+        2: { result: LAST_PRICE_RESULT },
+      }),
+    )
+    const result = await fetchOnChainBatchStateResult(
+      "https://rpc.example",
+      BATCH_ID,
+    )
+    expect(result.status).toBe("not-found")
+  })
+
+  it("reports error when the RPC fails", async () => {
+    fetchSpy.mockRejectedValue(new Error("rpc down"))
+    const result = await fetchOnChainBatchStateResult(
+      "https://rpc.example",
+      BATCH_ID,
+    )
+    expect(result.status).toBe("error")
+  })
+})
+
+describe("resolveBatchStatus", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  const RPC = "https://rpc.example"
+  const BEE = "https://bee.example"
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch")
+  })
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it("found via contract, with the contract TTL", async () => {
+    fetchSpy.mockImplementation((url) =>
+      Promise.resolve(
+        url === RPC ? batchResponse(FULL_RESPONSE) : ({} as Response),
+      ),
+    )
+    const result = await resolveBatchStatus(RPC, BEE, BATCH_ID)
+    expect(result).toEqual({
+      status: "found",
+      ttlSeconds: EXPECTED_TTL_SECONDS,
+    })
+  })
+
+  it("not-found is authoritative and does not consult the Bee node", async () => {
+    fetchSpy.mockImplementation((url) => {
+      if (url === RPC) {
+        return Promise.resolve(
+          batchResponse({
+            0: { result: ZERO_TUPLE },
+            1: { result: OUT_PAYMENT_RESULT },
+            2: { result: LAST_PRICE_RESULT },
+          }),
+        )
+      }
+      throw new Error("Bee must not be consulted on contract not-found")
+    })
+    const result = await resolveBatchStatus(RPC, BEE, BATCH_ID)
+    expect(result).toEqual({ status: "not-found" })
+  })
+
+  it("falls back to the Bee node when the contract read errors", async () => {
+    fetchSpy.mockImplementation((url) =>
+      url === RPC
+        ? Promise.reject(new Error("rpc down"))
+        : Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ batchTTL: 4242 }),
+          } as Response),
+    )
+    const result = await resolveBatchStatus(RPC, BEE, BATCH_ID)
+    expect(result).toEqual({ status: "found", ttlSeconds: 4242 })
+  })
+
+  it("is unreachable when both the contract and the Bee node fail", async () => {
+    fetchSpy.mockImplementation((url) =>
+      url === RPC
+        ? Promise.reject(new Error("rpc down"))
+        : Promise.resolve({
+            ok: false,
+            status: 404,
+            json: () => Promise.resolve({}),
+          } as Response),
+    )
+    const result = await resolveBatchStatus(RPC, BEE, BATCH_ID)
+    expect(result).toEqual({ status: "unreachable" })
   })
 })

--- a/lib/src/utils/postage-contract.test.ts
+++ b/lib/src/utils/postage-contract.test.ts
@@ -177,6 +177,25 @@ describe("fetchOnChainBatchState", () => {
     expect(body[0].params[0].data).toBe(`0xc81e25ab${BATCH_ID}`)
   })
 
+  it("targets a custom contract address when provided (local dev chain)", async () => {
+    fetchSpy.mockResolvedValue(batchResponse(FULL_RESPONSE))
+    const LOCAL_CONTRACT = "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512"
+
+    await fetchOnChainBatchState(
+      "https://rpc.example",
+      BATCH_ID,
+      LOCAL_CONTRACT,
+    )
+
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0][1] as RequestInit).body as string,
+    )
+    expect(body).toHaveLength(3)
+    for (const call of body) {
+      expect(call.params[0].to).toBe(LOCAL_CONTRACT)
+    }
+  })
+
   it("accepts a 0x-prefixed batch ID", async () => {
     fetchSpy.mockResolvedValue(batchResponse(FULL_RESPONSE))
 

--- a/lib/src/utils/postage-contract.test.ts
+++ b/lib/src/utils/postage-contract.test.ts
@@ -1,0 +1,357 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import {
+  calculateContractTTLSeconds,
+  decodeBatches,
+  decodeUint,
+  fetchAuthoritativeBatchTTL,
+  fetchBatchTTLFromContract,
+  fetchOnChainBatchState,
+  POSTAGE_STAMP_CONTRACT_ADDRESS,
+  type OnChainBatchState,
+} from "./postage-contract"
+
+// Real on-chain data captured for batch
+// 178f3ac9741b7659c4b80e1ae80fbf5ef4975f7aceed6560712bb4d126697de0
+// (the batch from issue #344) at block ~46.6M.
+const BATCH_ID =
+  "178f3ac9741b7659c4b80e1ae80fbf5ef4975f7aceed6560712bb4d126697de0"
+
+const OWNER = "0xb486f0d45be037a937e92bf48ee85f63053ed61d"
+const DEPTH = 21
+const BUCKET_DEPTH = 16
+const NORMALISED_BALANCE = 682583171899n
+const LAST_UPDATED_BLOCK = 46591298n
+const CURRENT_TOTAL_OUT_PAYMENT = 675749301230n
+const LAST_PRICE = 59203n
+// remaining = 682583171899 - 675749301230 = 6833870669
+// blocks    = 6833870669 / 59203 = 115431
+// seconds   = 115431 * 5 = 577155
+const EXPECTED_TTL_SECONDS = 577155
+
+/** Left-pads a value to a 32-byte (64-hex) ABI word. */
+function word(value: bigint | string): string {
+  const hex =
+    typeof value === "bigint"
+      ? value.toString(16)
+      : value.replace(/^0x/, "").toLowerCase()
+  return hex.padStart(64, "0")
+}
+
+// batches() returns a static tuple (address, uint8, uint8, bool, uint256, uint256).
+const BATCHES_RESULT =
+  "0x" +
+  word(OWNER) +
+  word(BigInt(DEPTH)) +
+  word(BigInt(BUCKET_DEPTH)) +
+  word(0n) + // immutableFlag = false
+  word(NORMALISED_BALANCE) +
+  word(LAST_UPDATED_BLOCK)
+
+const OUT_PAYMENT_RESULT = "0x" + word(CURRENT_TOTAL_OUT_PAYMENT)
+const LAST_PRICE_RESULT = "0x" + word(LAST_PRICE)
+
+function batchResponse(
+  results: Record<number, { result?: string; error?: { message: string } }>,
+): Response {
+  const body = Object.entries(results).map(([id, value]) => ({
+    jsonrpc: "2.0",
+    id: Number(id),
+    ...value,
+  }))
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  } as Response
+}
+
+const FULL_RESPONSE = {
+  0: { result: BATCHES_RESULT },
+  1: { result: OUT_PAYMENT_RESULT },
+  2: { result: LAST_PRICE_RESULT },
+}
+
+describe("decodeBatches", () => {
+  it("decodes the batches() tuple", () => {
+    const batch = decodeBatches(BATCHES_RESULT)
+    expect(batch.owner).toBe("0xb486f0d45be037a937e92bf48ee85f63053ed61d")
+    expect(batch.depth).toBe(21)
+    expect(batch.bucketDepth).toBe(16)
+    expect(batch.immutableFlag).toBe(false)
+    expect(batch.normalisedBalance).toBe(NORMALISED_BALANCE)
+    expect(batch.lastUpdatedBlockNumber).toBe(46591298n)
+  })
+
+  it("throws when the payload is too short", () => {
+    expect(() => decodeBatches("0x00")).toThrow(/length/)
+  })
+})
+
+describe("decodeUint", () => {
+  it("decodes a single uint256 word", () => {
+    expect(decodeUint(OUT_PAYMENT_RESULT)).toBe(CURRENT_TOTAL_OUT_PAYMENT)
+    expect(decodeUint(LAST_PRICE_RESULT)).toBe(LAST_PRICE)
+  })
+
+  it("throws on empty payload", () => {
+    expect(() => decodeUint("0x")).toThrow()
+  })
+})
+
+describe("calculateContractTTLSeconds", () => {
+  const baseState: OnChainBatchState = {
+    batch: {
+      owner: "0xb486f0d45be037a937e92bf48ee85f63053ed61d",
+      depth: 21,
+      bucketDepth: 16,
+      immutableFlag: false,
+      normalisedBalance: NORMALISED_BALANCE,
+      lastUpdatedBlockNumber: 46591298n,
+    },
+    currentTotalOutPayment: CURRENT_TOTAL_OUT_PAYMENT,
+    lastPrice: LAST_PRICE,
+  }
+
+  it("matches the value Bee computes from the same chain state", () => {
+    expect(calculateContractTTLSeconds(baseState)).toBe(EXPECTED_TTL_SECONDS)
+  })
+
+  it("returns 0 when the batch is expired (outpayment caught up)", () => {
+    expect(
+      calculateContractTTLSeconds({
+        ...baseState,
+        currentTotalOutPayment: NORMALISED_BALANCE,
+      }),
+    ).toBe(0)
+    expect(
+      calculateContractTTLSeconds({
+        ...baseState,
+        currentTotalOutPayment: NORMALISED_BALANCE + 1n,
+      }),
+    ).toBe(0)
+  })
+
+  it("returns undefined for a zero price (no finite expiry)", () => {
+    expect(
+      calculateContractTTLSeconds({ ...baseState, lastPrice: 0n }),
+    ).toBeUndefined()
+  })
+})
+
+describe("fetchOnChainBatchState", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch")
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it("fetches and decodes the full batch state", async () => {
+    fetchSpy.mockResolvedValue(batchResponse(FULL_RESPONSE))
+
+    const state = await fetchOnChainBatchState("https://rpc.example", BATCH_ID)
+
+    expect(state).toBeDefined()
+    expect(state?.batch.normalisedBalance).toBe(NORMALISED_BALANCE)
+    expect(state?.currentTotalOutPayment).toBe(CURRENT_TOTAL_OUT_PAYMENT)
+    expect(state?.lastPrice).toBe(LAST_PRICE)
+  })
+
+  it("targets the PostageStamp contract with the batches() selector", async () => {
+    fetchSpy.mockResolvedValue(batchResponse(FULL_RESPONSE))
+
+    await fetchOnChainBatchState("https://rpc.example", BATCH_ID)
+
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0][1] as RequestInit).body as string,
+    )
+    expect(body).toHaveLength(3)
+    expect(body[0].method).toBe("eth_call")
+    expect(body[0].params[0].to).toBe(POSTAGE_STAMP_CONTRACT_ADDRESS)
+    expect(body[0].params[0].data).toBe(`0xc81e25ab${BATCH_ID}`)
+  })
+
+  it("accepts a 0x-prefixed batch ID", async () => {
+    fetchSpy.mockResolvedValue(batchResponse(FULL_RESPONSE))
+
+    const state = await fetchOnChainBatchState(
+      "https://rpc.example",
+      `0x${BATCH_ID}`,
+    )
+
+    expect(state).toBeDefined()
+    const body = JSON.parse(
+      (fetchSpy.mock.calls[0][1] as RequestInit).body as string,
+    )
+    expect(body[0].params[0].data).toBe(`0xc81e25ab${BATCH_ID}`)
+  })
+
+  it("matches responses by id even when returned out of order", async () => {
+    fetchSpy.mockResolvedValue(
+      batchResponse({
+        2: { result: LAST_PRICE_RESULT },
+        0: { result: BATCHES_RESULT },
+        1: { result: OUT_PAYMENT_RESULT },
+      }),
+    )
+
+    const state = await fetchOnChainBatchState("https://rpc.example", BATCH_ID)
+
+    expect(state?.lastPrice).toBe(LAST_PRICE)
+    expect(state?.currentTotalOutPayment).toBe(CURRENT_TOTAL_OUT_PAYMENT)
+  })
+
+  it("returns undefined for an unknown batch (zero owner)", async () => {
+    const zeroTuple = "0x" + "0".repeat(64 * 6)
+    fetchSpy.mockResolvedValue(
+      batchResponse({
+        0: { result: zeroTuple },
+        1: { result: OUT_PAYMENT_RESULT },
+        2: { result: LAST_PRICE_RESULT },
+      }),
+    )
+
+    const state = await fetchOnChainBatchState("https://rpc.example", BATCH_ID)
+
+    expect(state).toBeUndefined()
+  })
+
+  it("returns undefined when a sub-call returns an error", async () => {
+    fetchSpy.mockResolvedValue(
+      batchResponse({
+        0: { result: BATCHES_RESULT },
+        1: { error: { message: "execution reverted" } },
+        2: { result: LAST_PRICE_RESULT },
+      }),
+    )
+
+    const state = await fetchOnChainBatchState("https://rpc.example", BATCH_ID)
+
+    expect(state).toBeUndefined()
+  })
+
+  it("returns undefined when the response is not ok", async () => {
+    fetchSpy.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.resolve([]),
+    } as Response)
+
+    const state = await fetchOnChainBatchState("https://rpc.example", BATCH_ID)
+
+    expect(state).toBeUndefined()
+  })
+
+  it("returns undefined when fetch rejects", async () => {
+    fetchSpy.mockRejectedValue(new Error("network error"))
+
+    const state = await fetchOnChainBatchState("https://rpc.example", BATCH_ID)
+
+    expect(state).toBeUndefined()
+  })
+
+  it("returns undefined for a malformed batch ID without calling fetch", async () => {
+    const state = await fetchOnChainBatchState("https://rpc.example", "nothex")
+
+    expect(state).toBeUndefined()
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})
+
+describe("fetchBatchTTLFromContract", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch")
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it("returns the ground-truth TTL in seconds", async () => {
+    fetchSpy.mockResolvedValue(batchResponse(FULL_RESPONSE))
+
+    const ttl = await fetchBatchTTLFromContract("https://rpc.example", BATCH_ID)
+
+    expect(ttl).toBe(EXPECTED_TTL_SECONDS)
+  })
+
+  it("returns undefined when the batch is unknown", async () => {
+    fetchSpy.mockRejectedValue(new Error("network error"))
+
+    const ttl = await fetchBatchTTLFromContract("https://rpc.example", BATCH_ID)
+
+    expect(ttl).toBeUndefined()
+  })
+})
+
+describe("fetchAuthoritativeBatchTTL", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  const RPC = "https://rpc.example"
+  const BEE = "https://bee.example"
+
+  function beeStampResponse(batchTTL: number): Response {
+    return {
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ batchTTL }),
+    } as Response
+  }
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch")
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it("prefers the contract TTL when the contract read succeeds", async () => {
+    // Answer the Bee node too, with a different value, to prove the contract wins.
+    fetchSpy.mockImplementation((url) =>
+      Promise.resolve(
+        url === RPC ? batchResponse(FULL_RESPONSE) : beeStampResponse(999),
+      ),
+    )
+
+    const ttl = await fetchAuthoritativeBatchTTL(RPC, BEE, BATCH_ID)
+
+    expect(ttl).toBe(EXPECTED_TTL_SECONDS)
+  })
+
+  it("falls back to the Bee node batchTTL when the contract read fails", async () => {
+    fetchSpy.mockImplementation((url) =>
+      url === RPC
+        ? Promise.reject(new Error("rpc down"))
+        : Promise.resolve(beeStampResponse(86400)),
+    )
+
+    const ttl = await fetchAuthoritativeBatchTTL(RPC, BEE, BATCH_ID)
+
+    expect(ttl).toBe(86400)
+  })
+
+  it("returns undefined when both sources fail", async () => {
+    fetchSpy.mockImplementation((url) =>
+      url === RPC
+        ? Promise.reject(new Error("rpc down"))
+        : Promise.resolve({
+            ok: false,
+            status: 404,
+            json: () => Promise.resolve({}),
+          } as Response),
+    )
+
+    const ttl = await fetchAuthoritativeBatchTTL(RPC, BEE, BATCH_ID)
+
+    expect(ttl).toBeUndefined()
+  })
+})

--- a/lib/src/utils/postage-contract.ts
+++ b/lib/src/utils/postage-contract.ts
@@ -20,6 +20,7 @@
  */
 
 import { fetchBatchTTL, GNOSIS_BLOCK_TIME } from "./ttl"
+import { postJsonRpc } from "./json-rpc"
 
 /**
  * PostageStamp contract address on Gnosis Chain. Lowercased — RPC nodes accept
@@ -38,9 +39,11 @@ const SELECTOR_CURRENT_TOTAL_OUT_PAYMENT = "51b17cd0" // currentTotalOutPayment(
 const SELECTOR_LAST_PRICE = "053f14da" // lastPrice()
 
 const HEX_WORD_LENGTH = 64 // 32 bytes as hex
-const BATCH_ID_HEX_LENGTH = 64 // 32 bytes as hex
 const ADDRESS_HEX_LENGTH = 40 // 20 bytes as hex
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+// A batch ID is exactly one 32-byte word. Compiled once, not per call.
+const BATCH_ID_REGEX = new RegExp(`^[0-9a-f]{${HEX_WORD_LENGTH}}$`)
 
 /**
  * Decoded `batches(bytes32)` tuple. Field names mirror the contract's `Batch`
@@ -75,7 +78,7 @@ export interface OnChainBatchState {
 function normalizeBatchId(batchId: string): string {
   const stripped = batchId.startsWith("0x") ? batchId.slice(2) : batchId
   const lower = stripped.toLowerCase()
-  if (!new RegExp(`^[0-9a-f]{${BATCH_ID_HEX_LENGTH}}$`).test(lower)) {
+  if (!BATCH_ID_REGEX.test(lower)) {
     throw new Error(`Invalid batch ID: ${batchId}`)
   }
   return lower
@@ -143,21 +146,13 @@ async function ethCallBatch(
     params: [{ to: call.to, data: call.data }, "latest"],
   }))
 
-  const response = await fetch(rpcUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
-  })
-  if (!response.ok) {
-    throw new Error(`RPC request failed: HTTP ${response.status}`)
-  }
-
-  const data: unknown = await response.json()
+  const data: unknown = await postJsonRpc(rpcUrl, payload)
   if (!Array.isArray(data) || data.length !== calls.length) {
     throw new Error("Malformed JSON-RPC batch response")
   }
 
   const results: string[] = new Array(calls.length)
+  const seen = new Set<number>()
   for (const entry of data as Array<{
     id?: unknown
     result?: unknown
@@ -170,13 +165,22 @@ async function ethCallBatch(
     ) {
       throw new Error("JSON-RPC response with out-of-range id")
     }
+    if (seen.has(entry.id)) {
+      throw new Error(`JSON-RPC response with duplicate id ${entry.id}`)
+    }
     if (entry.error) {
       throw new Error(`RPC error: ${entry.error.message ?? "unknown"}`)
     }
     if (typeof entry.result !== "string") {
       throw new Error("JSON-RPC response missing result")
     }
+    seen.add(entry.id)
     results[entry.id] = entry.result
+  }
+  // Unique, in-range ids covering exactly `calls.length` slots means every
+  // slot is filled — so the `string[]` type holds no holes.
+  if (seen.size !== calls.length) {
+    throw new Error("JSON-RPC batch response missing results")
   }
   return results
 }

--- a/lib/src/utils/postage-contract.ts
+++ b/lib/src/utils/postage-contract.ts
@@ -188,6 +188,9 @@ async function ethCallBatch(
  *
  * @param rpcUrl - Gnosis Chain JSON-RPC URL
  * @param batchId - 32-byte hex batch ID, with or without `0x` prefix
+ * @param contractAddress - PostageStamp contract address to read from. Defaults
+ *          to the Gnosis mainnet deployment; override for a local dev chain
+ *          (bee-compose anvil deploys it at a different address).
  * @returns The decoded state, or `undefined` if the batch is unknown to the
  *          contract (zero owner) or the RPC request fails. Never throws — the
  *          UI falls back to other expiry sources on `undefined`.
@@ -195,21 +198,22 @@ async function ethCallBatch(
 export async function fetchOnChainBatchState(
   rpcUrl: string,
   batchId: string,
+  contractAddress: string = POSTAGE_STAMP_CONTRACT_ADDRESS,
 ): Promise<OnChainBatchState | undefined> {
   try {
     const id = normalizeBatchId(batchId)
     const [batchesResult, outPaymentResult, lastPriceResult] =
       await ethCallBatch(rpcUrl, [
         {
-          to: POSTAGE_STAMP_CONTRACT_ADDRESS,
+          to: contractAddress,
           data: `0x${SELECTOR_BATCHES}${id}`,
         },
         {
-          to: POSTAGE_STAMP_CONTRACT_ADDRESS,
+          to: contractAddress,
           data: `0x${SELECTOR_CURRENT_TOTAL_OUT_PAYMENT}`,
         },
         {
-          to: POSTAGE_STAMP_CONTRACT_ADDRESS,
+          to: contractAddress,
           data: `0x${SELECTOR_LAST_PRICE}`,
         },
       ])
@@ -261,14 +265,17 @@ export function calculateContractTTLSeconds(
  * batch the contract knows about, regardless of whether the configured Bee node
  * tracks it.
  *
+ * @param contractAddress - PostageStamp contract address (defaults to mainnet;
+ *          override for a local dev chain).
  * @returns Remaining TTL in seconds (`0` when expired), or `undefined` when the
  *          batch is unknown, the RPC request fails, or the price is zero.
  */
 export async function fetchBatchTTLFromContract(
   rpcUrl: string,
   batchId: string,
+  contractAddress: string = POSTAGE_STAMP_CONTRACT_ADDRESS,
 ): Promise<number | undefined> {
-  const state = await fetchOnChainBatchState(rpcUrl, batchId)
+  const state = await fetchOnChainBatchState(rpcUrl, batchId, contractAddress)
   if (state === undefined) {
     return undefined
   }
@@ -290,15 +297,18 @@ export async function fetchBatchTTLFromContract(
  * @param gnosisRpcUrl - Gnosis Chain JSON-RPC URL (for the contract read)
  * @param beeUrl - Bee node URL (fallback)
  * @param batchId - 32-byte hex batch ID, with or without `0x` prefix
+ * @param contractAddress - PostageStamp contract address for the contract read
+ *          (defaults to mainnet; override for a local dev chain).
  * @returns Remaining TTL in seconds, or `undefined` if neither source can answer.
  */
 export async function fetchAuthoritativeBatchTTL(
   gnosisRpcUrl: string,
   beeUrl: string,
   batchId: string,
+  contractAddress: string = POSTAGE_STAMP_CONTRACT_ADDRESS,
 ): Promise<number | undefined> {
   return (
-    (await fetchBatchTTLFromContract(gnosisRpcUrl, batchId)) ??
+    (await fetchBatchTTLFromContract(gnosisRpcUrl, batchId, contractAddress)) ??
     (await fetchBatchTTL(beeUrl, batchId))
   )
 }

--- a/lib/src/utils/postage-contract.ts
+++ b/lib/src/utils/postage-contract.ts
@@ -1,0 +1,304 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Reads postage batch state directly from the Swarm PostageStamp contract on
+ * Gnosis Chain, by batch ID, over a plain JSON-RPC `eth_call`.
+ *
+ * This is the ground truth for a stamp's remaining lifetime: it is the exact
+ * data a Bee node uses internally to compute `batchTTL`, but it does not
+ * require the node to know about the batch. A stamp added manually (or owned
+ * by a different node) has no entry in `GET /stamps/{id}`, so the Bee-node TTL
+ * path falls back to a constant-price approximation that drifts as the chain
+ * price moves (see issue #344). Querying the contract avoids that entirely.
+ *
+ * The contract exposes the per-chunk normalised balance accounting used by the
+ * storage-incentives system:
+ *   remainingBalancePerChunk = normalisedBalance - currentTotalOutPayment()
+ *   remainingBlocks          = remainingBalancePerChunk / lastPrice()
+ *   ttlSeconds               = remainingBlocks * GNOSIS_BLOCK_TIME
+ */
+
+import { fetchBatchTTL, GNOSIS_BLOCK_TIME } from "./ttl"
+
+/**
+ * PostageStamp contract address on Gnosis Chain. Lowercased — RPC nodes accept
+ * a non-checksummed `to`, and lowercasing sidesteps any checksum mistake.
+ */
+export const POSTAGE_STAMP_CONTRACT_ADDRESS =
+  "0x45a1502382541cd610cc9068e88727426b696293"
+
+/**
+ * 4-byte function selectors (first 4 bytes of keccak256 of the signature).
+ * Hardcoded so the library needs no keccak/ABI dependency for these fixed,
+ * argument-free (or single-bytes32) calls.
+ */
+const SELECTOR_BATCHES = "c81e25ab" // batches(bytes32)
+const SELECTOR_CURRENT_TOTAL_OUT_PAYMENT = "51b17cd0" // currentTotalOutPayment()
+const SELECTOR_LAST_PRICE = "053f14da" // lastPrice()
+
+const HEX_WORD_LENGTH = 64 // 32 bytes as hex
+const BATCH_ID_HEX_LENGTH = 64 // 32 bytes as hex
+const ADDRESS_HEX_LENGTH = 40 // 20 bytes as hex
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+/**
+ * Decoded `batches(bytes32)` tuple. Field names mirror the contract's `Batch`
+ * struct. `normalisedBalance` is a per-chunk value denominated in PLUR; it is
+ * the cumulative outpayment level at which this batch runs out.
+ */
+export interface OnChainPostageBatch {
+  owner: string
+  depth: number
+  bucketDepth: number
+  immutableFlag: boolean
+  normalisedBalance: bigint
+  lastUpdatedBlockNumber: bigint
+}
+
+/**
+ * A consistent snapshot of one batch plus the global accounting needed to turn
+ * its `normalisedBalance` into a remaining TTL.
+ */
+export interface OnChainBatchState {
+  batch: OnChainPostageBatch
+  /** Per-chunk cumulative outpayment so far, in PLUR (`currentTotalOutPayment()`). */
+  currentTotalOutPayment: bigint
+  /** Per-chunk per-block storage price, in PLUR (`lastPrice()`). */
+  lastPrice: bigint
+}
+
+/**
+ * Normalises a batch ID to 64 lowercase hex chars (no `0x`) for ABI encoding.
+ * @throws if the input is not a 32-byte hex string.
+ */
+function normalizeBatchId(batchId: string): string {
+  const stripped = batchId.startsWith("0x") ? batchId.slice(2) : batchId
+  const lower = stripped.toLowerCase()
+  if (!new RegExp(`^[0-9a-f]{${BATCH_ID_HEX_LENGTH}}$`).test(lower)) {
+    throw new Error(`Invalid batch ID: ${batchId}`)
+  }
+  return lower
+}
+
+/** Splits a `0x`-prefixed return payload into 32-byte (64-hex) words. */
+function toWords(hex: string): string[] {
+  const body = hex.startsWith("0x") ? hex.slice(2) : hex
+  const words: string[] = []
+  for (let i = 0; i < body.length; i += HEX_WORD_LENGTH) {
+    words.push(body.slice(i, i + HEX_WORD_LENGTH))
+  }
+  return words
+}
+
+/**
+ * Decodes the ABI-encoded return of `batches(bytes32)` — a static tuple of
+ * `(address, uint8, uint8, bool, uint256, uint256)`, i.e. six 32-byte words.
+ * @throws if the payload is too short to hold the tuple.
+ */
+export function decodeBatches(hex: string): OnChainPostageBatch {
+  const words = toWords(hex)
+  const EXPECTED_WORDS = 6
+  if (words.length < EXPECTED_WORDS) {
+    throw new Error(`Unexpected batches() return length: ${hex}`)
+  }
+  return {
+    owner: `0x${words[0].slice(HEX_WORD_LENGTH - ADDRESS_HEX_LENGTH)}`,
+    depth: Number(BigInt(`0x${words[1]}`)),
+    bucketDepth: Number(BigInt(`0x${words[2]}`)),
+    immutableFlag: BigInt(`0x${words[3]}`) !== 0n,
+    normalisedBalance: BigInt(`0x${words[4]}`),
+    lastUpdatedBlockNumber: BigInt(`0x${words[5]}`),
+  }
+}
+
+/** Decodes a single-`uint256` return payload to a BigInt. */
+export function decodeUint(hex: string): bigint {
+  const body = hex.startsWith("0x") ? hex.slice(2) : hex
+  if (body.length === 0) {
+    throw new Error("Empty uint return")
+  }
+  return BigInt(`0x${body}`)
+}
+
+interface JsonRpcCall {
+  to: string
+  data: string
+}
+
+/**
+ * Sends a batched `eth_call` JSON-RPC request and returns the raw hex result of
+ * each call, in the same order as `calls`. Responses are matched back by id
+ * because JSON-RPC does not guarantee batch ordering.
+ * @throws if the transport fails or any sub-call returns an error/empty result.
+ */
+async function ethCallBatch(
+  rpcUrl: string,
+  calls: JsonRpcCall[],
+): Promise<string[]> {
+  const payload = calls.map((call, index) => ({
+    jsonrpc: "2.0",
+    id: index,
+    method: "eth_call",
+    params: [{ to: call.to, data: call.data }, "latest"],
+  }))
+
+  const response = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  })
+  if (!response.ok) {
+    throw new Error(`RPC request failed: HTTP ${response.status}`)
+  }
+
+  const data: unknown = await response.json()
+  if (!Array.isArray(data) || data.length !== calls.length) {
+    throw new Error("Malformed JSON-RPC batch response")
+  }
+
+  const results: string[] = new Array(calls.length)
+  for (const entry of data as Array<{
+    id?: unknown
+    result?: unknown
+    error?: { message?: string }
+  }>) {
+    if (
+      typeof entry.id !== "number" ||
+      entry.id < 0 ||
+      entry.id >= calls.length
+    ) {
+      throw new Error("JSON-RPC response with out-of-range id")
+    }
+    if (entry.error) {
+      throw new Error(`RPC error: ${entry.error.message ?? "unknown"}`)
+    }
+    if (typeof entry.result !== "string") {
+      throw new Error("JSON-RPC response missing result")
+    }
+    results[entry.id] = entry.result
+  }
+  return results
+}
+
+/**
+ * Fetches a consistent on-chain snapshot of a postage batch from the
+ * PostageStamp contract: its `batches(batchId)` tuple plus the global
+ * `currentTotalOutPayment()` and `lastPrice()`.
+ *
+ * @param rpcUrl - Gnosis Chain JSON-RPC URL
+ * @param batchId - 32-byte hex batch ID, with or without `0x` prefix
+ * @returns The decoded state, or `undefined` if the batch is unknown to the
+ *          contract (zero owner) or the RPC request fails. Never throws — the
+ *          UI falls back to other expiry sources on `undefined`.
+ */
+export async function fetchOnChainBatchState(
+  rpcUrl: string,
+  batchId: string,
+): Promise<OnChainBatchState | undefined> {
+  try {
+    const id = normalizeBatchId(batchId)
+    const [batchesResult, outPaymentResult, lastPriceResult] =
+      await ethCallBatch(rpcUrl, [
+        {
+          to: POSTAGE_STAMP_CONTRACT_ADDRESS,
+          data: `0x${SELECTOR_BATCHES}${id}`,
+        },
+        {
+          to: POSTAGE_STAMP_CONTRACT_ADDRESS,
+          data: `0x${SELECTOR_CURRENT_TOTAL_OUT_PAYMENT}`,
+        },
+        {
+          to: POSTAGE_STAMP_CONTRACT_ADDRESS,
+          data: `0x${SELECTOR_LAST_PRICE}`,
+        },
+      ])
+
+    const batch = decodeBatches(batchesResult)
+    // A non-existent batch decodes to an all-zero tuple. Treat it as unknown so
+    // callers fall back rather than render a bogus "expired" date.
+    if (batch.owner === ZERO_ADDRESS) {
+      return undefined
+    }
+
+    return {
+      batch,
+      currentTotalOutPayment: decodeUint(outPaymentResult),
+      lastPrice: decodeUint(lastPriceResult),
+    }
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Computes a batch's remaining TTL in seconds from an on-chain snapshot, using
+ * the same integer math as the storage-incentives contract and Bee node.
+ *
+ * @returns Remaining seconds (`0` when expired), or `undefined` when the price
+ *          is zero — the batch then drains at no cost and has no finite expiry,
+ *          which we cannot render as a date. On mainnet the PriceOracle floor
+ *          keeps `lastPrice` well above zero, so this only guards dev chains.
+ */
+export function calculateContractTTLSeconds(
+  state: OnChainBatchState,
+): number | undefined {
+  const remaining = state.batch.normalisedBalance - state.currentTotalOutPayment
+  if (remaining <= 0n) {
+    return 0
+  }
+  if (state.lastPrice <= 0n) {
+    return undefined
+  }
+  const remainingBlocks = remaining / state.lastPrice
+  return Number(remainingBlocks * BigInt(GNOSIS_BLOCK_TIME))
+}
+
+/**
+ * Convenience wrapper: fetches a batch's on-chain state and returns its
+ * remaining TTL in seconds. This is the contract-backed counterpart to
+ * {@link fetchBatchTTL} (which reads the Bee node), and unlike it works for any
+ * batch the contract knows about, regardless of whether the configured Bee node
+ * tracks it.
+ *
+ * @returns Remaining TTL in seconds (`0` when expired), or `undefined` when the
+ *          batch is unknown, the RPC request fails, or the price is zero.
+ */
+export async function fetchBatchTTLFromContract(
+  rpcUrl: string,
+  batchId: string,
+): Promise<number | undefined> {
+  const state = await fetchOnChainBatchState(rpcUrl, batchId)
+  if (state === undefined) {
+    return undefined
+  }
+  return calculateContractTTLSeconds(state)
+}
+
+/**
+ * Resolves a batch's remaining TTL (seconds) from the most authoritative source
+ * available, in order:
+ *   1. The PostageStamp contract, read directly by batchId — ground truth that
+ *      works for any batch, even one the configured Bee node has never seen.
+ *   2. The Bee node's `batchTTL` — also live chain state, but only for batches
+ *      the node tracks.
+ *
+ * This is the single canonical "best remaining TTL" lookup; callers layer a
+ * price-based approximation ({@link calculateTTLSeconds}) on top when both
+ * sources return `undefined`.
+ *
+ * @param gnosisRpcUrl - Gnosis Chain JSON-RPC URL (for the contract read)
+ * @param beeUrl - Bee node URL (fallback)
+ * @param batchId - 32-byte hex batch ID, with or without `0x` prefix
+ * @returns Remaining TTL in seconds, or `undefined` if neither source can answer.
+ */
+export async function fetchAuthoritativeBatchTTL(
+  gnosisRpcUrl: string,
+  beeUrl: string,
+  batchId: string,
+): Promise<number | undefined> {
+  return (
+    (await fetchBatchTTLFromContract(gnosisRpcUrl, batchId)) ??
+    (await fetchBatchTTL(beeUrl, batchId))
+  )
+}

--- a/lib/src/utils/postage-contract.ts
+++ b/lib/src/utils/postage-contract.ts
@@ -30,6 +30,41 @@ export const POSTAGE_STAMP_CONTRACT_ADDRESS =
   "0x45a1502382541cd610cc9068e88727426b696293"
 
 /**
+ * True when an RPC URL targets a local dev chain (bee-compose anvil). A
+ * dev-deployed PostageStamp address is only valid against such a node.
+ */
+function isLocalRpcUrl(rpcUrl: string): boolean {
+  try {
+    const { hostname } = new URL(rpcUrl)
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "0.0.0.0"
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Picks the PostageStamp contract address that matches the chain `rpcUrl` points
+ * at. A dev-override address (bee-compose anvil) is only honoured against a local
+ * RPC; against any remote RPC (Gnosis mainnet) it would read a nonexistent
+ * contract — `eth_call` returns empty, the batch looks unknown, and callers
+ * silently fall back to a bogus price estimate. Tying the address to the RPC
+ * network stops the two from drifting apart, which is what produced wildly wrong
+ * estimated expiry dates when a dev build read a mainnet batch (#344).
+ */
+export function resolvePostageStampContractAddress(
+  rpcUrl: string,
+  localContractAddress?: string,
+): string {
+  return isLocalRpcUrl(rpcUrl) && localContractAddress
+    ? localContractAddress
+    : POSTAGE_STAMP_CONTRACT_ADDRESS
+}
+
+/**
  * 4-byte function selectors (first 4 bytes of keccak256 of the signature).
  * Hardcoded so the library needs no keccak/ABI dependency for these fixed,
  * argument-free (or single-bytes32) calls.
@@ -199,11 +234,29 @@ async function ethCallBatch(
  *          contract (zero owner) or the RPC request fails. Never throws — the
  *          UI falls back to other expiry sources on `undefined`.
  */
-export async function fetchOnChainBatchState(
+/**
+ * Outcome of an on-chain batch read, keeping the two failure modes distinct:
+ *   - `found` — the contract knows the batch (non-zero owner).
+ *   - `not-found` — the contract returned an all-zero tuple; the batch
+ *     authoritatively does not exist on this chain.
+ *   - `error` — the RPC request failed or returned an undecodable payload, so
+ *     existence is *unknown* (not the same as "does not exist").
+ */
+export type OnChainBatchResult =
+  | { status: "found"; state: OnChainBatchState }
+  | { status: "not-found" }
+  | { status: "error" }
+
+/**
+ * Reads a batch's on-chain state, distinguishing "definitively absent" from
+ * "couldn't check". {@link fetchOnChainBatchState} is the simpler wrapper that
+ * collapses both into `undefined`.
+ */
+export async function fetchOnChainBatchStateResult(
   rpcUrl: string,
   batchId: string,
   contractAddress: string = POSTAGE_STAMP_CONTRACT_ADDRESS,
-): Promise<OnChainBatchState | undefined> {
+): Promise<OnChainBatchResult> {
   try {
     const id = normalizeBatchId(batchId)
     const [batchesResult, outPaymentResult, lastPriceResult] =
@@ -223,20 +276,36 @@ export async function fetchOnChainBatchState(
       ])
 
     const batch = decodeBatches(batchesResult)
-    // A non-existent batch decodes to an all-zero tuple. Treat it as unknown so
-    // callers fall back rather than render a bogus "expired" date.
+    // A non-existent batch decodes to an all-zero tuple — a definitive "no such
+    // batch on this chain", distinct from an RPC error below.
     if (batch.owner === ZERO_ADDRESS) {
-      return undefined
+      return { status: "not-found" }
     }
 
     return {
-      batch,
-      currentTotalOutPayment: decodeUint(outPaymentResult),
-      lastPrice: decodeUint(lastPriceResult),
+      status: "found",
+      state: {
+        batch,
+        currentTotalOutPayment: decodeUint(outPaymentResult),
+        lastPrice: decodeUint(lastPriceResult),
+      },
     }
   } catch {
-    return undefined
+    return { status: "error" }
   }
+}
+
+export async function fetchOnChainBatchState(
+  rpcUrl: string,
+  batchId: string,
+  contractAddress: string = POSTAGE_STAMP_CONTRACT_ADDRESS,
+): Promise<OnChainBatchState | undefined> {
+  const result = await fetchOnChainBatchStateResult(
+    rpcUrl,
+    batchId,
+    contractAddress,
+  )
+  return result.status === "found" ? result.state : undefined
 }
 
 /**
@@ -301,18 +370,83 @@ export async function fetchBatchTTLFromContract(
  * @param gnosisRpcUrl - Gnosis Chain JSON-RPC URL (for the contract read)
  * @param beeUrl - Bee node URL (fallback)
  * @param batchId - 32-byte hex batch ID, with or without `0x` prefix
- * @param contractAddress - PostageStamp contract address for the contract read
- *          (defaults to mainnet; override for a local dev chain).
+ * @param localContractAddress - PostageStamp address for a local dev chain. Only
+ *          honoured when `gnosisRpcUrl` targets a local node; against any remote
+ *          RPC the Gnosis mainnet deployment is used regardless (see
+ *          {@link resolvePostageStampContractAddress}).
  * @returns Remaining TTL in seconds, or `undefined` if neither source can answer.
  */
 export async function fetchAuthoritativeBatchTTL(
   gnosisRpcUrl: string,
   beeUrl: string,
   batchId: string,
-  contractAddress: string = POSTAGE_STAMP_CONTRACT_ADDRESS,
+  localContractAddress?: string,
 ): Promise<number | undefined> {
+  const contractAddress = resolvePostageStampContractAddress(
+    gnosisRpcUrl,
+    localContractAddress,
+  )
   return (
     (await fetchBatchTTLFromContract(gnosisRpcUrl, batchId, contractAddress)) ??
     (await fetchBatchTTL(beeUrl, batchId))
   )
+}
+
+/**
+ * Existence + remaining TTL of a batch, for UI that must tell "this batch does
+ * not exist on the configured chain" apart from "we couldn't reach the chain".
+ *   - `found` — carries `ttlSeconds` (remaining TTL, or `undefined` when the
+ *     price is zero so there is no finite expiry).
+ *   - `not-found` — the PostageStamp contract authoritatively has no such batch.
+ *   - `unreachable` — neither the contract nor the Bee node could be reached, so
+ *     existence is unknown.
+ */
+export type BatchResolution =
+  | { status: "found"; ttlSeconds: number | undefined }
+  | { status: "not-found" }
+  | { status: "unreachable" }
+
+/**
+ * Resolves a batch's existence and remaining TTL, treating the on-chain contract
+ * as the source of truth. A contract `not-found` is authoritative — a Bee node
+ * that happens to track the batch cannot override the chain. The Bee node is
+ * consulted only when the contract read itself failed (RPC unreachable), as a
+ * best-effort second opinion.
+ *
+ * Unlike {@link fetchAuthoritativeBatchTTL} (best-effort TTL, falls back to Bee
+ * even on contract `not-found`), this is the stricter lookup for existence-aware
+ * UI.
+ *
+ * @param localContractAddress - PostageStamp address for a local dev chain; only
+ *          honoured against a local RPC (see {@link resolvePostageStampContractAddress}).
+ */
+export async function resolveBatchStatus(
+  gnosisRpcUrl: string,
+  beeUrl: string,
+  batchId: string,
+  localContractAddress?: string,
+): Promise<BatchResolution> {
+  const contractAddress = resolvePostageStampContractAddress(
+    gnosisRpcUrl,
+    localContractAddress,
+  )
+  const contract = await fetchOnChainBatchStateResult(
+    gnosisRpcUrl,
+    batchId,
+    contractAddress,
+  )
+  if (contract.status === "found") {
+    return {
+      status: "found",
+      ttlSeconds: calculateContractTTLSeconds(contract.state),
+    }
+  }
+  if (contract.status === "not-found") {
+    return { status: "not-found" }
+  }
+  // Contract read errored — fall back to the Bee node as a second opinion.
+  const beeTtl = await fetchBatchTTL(beeUrl, batchId)
+  return beeTtl !== undefined
+    ? { status: "found", ttlSeconds: beeTtl }
+    : { status: "unreachable" }
 }

--- a/lib/src/utils/ttl.ts
+++ b/lib/src/utils/ttl.ts
@@ -5,6 +5,8 @@
  * TTL (Time To Live) calculation and formatting utilities for postage stamps
  */
 
+import { postJsonRpc } from "./json-rpc"
+
 /**
  * Gnosis Chain block time in seconds
  */
@@ -138,18 +140,13 @@ export async function getBlockTimestamp(
   rpcUrl: string,
   blockNumber: number,
 ): Promise<number> {
-  const response = await fetch(rpcUrl, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      jsonrpc: "2.0",
-      method: "eth_getBlockByNumber",
-      params: [`0x${blockNumber.toString(16)}`, false],
-      id: 1,
-    }),
-  })
+  const data = (await postJsonRpc(rpcUrl, {
+    jsonrpc: "2.0",
+    method: "eth_getBlockByNumber",
+    params: [`0x${blockNumber.toString(16)}`, false],
+    id: 1,
+  })) as { error?: { message?: string }; result?: { timestamp: string } }
 
-  const data = await response.json()
   if (data.error) {
     throw new Error(`RPC error: ${data.error.message}`)
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dev:demo:new": "PUBLIC_ID_DOMAIN=http://localhost:5500 pnpm --filter @swarm-id/demo exec vite dev --port 3500",
     "dev:demo:legacy": "PUBLIC_ID_DOMAIN=http://localhost:5510 pnpm dev:demo",
     "dev:lib": "pnpm --filter @snaha/swarm-id build:watch",
-    "dev:ui:legacy": "pnpm --filter swarm-identity dev",
+    "dev:ui:legacy": "VITE_POSTAGE_STAMP_CONTRACT_ADDRESS=0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512 pnpm --filter swarm-identity dev",
     "dev:ui:new": "pnpm --filter @swarm-id/ui dev",
     "dev:docs": "pnpm --filter @swarm-id/docs dev",
     "build": "pnpm -r --workspace-concurrency=1 build",

--- a/swarm-ui/src/app.d.ts
+++ b/swarm-ui/src/app.d.ts
@@ -11,6 +11,13 @@ declare global {
     // interface PageState {}
     // interface Platform {}
   }
+
+  // Optional override for the PostageStamp contract address used in on-chain
+  // stamp-TTL reads. Unset in production (falls back to the mainnet default);
+  // set to the local anvil deployment for development. See $lib/constants.
+  interface ImportMetaEnv {
+    readonly VITE_POSTAGE_STAMP_CONTRACT_ADDRESS?: string
+  }
 }
 
 export {}

--- a/swarm-ui/src/lib/components/postage-stamp-form.svelte
+++ b/swarm-ui/src/lib/components/postage-stamp-form.svelte
@@ -59,88 +59,116 @@
     return undefined
   })
 
+  // Validation errors are surfaced only when focus leaves a field, never while
+  // typing. These hold the error snapshot captured at blur (the derived *Error
+  // values above stay live and drive `disabled`). Mutated only in focus handlers,
+  // so typing in a field never changes its displayed error.
+  let batchIDErrorShown = $state<string | undefined>(undefined)
+  let numberErrorShown = $state<string | undefined>(undefined)
+  let signerKeyErrorShown = $state<string | undefined>(undefined)
+
+  // Snapshot the current error when focus leaves a field — but not when the whole
+  // window loses focus (e.g. alt-tabbing to an editor to copy a value).
+  function snapshotOnBlur(snapshot: () => void) {
+    if (document.hasFocus()) snapshot()
+  }
+
   $effect(() => {
-    disabled = !batchID || !depth || !!batchIDError || !!numberError || !!signerKeyError
+    disabled =
+      !batchID || !depth || !signerKey || !!batchIDError || !!numberError || !!signerKeyError
   })
 </script>
 
 <Vertical>
   <!-- Row 1 -->
-  <div class="input-wrapper">
+  <div
+    class="input-wrapper"
+    onfocusin={() => (batchIDErrorShown = undefined)}
+    onfocusout={() => snapshotOnBlur(() => (batchIDErrorShown = batchIDError))}
+  >
     <Input
       variant="outline"
       dimension="compact"
       name="batchID"
       bind:value={batchID}
-      error={batchIDError}
+      error={batchIDErrorShown}
       label="Stamp ID"
       helperText="Don't reuse stamps across accounts and identities"
     />
   </div>
-  {#if batchIDError}
+  {#if batchIDErrorShown}
     <div class="error-full-width">
-      <ErrorMessage>{batchIDError}</ErrorMessage>
+      <ErrorMessage>{batchIDErrorShown}</ErrorMessage>
     </div>
   {/if}
 
   <!-- Row 2 -->
   <Vertical>
-    <ResponsiveLayout --responsive-justify-content="stretch">
-      <FormattedNumberInput
-        variant="outline"
-        dimension="compact"
-        name="depth"
-        locale={undefined}
-        bind:value={depth}
-        label="Depth"
-        class="flex-grow"
-        min={0}
-        max={255}
-        step={1}
-      />
-      <FormattedBigintInput
-        variant="outline"
-        dimension="compact"
-        name="amount"
-        locale={undefined}
-        bind:value={amount}
-        label="Amount"
-        class="flex-grow"
-        min={0n}
-      />
-      <FormattedNumberInput
-        variant="outline"
-        dimension="compact"
-        name="blockNumber"
-        locale={undefined}
-        bind:value={blockNumber}
-        label="Block number"
-        class="flex-grow"
-        min={0}
-        step={1}
-      />
-    </ResponsiveLayout>
-    {#if numberError}
+    <div
+      onfocusin={() => (numberErrorShown = undefined)}
+      onfocusout={() => snapshotOnBlur(() => (numberErrorShown = numberError))}
+    >
+      <ResponsiveLayout --responsive-justify-content="stretch">
+        <FormattedNumberInput
+          variant="outline"
+          dimension="compact"
+          name="depth"
+          locale={undefined}
+          bind:value={depth}
+          label="Depth"
+          class="flex-grow"
+          min={0}
+          max={255}
+          step={1}
+        />
+        <FormattedBigintInput
+          variant="outline"
+          dimension="compact"
+          name="amount"
+          locale={undefined}
+          bind:value={amount}
+          label="Amount"
+          class="flex-grow"
+          min={0n}
+        />
+        <FormattedNumberInput
+          variant="outline"
+          dimension="compact"
+          name="blockNumber"
+          locale={undefined}
+          bind:value={blockNumber}
+          label="Block number"
+          class="flex-grow"
+          min={0}
+          step={1}
+        />
+      </ResponsiveLayout>
+    </div>
+    {#if numberErrorShown}
       <div class="error-full-width">
-        <ErrorMessage>{numberError}</ErrorMessage>
+        <ErrorMessage>{numberErrorShown}</ErrorMessage>
       </div>
     {/if}
   </Vertical>
 
   <!-- Row 3 -->
-  <div class="input-wrapper">
+  <div
+    class="input-wrapper"
+    onfocusin={() => (signerKeyErrorShown = undefined)}
+    onfocusout={() => snapshotOnBlur(() => (signerKeyErrorShown = signerKeyError))}
+  >
     <Input
       variant="outline"
       dimension="compact"
       name="signerKey"
       bind:value={signerKey}
-      error={signerKeyError}
+      error={signerKeyErrorShown}
       label="Signer key"
     />
   </div>
-  {#if signerKeyError}
+  {#if signerKeyErrorShown}
     <div class="error-full-width">
-      <ErrorMessage>{signerKeyError}</ErrorMessage>
+      <ErrorMessage>{signerKeyErrorShown}</ErrorMessage>
     </div>
   {/if}
 

--- a/swarm-ui/src/lib/constants.ts
+++ b/swarm-ui/src/lib/constants.ts
@@ -10,3 +10,6 @@
 // `dev:swarm-ui`) and must also point the Gnosis RPC URL at the local node
 // (http://localhost:9545) via the identity UI's network settings.
 export const postageStampContractAddress = import.meta.env.VITE_POSTAGE_STAMP_CONTRACT_ADDRESS
+
+// Milliseconds per second — for converting TTL/Unix seconds to JS `Date` ms.
+export const MS_PER_SECOND = 1000

--- a/swarm-ui/src/lib/constants.ts
+++ b/swarm-ui/src/lib/constants.ts
@@ -1,0 +1,12 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Optional override for the PostageStamp contract address used in on-chain
+// stamp-expiry (TTL) reads. `undefined` when the env var is unset — the lib's
+// TTL functions then apply their Gnosis mainnet default, so the app never needs
+// to know the mainnet address itself. Production builds set nothing and get
+// mainnet; local development against the bee-compose anvil chain sets
+// VITE_POSTAGE_STAMP_CONTRACT_ADDRESS inline in the dev script (see package.json
+// `dev:swarm-ui`) and must also point the Gnosis RPC URL at the local node
+// (http://localhost:9545) via the identity UI's network settings.
+export const postageStampContractAddress = import.meta.env.VITE_POSTAGE_STAMP_CONTRACT_ADDRESS

--- a/swarm-ui/src/routes/(app)/dev/+page.svelte
+++ b/swarm-ui/src/routes/(app)/dev/+page.svelte
@@ -30,6 +30,7 @@
     fetchChainState,
     formatTTL,
   } from '@snaha/swarm-id'
+  import { MS_PER_SECOND } from '$lib/constants'
   import { SvelteMap } from 'svelte/reactivity'
 
   // How many days of validity to fund by default when auto-filling the
@@ -37,8 +38,6 @@
   // POST /stamps; 7 days gives comfortable headroom for dev testing without
   // re-buying constantly.
   const DEFAULT_STAMP_DAYS = 7
-
-  const MS_PER_SECOND = 1000
 
   // Renders a listed stamp's remaining lifetime as "<ttl> (<date>)". batchTTL
   // comes straight from the Bee node's /stamps response — authoritative for the

--- a/swarm-ui/src/routes/(app)/dev/+page.svelte
+++ b/swarm-ui/src/routes/(app)/dev/+page.svelte
@@ -28,6 +28,7 @@
     calculateStampAmountForDays,
     derivePostageSignerKey,
     fetchChainState,
+    formatTTL,
   } from '@snaha/swarm-id'
   import { SvelteMap } from 'svelte/reactivity'
 
@@ -36,6 +37,19 @@
   // POST /stamps; 7 days gives comfortable headroom for dev testing without
   // re-buying constantly.
   const DEFAULT_STAMP_DAYS = 7
+
+  const MS_PER_SECOND = 1000
+
+  // Renders a listed stamp's remaining lifetime as "<ttl> (<date>)". batchTTL
+  // comes straight from the Bee node's /stamps response — authoritative for the
+  // batches it tracks, which is exactly what this list shows (no contract read
+  // needed here, and the default chain is local where the mainnet PostageStamp
+  // contract isn't deployed).
+  function formatStampExpiry(batchTTL: number): string {
+    if (!batchTTL || batchTTL <= 0) return 'Expired'
+    const date = new Date(Date.now() + batchTTL * MS_PER_SECOND).toLocaleDateString()
+    return `${formatTTL(batchTTL)} (${date})`
+  }
 
   // Tab state
   type Tab = 'overview' | 'stamps' | 'sync' | 'devices'
@@ -850,6 +864,9 @@ Check console logs for details:
                 </Typography>
                 <Typography variant="small" style="color: var(--colors-medium);">
                   Utilization: {stamp.utilization}
+                </Typography>
+                <Typography variant="small" style="color: var(--colors-medium);">
+                  Expires: {formatStampExpiry(stamp.batchTTL)}
                 </Typography>
                 {@const assignment = stampAssignments.get(stamp.batchID)}
                 <Typography variant="small" style="color: var(--colors-medium);">

--- a/swarm-ui/src/routes/(app)/identity/[id]/stamps/+page.svelte
+++ b/swarm-ui/src/routes/(app)/identity/[id]/stamps/+page.svelte
@@ -26,9 +26,10 @@
   import WarningAltFilled from 'carbon-icons-svelte/lib/WarningAltFilled.svelte'
   import {
     calculateTTLSeconds,
-    fetchAuthoritativeBatchTTL,
+    resolveBatchStatus,
     fetchSwarmPrice,
     getBlockTimestamp,
+    type BatchResolution,
   } from '@snaha/swarm-id'
   import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
   import { postageStampContractAddress, MS_PER_SECOND } from '$lib/constants'
@@ -39,6 +40,11 @@
   const BYTES_PER_MB = BYTES_PER_KB * BYTES_PER_KB
   const BYTES_PER_GB = BYTES_PER_MB * BYTES_PER_KB
   const SECONDS_PER_MONTH = 2592000
+  const MONTHS_PER_YEAR = 12
+  // A constant-price estimate beyond this is treated as nonsense (e.g. a stale
+  // price epoch or a mis-entered amount can yield year-40000 dates, #344). We'd
+  // rather show no expiry than an absurd one.
+  const MAX_PLAUSIBLE_STAMP_TTL_YEARS = 100
   const MAX_UTILIZATION_PERCENT = 100
   const EXPIRY_SOON_LIFETIME_FRACTION = 0.1
   const BEEPORT_TOPUP_URL = 'https://beeport.eth.limo/?topup='
@@ -67,6 +73,10 @@
   // for price changes since stamp creation that the Swarmscan-price
   // approximation cannot.
   const chainExpiryMs = new SvelteMap<string, number>()
+  // Per-batch on-chain existence status (no entry = still resolving). Drives the
+  // card: a batch absent from / unverifiable against the configured chain shows a
+  // notice instead of fabricated capacity/expiry details.
+  const batchStatus = new SvelteMap<string, BatchResolution['status']>()
 
   async function fetchBlockTimestamp(blockNumber: number): Promise<number | undefined> {
     if (blockTimestamps.has(blockNumber)) {
@@ -87,17 +97,18 @@
 
   async function fetchStampExpiry(stamp: PostageStamp): Promise<void> {
     const batchId = stamp.batchID.toHex()
-    // Resolve remaining TTL from the most authoritative source: the on-chain
-    // PostageStamp contract first (works for any batchId, even one the
-    // configured Bee node has never seen), then the Bee node's batchTTL.
-    const ttlSeconds = await fetchAuthoritativeBatchTTL(
+    // Resolve existence + remaining TTL from the PostageStamp contract (the
+    // source of truth, works for any batchId the Bee node never saw), falling
+    // back to the Bee node only when the contract read itself fails.
+    const resolution = await resolveBatchStatus(
       networkSettingsStore.gnosisRpcUrl,
       networkSettingsStore.beeNodeUrl,
       batchId,
       postageStampContractAddress,
     )
-    if (ttlSeconds !== undefined) {
-      chainExpiryMs.set(batchId, Date.now() + ttlSeconds * MS_PER_SECOND)
+    batchStatus.set(batchId, resolution.status)
+    if (resolution.status === 'found' && resolution.ttlSeconds !== undefined) {
+      chainExpiryMs.set(batchId, Date.now() + resolution.ttlSeconds * MS_PER_SECOND)
     }
   }
 
@@ -169,9 +180,23 @@
       return undefined
     }
     const durationSeconds = calculateTTLSeconds(stamp.amount, price)
+    const maxTtlSeconds = MAX_PLAUSIBLE_STAMP_TTL_YEARS * MONTHS_PER_YEAR * SECONDS_PER_MONTH
+    // An estimate of 0 (bad inputs) or an implausibly distant one is treated as
+    // "unknown" rather than rendered as a wrong date — the row is then hidden.
+    if (durationSeconds <= 0 || durationSeconds > maxTtlSeconds) {
+      return undefined
+    }
     const startTimeMs =
       blockTimestamp !== undefined ? blockTimestamp * MS_PER_SECOND : stamp.createdAt
-    return { expiryMs: startTimeMs + durationSeconds * MS_PER_SECOND, estimated: true }
+    const expiryMs = startTimeMs + durationSeconds * MS_PER_SECOND
+    // We only reach the estimate when neither chain source knew the batch (e.g.
+    // a batch not on the configured chain's contract). An estimate that lands in
+    // the past can't be trusted to mean "expired" — show "unknown" instead of a
+    // misleading expired date.
+    if (expiryMs <= Date.now()) {
+      return undefined
+    }
+    return { expiryMs, estimated: true }
   }
 
   function formatExpiryDate(expiryMs: number, estimated: boolean): string {
@@ -234,50 +259,73 @@
         {/snippet}
       </Input>
 
-      <Horizontal --horizontal-gap="var(--half-padding)" --horizontal-align-items="center">
-        <div class="capacity-label">
-          <Typography>{formatCapacity(stamp.utilization, stamp.depth)}</Typography>
-        </div>
-        <div class="progress-bar">
-          <div
-            class="progress-bar-fill"
-            style="width: {Math.min(
-              stamp.utilization * MAX_UTILIZATION_PERCENT,
-              MAX_UTILIZATION_PERCENT,
-            )}%"
-          ></div>
-        </div>
-      </Horizontal>
-
-      {@const stampBlockTimestamp = blockTimestamps.get(stamp.blockNumber)}
-      {@const stampChainExpiry = chainExpiryMs.get(stamp.batchID.toHex())}
-      {@const expiry = getExpiry(stamp, pricePerGBPerMonth, stampBlockTimestamp, stampChainExpiry)}
-      {#if expiry !== undefined}
-        {@const expired = isExpired(expiry.expiryMs)}
-        {@const expiringSoon =
-          !expired && isExpiringSoon(stamp, expiry.expiryMs, pricePerGBPerMonth)}
-        <Horizontal --horizontal-justify-content="space-between" --horizontal-align-items="center">
-          <Typography>Expiry date</Typography>
-          <Horizontal --horizontal-gap="var(--half-padding)" --horizontal-align-items="center">
-            <Typography
-              --typography-color={expired || expiringSoon ? 'var(--colors-red)' : undefined}
-            >
-              {formatExpiryDate(expiry.expiryMs, expiry.estimated)}
-            </Typography>
-            {#if expiry.estimated}
-              <Typography variant="small">(estimated)</Typography>
-            {/if}
-            {#if expired}
-              <Badge variant="error" dimension="small">
-                <WarningAltFilled size={16} />Expired
-              </Badge>
-            {:else if expiringSoon}
-              <Badge variant="error" dimension="small">
-                <WarningAltFilled size={16} />Expires soon
-              </Badge>
-            {/if}
-          </Horizontal>
+      {@const status = batchStatus.get(stamp.batchID.toHex())}
+      {#if status === 'not-found'}
+        <Horizontal --horizontal-gap="var(--half-padding)" --horizontal-align-items="center">
+          <WarningAltFilled size={16} />
+          <Typography variant="small">This batch does not exist on the current network.</Typography>
         </Horizontal>
+      {:else if status === 'unreachable'}
+        <Horizontal --horizontal-gap="var(--half-padding)" --horizontal-align-items="center">
+          <WarningAltFilled size={16} />
+          <Typography variant="small">
+            Network unreachable — couldn't verify this batch right now.
+          </Typography>
+        </Horizontal>
+      {:else}
+        <Horizontal --horizontal-gap="var(--half-padding)" --horizontal-align-items="center">
+          <div class="capacity-label">
+            <Typography>{formatCapacity(stamp.utilization, stamp.depth)}</Typography>
+          </div>
+          <div class="progress-bar">
+            <div
+              class="progress-bar-fill"
+              style="width: {Math.min(
+                stamp.utilization * MAX_UTILIZATION_PERCENT,
+                MAX_UTILIZATION_PERCENT,
+              )}%"
+            ></div>
+          </div>
+        </Horizontal>
+
+        {@const stampBlockTimestamp = blockTimestamps.get(stamp.blockNumber)}
+        {@const stampChainExpiry = chainExpiryMs.get(stamp.batchID.toHex())}
+        {@const expiry = getExpiry(
+          stamp,
+          pricePerGBPerMonth,
+          stampBlockTimestamp,
+          stampChainExpiry,
+        )}
+        {#if expiry !== undefined}
+          {@const expired = isExpired(expiry.expiryMs)}
+          {@const expiringSoon =
+            !expired && isExpiringSoon(stamp, expiry.expiryMs, pricePerGBPerMonth)}
+          <Horizontal
+            --horizontal-justify-content="space-between"
+            --horizontal-align-items="center"
+          >
+            <Typography>Expiry date</Typography>
+            <Horizontal --horizontal-gap="var(--half-padding)" --horizontal-align-items="center">
+              <Typography
+                --typography-color={expired || expiringSoon ? 'var(--colors-red)' : undefined}
+              >
+                {formatExpiryDate(expiry.expiryMs, expiry.estimated)}
+              </Typography>
+              {#if expiry.estimated}
+                <Typography variant="small">(estimated)</Typography>
+              {/if}
+              {#if expired}
+                <Badge variant="error" dimension="small">
+                  <WarningAltFilled size={16} />Expired
+                </Badge>
+              {:else if expiringSoon}
+                <Badge variant="error" dimension="small">
+                  <WarningAltFilled size={16} />Expires soon
+                </Badge>
+              {/if}
+            </Horizontal>
+          </Horizontal>
+        {/if}
       {/if}
     </Vertical>
   </Vertical>

--- a/swarm-ui/src/routes/(app)/identity/[id]/stamps/+page.svelte
+++ b/swarm-ui/src/routes/(app)/identity/[id]/stamps/+page.svelte
@@ -26,7 +26,7 @@
   import WarningAltFilled from 'carbon-icons-svelte/lib/WarningAltFilled.svelte'
   import {
     calculateTTLSeconds,
-    fetchBatchTTL,
+    fetchAuthoritativeBatchTTL,
     fetchSwarmPrice,
     getBlockTimestamp,
   } from '@snaha/swarm-id'
@@ -59,11 +59,14 @@
 
   let pricePerGBPerMonth = $state<number | undefined>(undefined)
   const blockTimestamps = new SvelteMap<number, number>()
-  // Map of batchID hex → expiry timestamp in ms (Date.now() + batchTTL), sourced
-  // from the configured Bee node's `/stamps/{id}` response. Bee computes batchTTL
-  // from live chain state, so it accounts for price changes since stamp creation
-  // that the Swarmscan-price approximation cannot.
-  const beeExpiryMs = new SvelteMap<string, number>()
+  // Map of batchID hex → expiry timestamp in ms (Date.now() + remaining TTL),
+  // sourced from live chain state. We read the PostageStamp contract directly by
+  // batchId (ground truth, works for any batch — including manually added stamps
+  // the Bee node does not track, see #344), and fall back to the Bee node's
+  // `/stamps/{id}` batchTTL only when the RPC read is unavailable. Both account
+  // for price changes since stamp creation that the Swarmscan-price
+  // approximation cannot.
+  const chainExpiryMs = new SvelteMap<string, number>()
 
   async function fetchBlockTimestamp(blockNumber: number): Promise<number | undefined> {
     if (blockTimestamps.has(blockNumber)) {
@@ -82,22 +85,30 @@
     }
   }
 
-  async function fetchStampExpiryFromBee(stamp: PostageStamp): Promise<void> {
-    const ttlSeconds = await fetchBatchTTL(networkSettingsStore.beeNodeUrl, stamp.batchID.toHex())
+  async function fetchStampExpiry(stamp: PostageStamp): Promise<void> {
+    const batchId = stamp.batchID.toHex()
+    // Resolve remaining TTL from the most authoritative source: the on-chain
+    // PostageStamp contract first (works for any batchId, even one the
+    // configured Bee node has never seen), then the Bee node's batchTTL.
+    const ttlSeconds = await fetchAuthoritativeBatchTTL(
+      networkSettingsStore.gnosisRpcUrl,
+      networkSettingsStore.beeNodeUrl,
+      batchId,
+    )
     if (ttlSeconds !== undefined) {
-      beeExpiryMs.set(stamp.batchID.toHex(), Date.now() + ttlSeconds * MS_PER_SECOND)
+      chainExpiryMs.set(batchId, Date.now() + ttlSeconds * MS_PER_SECOND)
     }
   }
 
   onMount(() => {
-    // Start the authoritative Bee batchTTL + block-timestamp fetches first;
-    // they don't depend on the Swarmscan price and shouldn't wait on it.
+    // Start the authoritative chain/Bee batchTTL + block-timestamp fetches
+    // first; they don't depend on the Swarmscan price and shouldn't wait on it.
     const stamps = [accountStamp, identityStamp].filter(Boolean) as PostageStamp[]
     for (const stamp of stamps) {
       if (stamp.blockNumber > 0) {
         fetchBlockTimestamp(stamp.blockNumber)
       }
-      fetchStampExpiryFromBee(stamp)
+      fetchStampExpiry(stamp)
     }
 
     // Swarmscan price feeds only the constant-price fallback and the
@@ -140,17 +151,18 @@
 
   /**
    * Resolves a stamp's expiry timestamp in ms, marking it as estimated when
-   * we had to fall back to the Swarmscan-price approximation. Bee's batchTTL
-   * (when available) reflects actual chain state and is treated as truth.
+   * we had to fall back to the Swarmscan-price approximation. The chain-sourced
+   * expiry (PostageStamp contract, or Bee's batchTTL) reflects actual chain
+   * state and is treated as truth.
    */
   function getExpiry(
     stamp: PostageStamp,
     price: number | undefined,
     blockTimestamp: number | undefined,
-    beeExpiry: number | undefined,
+    chainExpiry: number | undefined,
   ): StampExpiry | undefined {
-    if (beeExpiry !== undefined) {
-      return { expiryMs: beeExpiry, estimated: false }
+    if (chainExpiry !== undefined) {
+      return { expiryMs: chainExpiry, estimated: false }
     }
     if (price === undefined) {
       return undefined
@@ -237,8 +249,8 @@
       </Horizontal>
 
       {@const stampBlockTimestamp = blockTimestamps.get(stamp.blockNumber)}
-      {@const stampBeeExpiry = beeExpiryMs.get(stamp.batchID.toHex())}
-      {@const expiry = getExpiry(stamp, pricePerGBPerMonth, stampBlockTimestamp, stampBeeExpiry)}
+      {@const stampChainExpiry = chainExpiryMs.get(stamp.batchID.toHex())}
+      {@const expiry = getExpiry(stamp, pricePerGBPerMonth, stampBlockTimestamp, stampChainExpiry)}
       {#if expiry !== undefined}
         {@const expired = isExpired(expiry.expiryMs)}
         {@const expiringSoon =

--- a/swarm-ui/src/routes/(app)/identity/[id]/stamps/+page.svelte
+++ b/swarm-ui/src/routes/(app)/identity/[id]/stamps/+page.svelte
@@ -31,14 +31,13 @@
     getBlockTimestamp,
   } from '@snaha/swarm-id'
   import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
-  import { postageStampContractAddress } from '$lib/constants'
+  import { postageStampContractAddress, MS_PER_SECOND } from '$lib/constants'
 
   const BATCH_ID_PREVIEW_LENGTH = 8
   const CHUNK_SIZE_BYTES = 4096
   const BYTES_PER_KB = 1024
   const BYTES_PER_MB = BYTES_PER_KB * BYTES_PER_KB
   const BYTES_PER_GB = BYTES_PER_MB * BYTES_PER_KB
-  const MS_PER_SECOND = 1000
   const SECONDS_PER_MONTH = 2592000
   const MAX_UTILIZATION_PERCENT = 100
   const EXPIRY_SOON_LIFETIME_FRACTION = 0.1

--- a/swarm-ui/src/routes/(app)/identity/[id]/stamps/+page.svelte
+++ b/swarm-ui/src/routes/(app)/identity/[id]/stamps/+page.svelte
@@ -31,6 +31,7 @@
     getBlockTimestamp,
   } from '@snaha/swarm-id'
   import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
+  import { postageStampContractAddress } from '$lib/constants'
 
   const BATCH_ID_PREVIEW_LENGTH = 8
   const CHUNK_SIZE_BYTES = 4096
@@ -94,6 +95,7 @@
       networkSettingsStore.gnosisRpcUrl,
       networkSettingsStore.beeNodeUrl,
       batchId,
+      postageStampContractAddress,
     )
     if (ttlSeconds !== undefined) {
       chainExpiryMs.set(batchId, Date.now() + ttlSeconds * MS_PER_SECOND)

--- a/swarm-ui/src/routes/proxy/+page.svelte
+++ b/swarm-ui/src/routes/proxy/+page.svelte
@@ -6,12 +6,15 @@
 <script lang="ts">
   import { onMount } from 'svelte'
   import { initProxy } from '@snaha/swarm-id'
+  import { postageStampContractAddress } from '$lib/constants'
 
   let authButtonContainer: HTMLDivElement
 
   onMount(() => {
-    // Initialize the proxy - it reads Bee API URL from network settings internally
-    const proxy = initProxy()
+    // Initialize the proxy - it reads Bee API URL from network settings
+    // internally. The PostageStamp contract address comes from a build-time env
+    // so on-chain stamp-TTL reads target the right chain (mainnet vs local).
+    const proxy = initProxy({ postageStampContractAddress })
 
     // Set the container for auth button
     if (authButtonContainer) {


### PR DESCRIPTION
Fixes #344.

## Problem

Stamp expiry was derived from the Bee node's `/stamps/{id}` `batchTTL`, falling back to a constant-price (Swarmscan) approximation. A **manually-added stamp** has no entry on the configured Bee node, so it fell straight to the approximation — which drifts as the chain price moves and showed an **incorrect expiry date** (the issue's batch is a concrete example).

## Fix

Read the batch state **directly from the Gnosis PostageStamp contract** (`0x45a1…6293`) by `batchId`. This is the same ground truth Bee uses internally, but it resolves for **any** batch regardless of whether the node tracks it:

```
remaining = normalisedBalance − currentTotalOutPayment()
ttl       = remaining / lastPrice() × GNOSIS_BLOCK_TIME (5s)
```

New lib module `lib/src/utils/postage-contract.ts` performs a single batched `eth_call` (`batches`, `currentTotalOutPayment`, `lastPrice`) with lightweight **manual ABI encode/decode** — hardcoded 4-byte selectors + BigInt decode, **no new dependency** (no ethers/viem added to the published lib). It never throws: on RPC failure or an unknown batch it returns `undefined` so callers degrade gracefully.

`fetchAuthoritativeBatchTTL(gnosisRpcUrl, beeUrl, batchId)` centralises the **"contract first → Bee node fallback"** priority so every call site stays in sync.

## Used everywhere stamp expiry surfaces

| Surface | TTL source |
|---|---|
| Identity stamps page | contract → Bee → price estimate (marked *estimated*) |
| Proxy `getPostageBatch` (→ demo, via `batch.batchTTL`) | contract → Bee → price estimate |
| Dev page "Existing Stamps" list | Bee `batchTTL` — authoritative for the batches it lists; the default local dev chain has no mainnet contract, so a contract read would be redundant/fail |

## Tests & verification

- **24 unit tests** in `postage-contract.test.ts`: ABI decode, contract TTL math (against real captured chain values), source priority (contract wins / Bee fallback / both fail), and graceful degradation (unknown batch, RPC error, malformed id).
- Validated end-to-end against the **live Gnosis chain** for the issue's batch via both the default RPC and gateway.fm — resolves to the correct ~6d-16h remaining.
- `pnpm check:all` is green (format, lint, typecheck, tests, knip).

## Reviewer notes

- The PostageStamp contract address and the 4-byte selectors are hardcoded constants; selectors were computed from the function signatures and the formula is documented inline.
- `lib/dist` is gitignored — reviewers running swarm-ui typecheck locally must `pnpm --filter @snaha/swarm-id build` first, since swarm-ui typechecks against the built lib.

## Configurable contract address (local vs production)

The PostageStamp contract address is no longer hardcoded at the call sites. The
contract-read functions (`fetchOnChainBatchState`, `fetchBatchTTLFromContract`,
`fetchAuthoritativeBatchTTL`) and `initProxy` take an **optional** address,
defaulting to the mainnet `POSTAGE_STAMP_CONTRACT_ADDRESS` constant in the lib.
swarm-ui supplies it from an optional `VITE_POSTAGE_STAMP_CONTRACT_ADDRESS`
build-time env (`swarm-ui/src/lib/constants.ts`), so the mainnet default lives
in exactly one place (the lib) and the app passes only an override.

| Environment | How the address is set |
|---|---|
| **Production / deploys** | Env unset → `undefined` → lib applies the Gnosis mainnet default. No `.env`, no CI changes. |
| **Local (bee-compose anvil)** | `dev:swarm-ui` sets `VITE_POSTAGE_STAMP_CONTRACT_ADDRESS` to the local anvil deployment; also point the Gnosis RPC at `http://localhost:9545` in the network-settings modal. |

**All-or-nothing guarantee:** the three contract sub-calls are batched to the
same address on the same RPC, and `fetchAuthoritativeBatchTTL` returns the
contract TTL *or* the Bee TTL *or* the price estimate — never a mix. A
chain/address mismatch decodes to an empty/zero result → `undefined` → clean
Bee fallback, never a wrong value. Verified end-to-end against a live local
anvil chain (contract TTL matched the Bee node's `batchTTL`) and against the
default mainnet RPC.
