### PR TITLE
feat(sync): schema + validation for the binary partition-state wire format

### DIFF
--- a/docs-site/src/content/docs/multi-device-postage-batches.mdx
+++ b/docs-site/src/content/docs/multi-device-postage-batches.mdx
@@ -248,10 +248,42 @@ concatenates those references (`N · 64 ≤ 4096` bytes, one chunk even at `N = 
 feed points at the reference chunk. A taking-over device follows
 **feed → reference chunk → counter chunks**, decrypting each from its embedded key.
 
+### Wire format (byte layout)
+
+The format is **binary** and is versioned by the topic domain
+(`swarm-id-partition-state-v1`) — there is no in-blob version byte. A future v2 publishes
+under a v2 topic and never collides with v1 readers.
+
+**Reference chunk** — exactly `N × 64` bytes, where
+`N = numUtilizationChunks(batchDepth)`:
+
+| Offset        | Size | Content                                                             |
+| ------------- | ---- | ------------------------------------------------------------------- |
+| `i · 64`      | 32   | Swarm address of counter chunk `i`                                  |
+| `i · 64 + 32` | 32   | Decryption key of counter chunk `i` (random, generated per publish) |
+
+**Counter chunk `i`** — exactly 4096 bytes (`CHUNK_SIZE`): `bucketsPerChunk` consecutive
+per-bucket counters, **little-endian**, covering buckets
+`[i · bucketsPerChunk, (i + 1) · bucketsPerChunk)`. The counter width depends on the batch
+depth (`getChunkLayout`):
+
+| Batch depth                         | Counter width | `bucketsPerChunk` | `N` (chunks) |
+| ----------------------------------- | ------------- | ----------------- | ------------ |
+| `≤ 31` (`UINT16_COUNTER_MAX_DEPTH`) | `uint16` LE   | 2048              | 32           |
+| `≥ 32`                              | `uint32` LE   | 1024              | 64           |
+
+The decoded result is always a `Uint32Array(65536)` (one counter per bucket) regardless of
+the on-wire width; narrowing happens only at the serialize boundary. The decoded state is
+described by the exported `PartitionStateSchemaV1`
+(`{ counters: Uint32Array(NUM_BUCKETS) }` in `lib/src/sync/partition-state.ts`):
+`writePartitionState` validates its input against it, and `readPartitionState` validates
+the reassembled counter — plus the reference-chunk length (`N × 64`) and each counter
+chunk's length — before returning.
+
 Reads short-circuit on a cached "synced reference": if the feed still points at the
 reference a device last synced with, it skips the downloads and reuses its local counter.
-A failed counter read falls back to a fresh zero counter rather than aborting the
-acquisition.
+A failed or malformed counter read **fails safe**: it falls back to a fresh zero counter
+rather than aborting the acquisition, and does not cache the bad reference as synced.
 
 :::note[Historical: device-claim feed]
 Iteration 1 used a per-device claim feed

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -86,7 +86,9 @@ export {
   makePartitionStateTopic,
   readPartitionState,
   writePartitionState,
+  PartitionStateSchemaV1,
 } from "./sync/partition-state"
+export type { PartitionState } from "./sync/partition-state"
 export {
   acquirePartitionLock,
   compareGenerations,

--- a/lib/src/sync/partition-lease.integration.test.ts
+++ b/lib/src/sync/partition-lease.integration.test.ts
@@ -26,11 +26,15 @@ import {
   readPartitionLock,
   writePartitionLock,
 } from "./partition-lock"
+import { Binary } from "cafe-utility"
 import {
   LEASE_TTL_MS,
   PARTITION_COUNT,
   NUM_BUCKETS,
+  getChunkLayout,
 } from "../utils/batch-utilization"
+import { makeEncryptedContentAddressedChunk } from "../chunk"
+import { uploadData, type UploadTarget } from "../proxy/upload"
 import {
   MockBee,
   MockChunkStore,
@@ -57,6 +61,23 @@ const GUARD_MS = 50 // small for tests; production default is 2000
 // ============================================================================
 // Helpers
 // ============================================================================
+
+/**
+ * Upload `plaintext` with a random encryption key (mirrors the private
+ * `uploadReservedChunk` in partition-state.ts) and return its 64-byte
+ * encrypted reference (address ‖ key).
+ */
+async function uploadEncryptedBlob(
+  target: UploadTarget,
+  plaintext: Uint8Array,
+): Promise<Uint8Array> {
+  const encrypted = makeEncryptedContentAddressedChunk(plaintext)
+  await uploadData(target, plaintext, {
+    encryptionKey: encrypted.encryptionKey,
+    deferred: false,
+  })
+  return encrypted.reference.toUint8Array()
+}
 
 function makeLease(opts: {
   deviceId: string
@@ -210,6 +231,107 @@ describe("readPartitionState / writePartitionState round-trip", () => {
     expect(result.unchanged).toBe(false)
     expect(result.localCounter![0]).toBe(0)
     expect(result.localCounter![1234]).toBe(0)
+  })
+
+  it("falls back to a fresh counter when the reference chunk has the wrong length", async () => {
+    const { readPartitionState, makePartitionStateTopic } =
+      await import("./partition-state")
+    const { BasicEpochUpdater } = await import("../proxy/feeds/epochs")
+
+    const target: UploadTarget = {
+      mode: "stamper",
+      bee: bee as unknown as Bee,
+      stamper: createMockStamper() as unknown as Stamper,
+    }
+
+    // A readable chunk that is NOT numUtilizationChunks × 64 bytes — e.g. an
+    // entry written by a buggy or older writer. Reads must fail safe, not
+    // silently slice short/empty references out of it.
+    const malformedRef = await uploadEncryptedBlob(
+      target,
+      new Uint8Array(32).fill(7),
+    )
+    const topic = makePartitionStateTopic(TEST_BATCH_ID, 0)
+    const updater = new BasicEpochUpdater(topic, BACKUP_SIGNER)
+    await updater.update(
+      BigInt(Math.floor(Date.now() / 1000)),
+      malformedRef,
+      target,
+    )
+
+    const result = await readPartitionState({
+      bee: bee as unknown as Bee,
+      owner: OWNER,
+      batchId: TEST_BATCH_ID,
+      partition: 0,
+      batchDepth: TEST_BATCH_DEPTH,
+    })
+
+    expect(result.unchanged).toBe(false)
+    // The failed read must not be cached as "synced".
+    expect(result.referenceHex).toBeUndefined()
+    expect(result.localCounter!.every((c) => c === 0)).toBe(true)
+  })
+
+  it("falls back to a fresh counter when a counter chunk has the wrong length", async () => {
+    const { readPartitionState, makePartitionStateTopic } =
+      await import("./partition-state")
+    const { BasicEpochUpdater } = await import("../proxy/feeds/epochs")
+
+    const target: UploadTarget = {
+      mode: "stamper",
+      bee: bee as unknown as Bee,
+      stamper: createMockStamper() as unknown as Stamper,
+    }
+
+    // A correctly-sized reference chunk whose entries all point at a counter
+    // chunk of the wrong length (100 bytes instead of CHUNK_SIZE). mergeChunk
+    // must reject it and the read must fall back to a fresh counter.
+    const shortCounterRef = await uploadEncryptedBlob(
+      target,
+      new Uint8Array(100).fill(1),
+    )
+    const { numUtilizationChunks } = getChunkLayout(TEST_BATCH_DEPTH)
+    const referenceChunk = Binary.concatBytes(
+      ...Array.from({ length: numUtilizationChunks }, () => shortCounterRef),
+    )
+    const referenceChunkRef = await uploadEncryptedBlob(target, referenceChunk)
+
+    const topic = makePartitionStateTopic(TEST_BATCH_ID, 0)
+    const updater = new BasicEpochUpdater(topic, BACKUP_SIGNER)
+    await updater.update(
+      BigInt(Math.floor(Date.now() / 1000)),
+      referenceChunkRef,
+      target,
+    )
+
+    const result = await readPartitionState({
+      bee: bee as unknown as Bee,
+      owner: OWNER,
+      batchId: TEST_BATCH_ID,
+      partition: 0,
+      batchDepth: TEST_BATCH_DEPTH,
+    })
+
+    expect(result.unchanged).toBe(false)
+    expect(result.referenceHex).toBeUndefined()
+    expect(result.localCounter!.every((c) => c === 0)).toBe(true)
+  })
+
+  it("rejects publishing a counter with the wrong length", async () => {
+    const { writePartitionState } = await import("./partition-state")
+
+    await expect(
+      writePartitionState({
+        bee: bee as unknown as Bee,
+        stamper: createMockStamper() as unknown as Stamper,
+        batchId: TEST_BATCH_ID,
+        batchDepth: TEST_BATCH_DEPTH,
+        partition: 0,
+        localCounter: new Uint32Array(5),
+        backupSigner: BACKUP_SIGNER,
+      }),
+    ).rejects.toThrow(/65536/)
   })
 })
 

--- a/lib/src/sync/partition-state.ts
+++ b/lib/src/sync/partition-state.ts
@@ -29,6 +29,7 @@ import {
   type Stamper,
 } from "@ethersphere/bee-js"
 import { Binary } from "cafe-utility"
+import { z } from "zod"
 import { AsyncEpochFinder } from "../proxy/feeds/epochs/async-finder"
 import { BasicEpochUpdater } from "../proxy/feeds/epochs/updater"
 import { downloadDataWithChunkAPI } from "../proxy/download-data"
@@ -52,6 +53,26 @@ const PARTITION_STATE_TOPIC_DOMAIN = "swarm-id-partition-state-v1"
 
 /** Bytes to encode `partition` as big-endian uint32. */
 const UINT32_BYTES = 4
+
+/**
+ * Schema for the *decoded* partition state: the per-bucket counter
+ * reconstructed from the binary wire format (reference chunk → counter
+ * chunks, see the module doc above for the byte layout). The wire format is
+ * versioned by the feed topic domain (`PARTITION_STATE_TOPIC_DOMAIN`), not an
+ * in-blob version byte — a future v2 publishes under a v2 topic and never
+ * collides with v1 readers.
+ *
+ * `readPartitionState` validates the assembled counter against this schema
+ * before returning it; a failure falls back to a fresh zero counter.
+ * `writePartitionState` validates its input against it before publishing.
+ */
+export const PartitionStateSchemaV1 = z.object({
+  counters: z.instanceof(Uint32Array).refine((c) => c.length === NUM_BUCKETS, {
+    message: `counters must have ${NUM_BUCKETS} entries`,
+  }),
+})
+
+export type PartitionState = z.infer<typeof PartitionStateSchemaV1>
 
 /**
  * Build the per-partition state feed topic.
@@ -147,6 +168,12 @@ export async function readPartitionState(
       new Reference(refBytes).toHex(),
     )
     const { numUtilizationChunks } = getChunkLayout(batchDepth)
+    const expectedLength = numUtilizationChunks * ENCRYPTED_REFERENCE_BYTES
+    if (referenceChunk.length !== expectedLength) {
+      throw new Error(
+        `reference chunk has ${referenceChunk.length} bytes, expected ${expectedLength} (${numUtilizationChunks} × ${ENCRYPTED_REFERENCE_BYTES})`,
+      )
+    }
     for (let i = 0; i < numUtilizationChunks; i++) {
       const ref = referenceChunk.slice(
         i * ENCRYPTED_REFERENCE_BYTES,
@@ -158,6 +185,7 @@ export async function readPartitionState(
       )
       mergeChunk(localCounter, i, chunkData, batchDepth)
     }
+    PartitionStateSchemaV1.parse({ counters: localCounter })
   } catch (err) {
     console.warn(
       `[partition-state] reading partition ${partition} counter failed; seeding a fresh counter:`,
@@ -201,11 +229,7 @@ export async function writePartitionState(opts: {
     backupSigner,
   } = opts
 
-  if (localCounter.length !== NUM_BUCKETS) {
-    throw new Error(
-      `localCounter must have ${NUM_BUCKETS} entries, got ${localCounter.length}`,
-    )
-  }
+  PartitionStateSchemaV1.parse({ counters: localCounter })
 
   const { numUtilizationChunks } = getChunkLayout(batchDepth)
   const target: UploadTarget = { mode: "stamper", bee, stamper }

--- a/lib/src/sync/sync-account.test.ts
+++ b/lib/src/sync/sync-account.test.ts
@@ -167,13 +167,16 @@ vi.mock("../proxy/download-data", () => ({
   downloadDataWithChunkAPI: mockDownloadData,
 }))
 
-// Mock utilization to avoid complexity in these tests. The stamper class is a
-// real (mock) class because sync-account narrows the store's stamper with
+// Mock utilization to avoid complexity in these tests. Partial mock: real
+// constants (e.g. NUM_BUCKETS) stay available to transitive imports like
+// partition-state's module-scope schema. The stamper class override is a real
+// (mock) class because sync-account narrows the store's stamper with
 // `instanceof UtilizationAwareStamper` before handing it to the coordinator.
 const MockUtilizationAwareStamper = vi.hoisted(
   () => class MockUtilizationAwareStamper {},
 )
-vi.mock("../utils/batch-utilization", () => ({
+vi.mock("../utils/batch-utilization", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../utils/batch-utilization")>()),
   updateAfterWrite: vi.fn().mockResolvedValue({
     state: { chunks: new Map() },
     tracker: { hasDirtyChunks: () => false, getDirtyChunks: () => [] },


### PR DESCRIPTION
Closes #340. Follows #335's "every uploaded payload has a defined, validated schema" effort for the partition-**state** wire format. Non-breaking — no wire-format change; versioning stays in the feed topic domain (`swarm-id-partition-state-v1`).

## What

- **`PartitionStateSchemaV1`** over the *decoded* state (`{ counters: Uint32Array(NUM_BUCKETS) }`), co-located in `sync/partition-state.ts` (keeps batch-util constants out of `schemas.ts`), exported from `index.ts` together with the `PartitionState` type.
- **Decode-time validation, failing safe** (inside the existing try/catch, so malformed data falls back to a fresh zero counter without caching the bad reference as synced):
  - `readPartitionState` asserts the reference chunk is exactly `numUtilizationChunks × 64` bytes before slicing (a short chunk previously yielded silent empty refs / opaque downstream errors), and validates the reassembled counter against the schema.
  - `writePartitionState` validates its input via the schema (replaces the ad-hoc length check).
- **`mergeChunk` guard from the issue**: already exists (`length !== CHUNK_SIZE`, identical to `bucketsPerChunk × counterByteSize` for both codecs) — added the missing fail-safe **test coverage** instead of a redundant check.
- **Docs**: precise byte-layout spec in `multi-device-postage-batches.mdx` (reference-chunk offset table, uint16/uint32 LE codec table, topic-domain versioning) cross-referencing the schema.
- `sync-account.test.ts`: the `batch-utilization` mock is now partial (`importOriginal`) so real constants reach partition-state's module-scope schema; keeps the `MockUtilizationAwareStamper` override from #346.

## Acceptance (from #340)

- [x] Accurate, exported, domain-versioned `PartitionStateSchemaV1`
- [x] Reads validate and fail safe on malformed reference/counter chunks — MockBee/MockChunkStore tests
- [x] `writePartitionState` → `readPartitionState` round-trips a non-trivial counter (pre-existing test)
- [x] Byte layout documented
- [x] `pnpm check:all` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)