### PR TITLE
fix: show live postage stamp usable status in the demo app

### DIFF
--- a/demo/src/lib/stores/client.svelte.ts
+++ b/demo/src/lib/stores/client.svelte.ts
@@ -12,6 +12,11 @@ import { logStore } from './log.svelte'
 
 const PROXY_PATH = '/proxy'
 const CLIENT_TIMEOUT = 600000 // 10 minutes for large file uploads
+const STAMP_USABLE_POLL_INTERVAL = 10000 // fresh batches become usable after ~30s
+// Cap re-polling — on a public gateway the Bee node never learns about the
+// batch, so the proxy keeps reporting the stored snapshot and the stamp
+// would otherwise be polled forever.
+const STAMP_USABLE_POLL_MAX_ATTEMPTS = 30
 
 const BEE_ICON =
   'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTYiIGhlaWdodD0iNTYiIHZpZXdCb3g9IjAgMCA1NiA1NiIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KICA8cmVjdCB3aWR0aD0iNTYiIGhlaWdodD0iNTYiIGZpbGw9IndoaXRlIiByeD0iOCIvPgogIDx0ZXh0IHg9IjUwJSIgeT0iNTAlIiBmb250LXNpemU9IjMyIiBkb21pbmFudC1iYXNlbGluZT0ibWlkZGxlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIj7wn5CdPC90ZXh0Pgo8L3N2Zz4='
@@ -63,6 +68,18 @@ let currentSubsidisedGatewayUrl: string | undefined = undefined
 // switches identity or disconnects while a fetch is pending.
 let connectionGeneration = 0
 
+// Re-poll timer for a not-yet-usable stamp (see updatePostageStampInfo).
+let stampPollTimer: ReturnType<typeof setTimeout> | undefined
+let stampPollAttempts = 0
+
+function clearStampPollTimer() {
+  if (stampPollTimer !== undefined) {
+    clearTimeout(stampPollTimer)
+    stampPollTimer = undefined
+  }
+  stampPollAttempts = 0
+}
+
 async function updatePostageStampInfo(generation: number) {
   if (!client) return
 
@@ -71,6 +88,7 @@ async function updatePostageStampInfo(generation: number) {
     if (generation !== connectionGeneration) return
     if (batch) {
       const batchIdStr = String(batch.batchID)
+      const previous = stamp
       stamp = {
         batchID: batchIdStr,
         utilization: batch.utilization.toFixed(2),
@@ -82,9 +100,28 @@ async function updatePostageStampInfo(generation: number) {
         immutableFlag: batch.immutableFlag,
         ttl: formatTTL(batch.batchTTL),
       }
-      logStore.log(`Postage stamp loaded: ${batchIdStr.slice(0, 16)}...`)
+      // Poll re-runs only log when something the user can see changed.
+      if (previous === undefined || previous.batchID !== batchIdStr) {
+        logStore.log(`Postage stamp loaded: ${batchIdStr.slice(0, 16)}...`)
+      } else if (previous.usable !== batch.usable) {
+        logStore.log(`Postage stamp is now ${batch.usable ? 'usable' : 'unusable'}`)
+      }
+      // A freshly bought batch reports usable=false until it warms up on
+      // chain (~30s) — re-poll until it flips so the UI catches up without
+      // a reload.
+      if (batch.usable) {
+        stampPollAttempts = 0
+      } else if (stampPollAttempts < STAMP_USABLE_POLL_MAX_ATTEMPTS) {
+        stampPollAttempts++
+        stampPollTimer = setTimeout(() => {
+          stampPollTimer = undefined
+          if (generation !== connectionGeneration) return
+          void updatePostageStampInfo(generation)
+        }, STAMP_USABLE_POLL_INTERVAL)
+      }
     } else {
       stamp = undefined
+      stampPollAttempts = 0
       logStore.log('No postage stamp configured')
     }
   } catch (error) {
@@ -102,6 +139,7 @@ async function onConnectionChange(info: ConnectionInfo) {
   // snapshot (e.g. a different identity or pre-disconnect state) is dropped
   // when it resolves instead of overwriting current state.
   const generation = ++connectionGeneration
+  clearStampPollTimer()
   const isAuthenticated = info.identity !== undefined
   authenticated = isAuthenticated
   canUpload = info.canUpload
@@ -270,6 +308,8 @@ export const clientStore = {
       logStore.log(
         `Subsidised gateway changed to ${useSubsidised ? 'enabled' : 'disabled'}, reinitializing client...`,
       )
+      connectionGeneration++
+      clearStampPollTimer()
       client.destroy()
       client = undefined
       currentSubsidisedGatewayUrl = subsidisedUrl
@@ -286,6 +326,10 @@ export const clientStore = {
   },
 
   destroy() {
+    // Bump the generation so an in-flight `getPostageBatch` resolving after
+    // destroy can't write `stamp` back, and stop any pending re-poll.
+    connectionGeneration++
+    clearStampPollTimer()
     client?.destroy()
     client = undefined
     authenticated = false

--- a/lib/src/swarm-id-proxy.ts
+++ b/lib/src/swarm-id-proxy.ts
@@ -117,7 +117,7 @@ import { createAsyncSequentialFinder } from "./proxy/feeds/sequence"
 import { Binary } from "cafe-utility"
 import {
   calculateTTLSeconds,
-  fetchBatchTTL,
+  fetchBatchDetails,
   fetchSwarmPrice,
 } from "./utils/ttl"
 import { tryCreateTag } from "./utils/tag"
@@ -3887,13 +3887,17 @@ export class SwarmIdProxy {
       return
     }
 
-    // Prefer the Bee node's authoritative batchTTL (computed from live chain
-    // state). Fall back to the Swarmscan-price approximation when the Bee node
+    // Prefer the Bee node's authoritative batch details (computed from live
+    // chain state) — the stored stamp's `usable`/`exists` are a snapshot from
+    // assignment time and can be stale (e.g. a batch assigned during its ~30s
+    // warm-up stays `usable: false` in storage forever). Fall back to the
+    // stored values / Swarmscan-price TTL approximation when the Bee node
     // does not know about this batch (e.g. public gateway).
-    let batchTTL: number | undefined = await fetchBatchTTL(
+    const details = await fetchBatchDetails(
       this.beeApiUrl,
       stamp.batchID.toHex(),
     )
+    let batchTTL = details?.batchTTL
     if (batchTTL === undefined) {
       try {
         const pricePerGBPerMonth = await fetchSwarmPrice()
@@ -3907,14 +3911,14 @@ export class SwarmIdProxy {
     const postageBatch: PostageBatch = {
       batchID: stamp.batchID.toHex(),
       utilization: stamp.utilization,
-      usable: stamp.usable,
+      usable: details?.usable ?? stamp.usable,
       label: "", // PostageStamp doesn't store label
       depth: stamp.depth,
       amount: stamp.amount.toString(),
       bucketDepth: stamp.bucketDepth,
       blockNumber: stamp.blockNumber,
       immutableFlag: stamp.immutableFlag,
-      exists: stamp.exists,
+      exists: details?.exists ?? stamp.exists,
       batchTTL,
     }
 

--- a/lib/src/utils/ttl.test.ts
+++ b/lib/src/utils/ttl.test.ts
@@ -6,6 +6,7 @@ import {
   calculateStampAmountForDays,
   calculateTTLSeconds,
   fetchChainState,
+  fetchBatchDetails,
   fetchBatchTTL,
 } from "./ttl"
 
@@ -273,5 +274,110 @@ describe("fetchBatchTTL", () => {
     const ttl = await fetchBatchTTL("https://bee.example.com", BATCH_ID)
 
     expect(ttl).toBeUndefined()
+  })
+})
+
+describe("fetchBatchDetails", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch")
+  })
+
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it("returns batchTTL, usable and exists from Bee /stamps/{id} response", async () => {
+    fetchSpy.mockResolvedValue(
+      mockResponse({ batchTTL: 86400, usable: true, exists: true }),
+    )
+
+    const details = await fetchBatchDetails("https://bee.example.com", BATCH_ID)
+
+    expect(details).toEqual({ batchTTL: 86400, usable: true, exists: true })
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `https://bee.example.com/stamps/${BATCH_ID}`,
+    )
+  })
+
+  it("strips a trailing slash from the Bee URL", async () => {
+    fetchSpy.mockResolvedValue(mockResponse({ batchTTL: 123 }))
+
+    await fetchBatchDetails("https://bee.example.com/", BATCH_ID)
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `https://bee.example.com/stamps/${BATCH_ID}`,
+    )
+  })
+
+  it("omits fields missing from the response body", async () => {
+    fetchSpy.mockResolvedValue(mockResponse({ batchTTL: 86400 }))
+
+    const details = await fetchBatchDetails("https://bee.example.com", BATCH_ID)
+
+    expect(details).toEqual({
+      batchTTL: 86400,
+      usable: undefined,
+      exists: undefined,
+    })
+  })
+
+  it("omits wrongly-typed fields instead of failing", async () => {
+    fetchSpy.mockResolvedValue(
+      mockResponse({ batchTTL: "86400", usable: "yes", exists: 1 }),
+    )
+
+    const details = await fetchBatchDetails("https://bee.example.com", BATCH_ID)
+
+    expect(details).toEqual({
+      batchTTL: undefined,
+      usable: undefined,
+      exists: undefined,
+    })
+  })
+
+  it("normalises negative TTL values to 0 and passes usable through", async () => {
+    fetchSpy.mockResolvedValue(mockResponse({ batchTTL: -1, usable: false }))
+
+    const details = await fetchBatchDetails("https://bee.example.com", BATCH_ID)
+
+    expect(details).toEqual({ batchTTL: 0, usable: false, exists: undefined })
+  })
+
+  it("returns undefined when the stamp is not found (404)", async () => {
+    fetchSpy.mockResolvedValue(mockResponse({}, false, 404))
+
+    const details = await fetchBatchDetails("https://bee.example.com", BATCH_ID)
+
+    expect(details).toBeUndefined()
+  })
+
+  it("returns undefined when the response body is not an object", async () => {
+    fetchSpy.mockResolvedValue(mockResponse(null))
+
+    const details = await fetchBatchDetails("https://bee.example.com", BATCH_ID)
+
+    expect(details).toBeUndefined()
+  })
+
+  it("returns undefined when fetch rejects", async () => {
+    fetchSpy.mockRejectedValue(new Error("network error"))
+
+    const details = await fetchBatchDetails("https://bee.example.com", BATCH_ID)
+
+    expect(details).toBeUndefined()
+  })
+
+  it("returns undefined when JSON parsing fails", async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.reject(new Error("invalid json")),
+    } as unknown as Response)
+
+    const details = await fetchBatchDetails("https://bee.example.com", BATCH_ID)
+
+    expect(details).toBeUndefined()
   })
 })

--- a/lib/src/utils/ttl.ts
+++ b/lib/src/utils/ttl.ts
@@ -249,10 +249,70 @@ export function calculateStampAmountForDays(
 }
 
 /**
+ * Live details for a batch from a Bee node's `/stamps/{batchId}` endpoint.
+ * Fields are individually optional: each is present only when the response
+ * carries it with the expected type.
+ */
+export interface BatchDetails {
+  /** Remaining TTL in seconds; negative API values are normalised to `0`. */
+  batchTTL?: number
+  /** Whether the batch is usable (started and not expired). */
+  usable?: boolean
+  /** Whether the batch exists on chain. */
+  exists?: boolean
+}
+
+/**
+ * Fetches live batch details directly from a Bee node's `/stamps/{batchId}`
+ * endpoint. The Bee node computes these from current chain state, so they are
+ * authoritative — unlike the snapshot stored at stamp-assignment time, which
+ * can go stale (e.g. a freshly bought batch reports `usable: false` for ~30s).
+ *
+ * @param beeUrl - Bee node URL
+ * @param batchId - Hex-encoded batch ID (without `0x` prefix)
+ * @returns Batch details, or `undefined` if the Bee node does not know about
+ *          this batch or the request fails.
+ */
+export async function fetchBatchDetails(
+  beeUrl: string,
+  batchId: string,
+): Promise<BatchDetails | undefined> {
+  try {
+    const base = beeUrl.replace(/\/$/, "")
+    const response = await fetch(`${base}/stamps/${batchId}`)
+    if (!response.ok) {
+      return undefined
+    }
+    const data: unknown = await response.json()
+    if (typeof data !== "object" || data === null) {
+      return undefined
+    }
+    const { batchTTL, usable, exists } = data as {
+      batchTTL?: unknown
+      usable?: unknown
+      exists?: unknown
+    }
+    return {
+      batchTTL:
+        typeof batchTTL === "number"
+          ? batchTTL < 0
+            ? 0
+            : batchTTL
+          : undefined,
+      usable: typeof usable === "boolean" ? usable : undefined,
+      exists: typeof exists === "boolean" ? exists : undefined,
+    }
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * Fetches the remaining batchTTL (in seconds) for a stamp directly from a Bee
- * node's `/stamps/{batchId}` endpoint. The Bee node computes this from current
- * chain state (per-block price and cumulative outpayment), so it is more
- * accurate than the constant-price approximation in {@link calculateTTLSeconds}.
+ * node's `/stamps/{batchId}` endpoint, via {@link fetchBatchDetails}. The Bee
+ * node computes this from current chain state (per-block price and cumulative
+ * outpayment), so it is more accurate than the constant-price approximation
+ * in {@link calculateTTLSeconds}.
  *
  * @param beeUrl - Bee node URL
  * @param batchId - Hex-encoded batch ID (without `0x` prefix)
@@ -264,22 +324,6 @@ export async function fetchBatchTTL(
   beeUrl: string,
   batchId: string,
 ): Promise<number | undefined> {
-  try {
-    const base = beeUrl.replace(/\/$/, "")
-    const response = await fetch(`${base}/stamps/${batchId}`)
-    if (!response.ok) {
-      return undefined
-    }
-    const data: unknown = await response.json()
-    if (typeof data !== "object" || data === null) {
-      return undefined
-    }
-    const ttl = (data as { batchTTL?: unknown }).batchTTL
-    if (typeof ttl !== "number") {
-      return undefined
-    }
-    return ttl < 0 ? 0 : ttl
-  } catch {
-    return undefined
-  }
+  const details = await fetchBatchDetails(beeUrl, batchId)
+  return details?.batchTTL
 }


### PR DESCRIPTION
Fixes #351

## Problem

The stamp's `usable` flag is a snapshot frozen into localStorage at assignment time. A freshly bought batch reports `usable: false` during its ~30s on-chain warm-up, so a stamp assigned in that window showed "Unusable" in the demo sidebar forever — even after the batch became usable on the Bee node.

Two gaps compounded it:

1. The proxy's `handleGetPostageBatch` returned the stored flag verbatim, even though it already queried Bee's `GET /stamps/{batchId}` for the TTL — and that same response carries the fresh `usable`/`exists` fields, which were discarded.
2. The demo fetched the stamp exactly once per connection change, so an open page never re-checked.

## Fix

- **lib**: new `fetchBatchDetails(beeUrl, batchId)` in `utils/ttl.ts` parses `batchTTL`, `usable`, and `exists` from the single Bee request (per-field type guards; wrong-typed fields are omitted). `fetchBatchTTL` is reimplemented as a thin wrapper with an unchanged signature. `handleGetPostageBatch` prefers the live values and falls back to the stored snapshot only when the Bee node does not know the batch (public gateway — 404s, and 400 during warm-up, both covered). The Swarmscan-price TTL fallback is unchanged.
- **demo**: while the fetched stamp is unusable, re-poll every 10s, capped at 30 attempts so the public-gateway fallback doesn't poll forever. The log only records visible changes ("Postage stamp is now usable") — no 10s spam. Teardown paths (`destroy()`, subsidised-gateway reinit) now bump `connectionGeneration`, fixing a latent race where an in-flight fetch resolving after destroy could write stale state back.

The stored localStorage record intentionally keeps its snapshot value — the proxy response is fresh on every call.

## Out of scope (follow-up candidates)

- The sidebar's `utilization` value is frozen at assignment time the same way.
- Persisting the refreshed `usable` back to localStorage would also fix stale display in the identity UI stamp lists.

## Verification

- `pnpm check:all` green; 694 lib unit tests pass, including 9 new ones for `fetchBatchDetails` (happy path, partial/garbage bodies, 404, negative TTL, network errors).
- Live E2E against the local bee-compose cluster: staged the exact bug state (stored `usable: false`, batch usable on Bee) → badge correctly shows **Usable** with Bee's authoritative TTL. Then bought a fresh batch and assigned it during warm-up → badge showed "Unusable" (fallback TTL), and flipped to "Usable" within 15s of the batch warming up — no reload, no reconnect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)