### PR TITLE
feat(ui): port connect tabs and delete-auth from the legacy UI

### DIFF
--- a/ui/src/lib/components/home-account.svelte
+++ b/ui/src/lib/components/home-account.svelte
@@ -69,7 +69,7 @@
 
   type SectionId = 'identity' | 'access' | 'keys' | 'phrase' | 'backup'
   /** What the unlock confirmation is for; completes once the seed decrypts. */
-  type UnlockTarget = 'private-key' | 'phrase' | 'export' | 'change-method'
+  type UnlockTarget = 'private-key' | 'phrase' | 'export' | 'change-method' | 'delete'
   type DialogState =
     | { kind: 'unlock'; target: UnlockTarget; pending: boolean }
     | { kind: 'set-method'; pending: boolean }
@@ -219,6 +219,8 @@
       phraseRevealed = true
     } else if (target === 'export') {
       void exportBackupFile()
+    } else if (target === 'delete') {
+      deleteAccount()
     } else {
       newMethod = 'passkey'
       newPassword = ''
@@ -628,7 +630,9 @@
           ? 'Reveal secret recovery phrase'
           : dialog.target === 'export'
             ? 'Export backup'
-            : 'Change unlock method'}
+            : dialog.target === 'delete'
+              ? 'Delete account'
+              : 'Change unlock method'}
     >
       <p class="text-sm">
         {#if dialog.target === 'change-method'}
@@ -636,6 +640,8 @@
           your current {accessLabel.toLowerCase()}.
         {:else if dialog.target === 'export'}
           Unlock your account to export an encrypted backup file.
+        {:else if dialog.target === 'delete'}
+          Unlock your account to confirm the deletion.
         {:else}
           Make sure no one is watching your screen.
         {/if}
@@ -752,10 +758,11 @@
   <Dialog onclose={closeDialog} title="Delete account">
     <p class="text-sm">
       This removes the account and its data from this device. You can get it back later with a
-      backup file or its secret recovery phrase.
+      backup file or its secret recovery phrase.{#if !entropy}
+        You'll be asked to unlock your account to confirm.{/if}
     </p>
     <div class="flex w-full flex-col gap-2">
-      <Button variant="destructive" class="w-full" onclick={deleteAccount}>
+      <Button variant="destructive" class="w-full" onclick={() => openUnlock('delete')}>
         <Trash2 />
         Delete account
       </Button>

--- a/ui/src/routes/connect/+page.svelte
+++ b/ui/src/routes/connect/+page.svelte
@@ -18,6 +18,7 @@
   import { Button } from '$lib/components/ui/button'
   import { Dialog } from '$lib/components/ui/dialog'
   import { Input } from '$lib/components/ui/input'
+  import { Tabs } from '$lib/components/ui/tabs'
   import { completeConnect, reuseConnection } from '$lib/connect-handshake'
   import { unlockAccount } from '$lib/crypto/unlock'
   import routes from '$lib/routes'
@@ -41,6 +42,34 @@
     request ? (request.appIcon ?? `${request.appOrigin}/favicon.ico`) : undefined,
   )
   const accounts = $derived(accountsStore.accounts)
+
+  // Accounts previously connected to this app, most recently used first.
+  const previouslyUsed = $derived.by(() => {
+    const appOrigin = request?.appOrigin
+    if (!appOrigin) {
+      return []
+    }
+    return accounts
+      .map((account) => ({
+        account,
+        connection: account.connectedApps.find((app) => app.appUrl === appOrigin),
+      }))
+      .filter((entry) => entry.connection !== undefined)
+      .sort((a, b) => (b.connection?.lastConnectedAt ?? 0) - (a.connection?.lastConnectedAt ?? 0))
+      .map((entry) => entry.account)
+  })
+
+  const TABS = [
+    { value: 'previously-used', label: 'Previously used' },
+    { value: 'all-accounts', label: 'All accounts' },
+  ]
+
+  // Defaults to "Previously used" when available; a user selection takes precedence.
+  let selectedTab = $state<string | undefined>(undefined)
+  const activeTab = $derived(
+    selectedTab ?? (previouslyUsed.length > 0 ? 'previously-used' : 'all-accounts'),
+  )
+  const shownAccounts = $derived(activeTab === 'previously-used' ? previouslyUsed : accounts)
 
   onMount(() => {
     missingRequest = !connectStore.initFromHash(window.location.hash)
@@ -137,8 +166,11 @@
         {#if accounts.length > 0}
           <div class="flex w-full flex-col gap-2">
             <p class="text-muted-foreground text-xs">Connect with an account on this device</p>
+            {#if previouslyUsed.length > 0}
+              <Tabs tabs={TABS} bind:value={() => activeTab, (value) => (selectedTab = value)} />
+            {/if}
             <div class="flex w-full flex-col rounded-lg border p-1">
-              {#each accounts as account (account.id)}
+              {#each shownAccounts as account (account.id)}
                 <button
                   type="button"
                   class="hover:bg-muted focus-visible:bg-muted flex w-full cursor-pointer items-center gap-2 rounded-md px-1.5 py-1.5 text-left text-sm outline-none"


### PR DESCRIPTION
## What

Ports the two legacy-UI (`swarm-ui/`) features that landed while the new UI (`ui/`) was being built, applied to the screens the new UI already has:

- **Connect popup: Previously used / All accounts tabs** (port of #333). When at least one account has previously connected to the requesting app, the connect screen shows segmented tabs. "Previously used" is the default and lists those accounts most-recently-used first; "All accounts" shows everything. A manual tab selection takes precedence over the default. Since the new UI has accounts rather than identities, the grouping keys off each account's `connectedApps` history.
- **Authentication before account deletion** (port of #318). The delete confirmation now routes through the existing unlock machinery via a new `'delete'` unlock target instead of deleting immediately. This inherits the attempt-counter protection, so cancelling mid-ceremony can't be overridden by a late-resolving passkey/wallet approval — the same edge case the original PR handled. If the seed is already unlocked in the session, deletion proceeds straight from the confirm dialog, consistent with reveal/export.

## Not ported

The remaining legacy-UI PRs from the same window (#319, #320, #322, #325, #335, #316) touch postage-stamp, dev-page, or sync screens the new UI doesn't have yet — those features belong with those screens when they're built.

## Verification

- `pnpm check:all` and the ui unit tests pass.
- Exercised live in the dev preview with seeded accounts: tabs default to "Previously used" and switch correctly; deleting with a wrong password shows "Wrong password." and keeps the account, while the correct password deletes it and switches the session to the next account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)