### PR TITLE
feat(sync): intent SOCs resolve free-partition races across disjoint gateways

### DIFF
--- a/.claude/rules/bee-cluster.md
+++ b/.claude/rules/bee-cluster.md
@@ -13,39 +13,35 @@ Docker-based local Bee cluster for development with postage stamps. Uses [@snaha
 pnpm dev:bee          # Start cluster (queen + 3 full workers = 4-node net), foreground
 pnpm dev:bee:detach   # Start in background
 pnpm dev:bee:stop     # Stop cluster
-pnpm dev:bee:fresh    # Fresh start (purge data); does NOT --pull (see below)
+pnpm dev:bee:fresh    # Fresh start (purge data)
 ```
 
 The scripts start a 4-node full network (`--full 4` = queen + 3 full workers).
 
-## CRITICAL: the Bee image must be built with `REACHABILITY_OVERRIDE_PUBLIC=true`
+## Pushsync needs `reachabilityOverridePublic=true` — now built into bee-compose ≥ 0.1.4
 
-`deferred: false` writes (every epoch-feed, partition-lock SOC, and any direct `/bytes`/`/chunks`/`/soc`
-upload) require Bee **pushsync** to complete a network **receipt**. A node only stores+receipts a chunk
-when `IsReachable()` is true (`kademlia.go`: reachability == `Public`; checked in `pushsync.go`'s
-handler). Stock `ethersphere/bee` is compiled with `reachabilityOverridePublic="false"` (a **build-time
-ldflag**, not an env var), so it relies on libp2p AutoNAT — which never confirms reachability inside a
-docker bridge network. Every node's _own_ reachability stays `Unknown` → `IsReachable()` is false → no
-node ever stores a forwarded chunk → the push runs out Bee's hard `defaultTTL = 30 s` and fails with
-`context deadline exceeded`. Symptom: **every SOC/non-deferred upload takes exactly ~30 s** (the chunk
-is only stored locally on the origin, so reads work but replication/receipts don't), and multi-device
-lock SOCs never become network-readable by peers.
+`deferred: false` writes (every epoch-feed, partition-lock/intent SOC, and any direct
+`/bytes`/`/chunks`/`/soc` upload — note `uploadData`/`uploadChunk` are non-deferred) require Bee
+**pushsync** to complete a network **receipt**. A node only stores+receipts a chunk when `IsReachable()`
+is true (`kademlia.go`: reachability == `Public`; checked in `pushsync.go`'s handler). Stock
+`ethersphere/bee` is compiled with `reachabilityOverridePublic="false"` (a **build-time ldflag**, not an
+env var), so it relies on libp2p AutoNAT — which never confirms reachability inside a docker bridge
+network. Every node's _own_ reachability stays `Unknown` → `IsReachable()` is false → the push runs out
+Bee's hard `defaultTTL = 30 s` and fails with `context deadline exceeded`. Symptom: **every
+SOC/non-deferred upload takes exactly ~30 s** (reads still work — the chunk is stored locally on the
+origin — but replication/receipts don't), and multi-device lock/intent SOCs never become
+network-readable by peers.
 
-bee-compose 0.1.1's node image is `FROM ethersphere/bee:<ver>` (stock) and does **not** rebuild with the
-override — so out of the box pushsync is broken. Upstream fix tracked at
-**https://github.com/snaha/bee-compose/issues/11**. Until that ships, build a local override base image
-(the Bee Makefile supports the flag) before starting the cluster:
+**Fixed in bee-compose ≥ 0.1.4** ([#11](https://github.com/snaha/bee-compose/issues/11)):
+`bee/Dockerfile` recompiles Bee from source at `v${BEE_VERSION}` with
+`make binary REACHABILITY_OVERRIDE_PUBLIC=true`, so non-deferred uploads replicate out of the box — no
+manual override-image build needed. Cost: the **first** `bee-compose start` compiles Bee from source (a
+few minutes; cached and shared across node images afterward).
 
-```bash
-# from a bee source checkout (e.g. ./bee):
-make docker-build REACHABILITY_OVERRIDE_PUBLIC=true BEE_IMAGE=ethersphere/bee:<ver> PLATFORM=linux/amd64
-# force node images to rebuild on the override base, then start fresh WITHOUT --pull:
-docker rmi -f bee-compose:queen-<ver> bee-compose:worker-1-<ver> bee-compose:worker-2-<ver> bee-compose:worker-3-<ver>
-pnpm exec bee-compose start --full 4 --fresh
-```
-
-Do **NOT** use `--pull`: bee-compose's node services are local-build images, so `compose pull` errors
-(`pull access denied`), and pulling would also replace the local override base with stock Bee.
+> ⚠️ swarm-id pins `@snaha/bee-compose@^0.1.3` and the lockfile may still resolve to **0.1.3 (no
+> override → the ~30 s hang)**. If non-deferred uploads stall locally, update to ≥ 0.1.4
+> (`pnpm update @snaha/bee-compose`) and rebuild (`pnpm dev:bee:fresh`; the first start recompiles Bee).
+> (On a real public gateway the override is irrelevant — reachability is genuine there.)
 
 Verify after start (read-only): every node `bee_kademlia_reachability_status{...="Public"}` (NOT
 `Unknown`); queen `/topology` `connected ≥ 3`; a non-deferred upload returns in <1 s and queen

--- a/docs/Partition-Lock-Hardening-Plan.md
+++ b/docs/Partition-Lock-Hardening-Plan.md
@@ -192,6 +192,17 @@ both writers back on one mutable address — same divergence problem.
 > `knownDeviceIds` getter threaded from the proxy's account device registry. Constants:
 > `INTENT_EPOCH_MS = 30_000`, `INTENT_READ_TIMEOUT_MS = 2500`. The winner = strictly-minimum
 > generation; losers fall back to read-only. Description below is the original design.
+>
+> **Slot placement:** the intent SOC is stamped into the **contended partition's existing
+> reserved slot** (`= partition index`, `< DATA_COUNTER_START`), via
+> `UtilizationAwareStamper.reserveIntentSocSlot` — NOT a data slot and NOT a new reserved
+> index. So it can never share a postage `(bucket, slot)` with user data (deterministic).
+> Residuals, both ~1/65536 per contending pair per round and NOT closed: (1) two contenders'
+> intents hashing into the same bucket → one's stamp evicted → possible rare dual-acquire on
+> disjoint gateways (a verify-own-intent back-off would close it); (2) an intent overstamping
+> the contended partition's own stale lock SOC (harmless) or a published state chunk (→
+> read-only fallback, liveness-only). A dedicated reserved index was rejected: it does not
+> remove residual (1) and costs `1/2^(depth-16)` of the batch.
 
 The account already maintains a synced **device registry** (account-state sync, device
 announce). Use it for enumeration:

--- a/docs/Partition-Lock-Hardening-Plan.md
+++ b/docs/Partition-Lock-Hardening-Plan.md
@@ -185,6 +185,24 @@ derivation needs the rival's generation, which is exactly what neither can read 
 premise of the failure). A shared per-round address (e.g. derived from a time epoch) puts
 both writers back on one mutable address — same divergence problem.
 
+### Holder presence beacons — covers the join-against-an-existing-holder case (SHIPPED)
+
+> **Shipped.** The intent SOC now doubles as a **holder presence beacon**: a holder re-publishes
+> it every refresh tick at the current epoch with `leasedUntil` set (`PartitionLease.refresh` /
+> `publishPresenceBeacon`, payload field `PartitionIntentPayloadSchemaV1.leasedUntil`).
+> `PartitionLease.refreshHoldersFromPresence` (run in `acquire()`, unioned with the static
+> lock-SOC `refreshFromSwarm`) reads every known rival's beacon for the current+previous epoch
+> bucket — fresh per-epoch addresses that retrieve on the gateway where the static lock SOC 404s —
+> and marks a partition **held** iff a beacon has `leasedUntil > now`. This closes the original
+> symmetric/displacement gap's *mirror*: a device joining while a peer already holds a partition
+> now detects that holder and picks another partition (or read-only) instead of colliding. A bare
+> intent (no `leasedUntil`) is a contender, not a holder, and is still resolved by the intent
+> round; an expired beacon is ignored so a lapsed partition can be taken over. `knownDeviceIds` is
+> threaded into the background-sync coordinator (`sync-account.ts`) too, so it isn't a collision
+> source. Residuals unchanged: registry-lag enumeration gap, absence-unprovable (timeout = no
+> beacon), and the ~1/65536 reserved-slot collision — all fail to read-only / self-heal, never
+> silent overwrite.
+
 ### Extension that covers the symmetric case: per-device intent SOCs
 
 > **Shipped** in `lib/src/sync/partition-intent.ts` + wired through

--- a/docs/Partition-Lock-Hardening-Plan.md
+++ b/docs/Partition-Lock-Hardening-Plan.md
@@ -4,8 +4,7 @@ Status: Phase 1 fully specified. The disjoint-gateway hole has two shipped mitig
 
 1. **Deterministic home partition** (`deviceHomePartition`, `partition-lock.ts`): selection
    scans from `keccak256(deviceId) mod partitionCount` instead of always 0, so devices that
-   cannot see each other's locks still spread across slots rather than all binding partition
-   0. Probabilistic — colliding home partitions still race.
+   cannot see each other's locks still spread across slots rather than all binding partition 0. Probabilistic — colliding home partitions still race.
 2. **Per-device intent SOCs** (`partition-intent.ts`, the symmetric-free-partition extension
    below): a fresh claim of a free partition first runs an intent round at a per-epoch
    address that forces a network retrieval (bypassing the frozen gateway cache), so
@@ -17,7 +16,7 @@ Status: Phase 1 fully specified. The disjoint-gateway hole has two shipped mitig
 
 The 2 s guard window in `acquirePartitionLock` (`lib/src/sync/partition-lock.ts`) provides
 probabilistic mutual exclusion only. After writing its claim, a device does ONE verify-read
-and treats *absence of a rival* as success:
+and treats _absence of a rival_ as success:
 
 - a failed verify-read returns `"acquired"` optimistically;
 - a verify-read showing a **lower** generation (stale view, or a rival's chunk that
@@ -32,7 +31,7 @@ silently overwritten and never reconciled.
 
 An **initial** claim must observe its own write (generation equality on a verify-read)
 before returning `"acquired"`. Refresh of an already-live own lease keeps today's optimism —
-safe because `BatchWriteCoordinator.refreshTick` demotes only on a *confirmed* foreign
+safe because `BatchWriteCoordinator.refreshTick` demotes only on a _confirmed_ foreign
 holder (`isDisplaced` with a failed read keeps the lease; verified in code).
 
 ### Protocol change (`lib/src/sync/partition-lock.ts`)
@@ -42,7 +41,7 @@ holder (`isDisplaced` with a failed read keeps the lease; verified in code).
 - New outcome `"unconfirmed"` in `AcquirePartitionLockResult`: nobody contradicted us, but
   our own write never became readable; payload = our claim (peers may still see it live).
 - `isRefresh = current !== undefined && current.holderDeviceId === opts.deviceId &&
-  current.leasedUntil > t`, computed from the pre-write read. Liveness is required: an
+current.leasedUntil > t`, computed from the pre-write read. Liveness is required: an
   expired own claim is contestable and gets initial-claim strictness.
 - After `writePartitionLock` + `wait(guardMs)`: loop up to `1 + SAMPLES` reads (interval
   wait between extras):
@@ -59,7 +58,7 @@ holder (`isDisplaced` with a failed read keeps the lease; verified in code).
   `LEASE_TTL_MS`.
 
 **Why back-off instead of re-assert on LWW inversion** (a rival's lower-generation chunk
-physically survived over our logically-winning one): re-asserting makes *both* contenders
+physically survived over our logically-winning one): re-asserting makes _both_ contenders
 confirm themselves in the crossed-reads interleaving — a guaranteed dual-hold. Backing off
 on any live foreign claim yields exactly one winner regardless of which chunk physically
 survived. In the rare both-back-off cross, the slot heals via the 30 s TTL (correctness
@@ -93,8 +92,8 @@ over availability).
 ### What Phase 1 wins / does not win
 
 Wins: failed-read optimism eliminated for initial claims (fail-safe to read-only); broken
-read-your-writes environments (misrouted gateway, flaky node) become a *liveness* problem
-instead of a *safety* problem; LWW inversion resolved at acquire time with exactly one
+read-your-writes environments (misrouted gateway, flaky node) become a _liveness_ problem
+instead of a _safety_ problem; LWW inversion resolved at acquire time with exactly one
 winner; stale-payload `leasedUntil` regression fixed. Healthy-path latency unchanged
 (~2 s); degraded paths add ≤ 3 s before failing safe.
 
@@ -105,8 +104,8 @@ Does NOT win: the disjoint-gateway race below.
 Device A writes its claim through gateway/node X; device B through node Y. Each verify-read
 is served from the device's own node, which holds (and keeps serving) the device's own
 version of the lock SOC. Both confirm their own writes; neither sees the rival within the
-guard. Both acquire. Phase 1 cannot help: *reading back your own write through your own
-node proves nothing about what the rest of the network sees.*
+guard. Both acquire. Phase 1 cannot help: _reading back your own write through your own
+node proves nothing about what the rest of the network sees._
 
 Root cause: a single mutable address whose value can diverge across nodes. A Bee node
 serves a SOC from its local store when it has one — a node that stored your write has no
@@ -114,7 +113,7 @@ reason to re-fetch the address from the network, so it may never show you the ri
 version. The read path's freshness depends on cache coherence Swarm does not promise.
 
 **It is worse than the own-write case (verified in Bee source, see "Key Bee facts"
-below):** a node also caches chunks it *retrieved* (LRU, no TTL, no invalidation), and
+below):** a node also caches chunks it _retrieved_ (LRU, no TTL, no invalidation), and
 non-neighborhood nodes never participate in pull-sync for the address. So ANY reader
 behind a gateway gets a frozen view of the lock SOC after its first read — not just the
 writer. Displacement detection and Case C polling through a caching gateway degrade the
@@ -123,11 +122,11 @@ same way.
 ## Phase 2 direction — contest SOCs (exploration)
 
 Intuition (AG): alongside the lock SOC, a second SOC whose address is **deterministically
-derived from the lock SOC**, used to *contest* the existing holder.
+derived from the lock SOC**, used to _contest_ the existing holder.
 
 ### The kernel that makes this work
 
-The disjoint-gateway failure is a *local short-circuit*: your node serves its local copy
+The disjoint-gateway failure is a _local short-circuit_: your node serves its local copy
 of an address it has — because you wrote it, **or because it retrieved it once before**
 (retrieved chunks are cached with no TTL and no invalidation; see Key Bee facts). But a
 read of an address your node has **never seen** must trigger a network retrieval (routed
@@ -180,7 +179,7 @@ bounded outstanding request per 10 s tick, only while holding.
 
 ### Where it does not work directly: the symmetric free-partition race
 
-Two contenders claiming a *free* partition cannot derive each other's contest address: the
+Two contenders claiming a _free_ partition cannot derive each other's contest address: the
 derivation needs the rival's generation, which is exactly what neither can read (that's the
 premise of the failure). A shared per-round address (e.g. derived from a time epoch) puts
 both writers back on one mutable address — same divergence problem.
@@ -194,7 +193,7 @@ both writers back on one mutable address — same divergence problem.
 > lock-SOC `refreshFromSwarm`) reads every known rival's beacon for the current+previous epoch
 > bucket — fresh per-epoch addresses that retrieve on the gateway where the static lock SOC 404s —
 > and marks a partition **held** iff a beacon has `leasedUntil > now`. This closes the original
-> symmetric/displacement gap's *mirror*: a device joining while a peer already holds a partition
+> symmetric/displacement gap's _mirror_: a device joining while a peer already holds a partition
 > now detects that holder and picks another partition (or read-only) instead of colliding. A bare
 > intent (no `leasedUntil`) is a contender, not a holder, and is still resolved by the intent
 > round; an expired beacon is ignored so a lapsed partition can be taken over. `knownDeviceIds` is
@@ -230,7 +229,7 @@ intentId = keccak256("swarm-id-partition-intent-v1" ‖ partition ‖ deviceId �
 ```
 
 - Before (or while guarding) a claim on a free partition, a contender writes its intent at
-  its own address and reads every *other known device's* intent address for the current
+  its own address and reads every _other known device's_ intent address for the current
   (and previous) epoch bucket — all addresses it never wrote → network retrievals.
 - Intents carry the generation; the existing fence decides; the loser backs off before
   binding.
@@ -252,7 +251,7 @@ exists" from "the network failed to find it" (verified — Bee collapses all pee
 into one `storage.ErrNotFound` after exhaustion). Treating timeout as "rival may exist"
 would read-only every flaky single device (unacceptable); treating it as "no rival" keeps
 liveness but means the guarantee is "when the network works, rivals are seen". The honest
-claim for Phase 2 is therefore: it removes *gateway cache staleness* — the systematic,
+claim for Phase 2 is therefore: it removes _gateway cache staleness_ — the systematic,
 silent failure mode — leaving only genuine network partition/timeout, which the existing
 TTL + refresh backstop already bounds.
 
@@ -268,14 +267,14 @@ fallback.**
 
 - **Idle** (`activeUploadCount === 0`): run the existing `yieldIdleLease` path
   (`batch-write-coordinator.ts:710` — publish counter via `lease.release`, write the
-  release sentinel, unbind under the write lock), *skipping* the `IDLE_YIELD_MS` wait. The
+  release sentinel, unbind under the write lock), _skipping_ the `IDLE_YIELD_MS` wait. The
   contest is precisely an explicit version of the signal idle-yield currently infers from
   a 30 s silence, so it reuses the machinery and just accelerates it (worst-case handoff
   drops from ~30 s idle + TTL discovery to ~one refresh tick).
 - **Busy** (upload in flight): ignore the contest. The challenger keeps waiting exactly as
   in today's Case C. No "busy ack" chunk is needed: the holder's 10 s refresh keeps
   overstamping the lock SOC with fresh stamp timestamps, and Bee's conflict rule is
-  *deterministic by stamp timestamp* (newer wins, `reserve.go:141-145`), so within the
+  _deterministic by stamp timestamp_ (newer wins, `reserve.go:141-145`), so within the
   neighborhood the live holder keeps winning over any challenger write automatically.
 - **No generation bump as a denial signal**: refresh already mints a fresh generation
   every tick (`acquirePartitionLock` writes `timestampMs: now()` on each re-acquire), so
@@ -300,7 +299,7 @@ bucket; readers poll the current AND previous bucket.**
   a writer and reader can disagree on the bucket only within ~1 s of a boundary, and the
   previous-bucket poll covers exactly that case (plus write-to-read latency).
 - One write per (device, partition, bucket) also sidesteps Bee's same-address rule —
-  re-writing the same SOC address requires a *strictly newer* stamp timestamp (equal is
+  re-writing the same SOC address requires a _strictly newer_ stamp timestamp (equal is
   rejected, `reserve.go:143-144`); fresh per-bucket addresses never hit that path.
 
 ### 3. Intents: replace or augment the lock-SOC guard?
@@ -311,7 +310,7 @@ bucket; readers poll the current AND previous bucket.**
   brand-new device (not yet in the synced device registry) is invisible to per-device
   intent reads but still participates correctly in the lock protocol.
 - Negative intent checks are inherently ambiguous (timeout ≠ absence), so intents can only
-  ever be an *additional* detection channel, not a correctness foundation.
+  ever be an _additional_ detection channel, not a correctness foundation.
 - The guard verify also covers the same-node case for free — where it is already reliable
   (deterministic stamp-timestamp replacement on one node) and costs nothing extra.
 - Layering: lock SOC for correctness, Phase 1 sampling for own-path integrity, intents for
@@ -372,9 +371,9 @@ but two paths slipped through:
 `writePartitionState` (partition-state.ts:185-252) extracts and uploads the counter
 snapshot (steps 1–2), **then** writes the epoch-feed SOC (step 3,
 `BasicEpochUpdater.update` → `uploadSOC`) — and `clearReservedUtilizationChunks()` runs
-*before* the feed write (line 238), so the feed SOC takes the **data-slot path** in
+_before_ the feed write (line 238), so the feed SOC takes the **data-slot path** in
 `UtilizationAwareStamper.stamp()`: it occupies `slot(j)` in its bucket and bumps the live
-counter to `j+1` — *after* the snapshot was already extracted with `j`.
+counter to `j+1` — _after_ the snapshot was already extracted with `j`.
 
 Consequence: the next holder seeds the published counter and its **first data chunk in
 that bucket lands on the feed chunk's exact slot** → newer stamp evicts the feed-update
@@ -384,7 +383,7 @@ partition's data. Probability per handoff ≈ `n/65536` (n = chunks the next hol
 — small per cycle, but systematic, accumulating, and the failure is severe and silent.
 This also falsifies the docs-site claim that "an orderly hand-off never re-uses a slot."
 
-Fix sketch: the feed SOC's address is computable *before* upload (identifier =
+Fix sketch: the feed SOC's address is computable _before_ upload (identifier =
 f(topic, epoch), owner = backup signer; payload-independent). Snapshot the counter from a
 copy with the feed chunk's bucket pre-incremented (`snapshot[b] = live[b] + 1`), extract
 and upload state chunks from the copy, then let the feed stamp consume `slot(live[b])` —
@@ -393,11 +392,12 @@ slot is the alternative, but needs its bucket added to the publish's `claimedBuc
 before the state chunks are placed.)
 
 ### Gap 2 — utilization saves can evict published partition-state chunks, and the
+
 ### zero-counter fallback amplifies a 1-chunk loss into a full-partition overwrite
 
 Published state chunks (counter chunks + reference chunk) sit at
 `(random bucket, reserved slot p)`. Subsequent utilization saves by the next holder
-(`saveUtilizationState` / `flush`) overstamp reserved slot `p` in *their* buckets,
+(`saveUtilizationState` / `flush`) overstamp reserved slot `p` in _their_ buckets,
 nonce-avoiding clean utilization chunks and lock-SOC buckets — **but not the published
 state chunks' buckets** (unknown to that code). A collision evicts a published state
 chunk (~`33 × 32 / 65536` ≈ 1.6 % per full save, accumulating over a holdership).
@@ -411,6 +411,7 @@ existing data chunks network-wide. A one-chunk eviction becomes a whole-partitio
 loss.
 
 Fix sketch, two independent layers:
+
 1. **Fail safe instead of zero-seeding**: when the feed HAS an entry but its chunks can't
    be read, abort the acquisition (read-only this round, retry later) instead of seeding
    zero. Zero-seed only when the feed provably has no entry. This alone downgrades the
@@ -420,6 +421,7 @@ Fix sketch, two independent layers:
    `claimedBuckets` for `flush()` and `saveUtilizationState`.
 
 ### Gap 3 (minor, verify) — publish chunks can evict the holder's own on-Swarm
+
 ### utilization chunks
 
 The publish's `claimedBuckets` starts from only the lock bucket, so a state chunk can land
@@ -548,14 +550,14 @@ loop with a stubbed RNG or by asserting `claimedBuckets` input).
 
 ## Appendix — key Bee facts (verified in source, bee 2.x)
 
-| Fact | Evidence |
-| --- | --- |
-| Same-address SOC conflict: replace iff strictly newer **postage stamp timestamp**, else `ErrOverwriteNewerChunk`. Deterministic, not arrival order. | `pkg/storer/internal/reserve/reserve.go:139-219` |
-| Stamp-index (overstamp) collision, different addresses: newer stamp timestamp evicts the older chunk's data entirely. | `reserve.go:221-237`, `chunkstore.go:97-119` |
-| Stamp timestamps are minted by the client at stamping time (`Date.now()`), so the network's LWW aligns with the generation fence under the clock-sync assumption. | bee-js `src/stamper/stamper.ts:48` |
-| Reads short-circuit on local store; network retrieval only on local miss. | `pkg/storer/netstore.go:96-105` |
-| Successfully retrieved chunks are cached locally (LRU on access time, **no TTL, no invalidation**) — a gateway's view of a mutable SOC freezes after first contact. | `netstore.go:106-124`, `pkg/storer/internal/cache/cache.go:128-182` |
-| Pull-sync converges replicas on the highest stamp timestamp **within the storage neighborhood only**; non-neighborhood nodes never update their copies. | `pkg/pullsync/pullsync.go:379-390`, `pkg/storer/reserve.go:295` |
-| Push-sync receipt = chunk stored in the reserve of a proximity-verified neighborhood peer; ~3 replicas via multiplexing (`maxMultiplexForwards = 2`). | `pkg/pushsync/pushsync.go:268-287, :456-463, :55, :567-603` |
-| Retrieval of an absent chunk: per-peer timeout 30 s, up to 32 origin attempts, all errors collapse into `storage.ErrNotFound` — absence is indistinguishable from failure. | `pkg/retrieval/retrieval.go:125-130, :269-287` |
-| Bee notifies GSOC subscribers when a SOC push passes through a node responsible for the address — a possible future *notification* channel if contest addresses were mined into the holder's node's neighborhood (requires knowing the holder node's overlay + a gateway exposing the GSOC API; out of scope here, needs its own research). | `pkg/pushsync/pushsync.go:242-248`, `pkg/gsoc` |
+| Fact                                                                                                                                                                                                                                                                                                                                        | Evidence                                                            |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| Same-address SOC conflict: replace iff strictly newer **postage stamp timestamp**, else `ErrOverwriteNewerChunk`. Deterministic, not arrival order.                                                                                                                                                                                         | `pkg/storer/internal/reserve/reserve.go:139-219`                    |
+| Stamp-index (overstamp) collision, different addresses: newer stamp timestamp evicts the older chunk's data entirely.                                                                                                                                                                                                                       | `reserve.go:221-237`, `chunkstore.go:97-119`                        |
+| Stamp timestamps are minted by the client at stamping time (`Date.now()`), so the network's LWW aligns with the generation fence under the clock-sync assumption.                                                                                                                                                                           | bee-js `src/stamper/stamper.ts:48`                                  |
+| Reads short-circuit on local store; network retrieval only on local miss.                                                                                                                                                                                                                                                                   | `pkg/storer/netstore.go:96-105`                                     |
+| Successfully retrieved chunks are cached locally (LRU on access time, **no TTL, no invalidation**) — a gateway's view of a mutable SOC freezes after first contact.                                                                                                                                                                         | `netstore.go:106-124`, `pkg/storer/internal/cache/cache.go:128-182` |
+| Pull-sync converges replicas on the highest stamp timestamp **within the storage neighborhood only**; non-neighborhood nodes never update their copies.                                                                                                                                                                                     | `pkg/pullsync/pullsync.go:379-390`, `pkg/storer/reserve.go:295`     |
+| Push-sync receipt = chunk stored in the reserve of a proximity-verified neighborhood peer; ~3 replicas via multiplexing (`maxMultiplexForwards = 2`).                                                                                                                                                                                       | `pkg/pushsync/pushsync.go:268-287, :456-463, :55, :567-603`         |
+| Retrieval of an absent chunk: per-peer timeout 30 s, up to 32 origin attempts, all errors collapse into `storage.ErrNotFound` — absence is indistinguishable from failure.                                                                                                                                                                  | `pkg/retrieval/retrieval.go:125-130, :269-287`                      |
+| Bee notifies GSOC subscribers when a SOC push passes through a node responsible for the address — a possible future _notification_ channel if contest addresses were mined into the holder's node's neighborhood (requires knowing the holder node's overlay + a gateway exposing the GSOC API; out of scope here, needs its own research). | `pkg/pushsync/pushsync.go:242-248`, `pkg/gsoc`                      |

--- a/docs/Partition-Lock-Hardening-Plan.md
+++ b/docs/Partition-Lock-Hardening-Plan.md
@@ -1,0 +1,532 @@
+# Partition Lock Hardening — Verify-Own-Write Plan & Contest-SOC Direction
+
+Status: Phase 1 fully specified. The disjoint-gateway hole has two shipped mitigations:
+
+1. **Deterministic home partition** (`deviceHomePartition`, `partition-lock.ts`): selection
+   scans from `keccak256(deviceId) mod partitionCount` instead of always 0, so devices that
+   cannot see each other's locks still spread across slots rather than all binding partition
+   0. Probabilistic — colliding home partitions still race.
+2. **Per-device intent SOCs** (`partition-intent.ts`, the symmetric-free-partition extension
+   below): a fresh claim of a free partition first runs an intent round at a per-epoch
+   address that forces a network retrieval (bypassing the frozen gateway cache), so
+   contenders agree on one winner before binding. This is the real fix for the symmetric
+   free-partition race; the holder-vs-challenger displacement-detection direction remains
+   exploration.
+
+## Problem
+
+The 2 s guard window in `acquirePartitionLock` (`lib/src/sync/partition-lock.ts`) provides
+probabilistic mutual exclusion only. After writing its claim, a device does ONE verify-read
+and treats *absence of a rival* as success:
+
+- a failed verify-read returns `"acquired"` optimistically;
+- a verify-read showing a **lower** generation (stale view, or a rival's chunk that
+  physically replaced ours via LWW) also returns `"acquired"`.
+
+A device therefore never confirms its claim is actually readable on the network before
+binding the partition and stamping. Dual-hold is possible until the 10 s refresh /
+confirmed-displacement backstop catches it; chunks stamped by both sides in that window are
+silently overwritten and never reconciled.
+
+## Phase 1 — verify-own-write sampling (specified, ready to implement)
+
+An **initial** claim must observe its own write (generation equality on a verify-read)
+before returning `"acquired"`. Refresh of an already-live own lease keeps today's optimism —
+safe because `BatchWriteCoordinator.refreshTick` demotes only on a *confirmed* foreign
+holder (`isDisplaced` with a failed read keeps the lease; verified in code).
+
+### Protocol change (`lib/src/sync/partition-lock.ts`)
+
+- New constants: `PARTITION_LOCK_VERIFY_SAMPLES = 3`,
+  `PARTITION_LOCK_VERIFY_SAMPLE_INTERVAL_MS = 1000` (exported, next to `TIEBREAKER_BYTES`).
+- New outcome `"unconfirmed"` in `AcquirePartitionLockResult`: nobody contradicted us, but
+  our own write never became readable; payload = our claim (peers may still see it live).
+- `isRefresh = current !== undefined && current.holderDeviceId === opts.deviceId &&
+  current.leasedUntil > t`, computed from the pre-write read. Liveness is required: an
+  expired own claim is contestable and gets initial-claim strictness.
+- After `writePartitionLock` + `wait(guardMs)`: loop up to `1 + SAMPLES` reads (interval
+  wait between extras):
+  - read fails → next sample
+  - **equal** generation → `acquired` (own write confirmed; return `verified`)
+  - **higher** generation → `lost-race`
+  - foreign payload that is **live** → `lost-race` — back off, NEVER re-assert (see below)
+  - stale own lower generation / expired or released foreign → next sample
+  - exhausted → `isRefresh ? acquired (ourPayload) : unconfirmed (ourPayload)`
+- Fixes a latent wart: only an equal-generation read returns `verified`; exhausted paths
+  return `ourPayload`, so a stale self-read can no longer regress `leasedUntil` downstream.
+- Do NOT write a release sentinel on `unconfirmed`: a fresh now-timestamped generation
+  would out-fence a real winner we simply couldn't see. The ghost claim self-heals within
+  `LEASE_TTL_MS`.
+
+**Why back-off instead of re-assert on LWW inversion** (a rival's lower-generation chunk
+physically survived over our logically-winning one): re-asserting makes *both* contenders
+confirm themselves in the crossed-reads interleaving — a guaranteed dual-hold. Backing off
+on any live foreign claim yields exactly one winner regardless of which chunk physically
+survived. In the rare both-back-off cross, the slot heals via the 30 s TTL (correctness
+over availability).
+
+### Supporting changes
+
+- `partition-lease.ts`: thread an optional `wait` override into both `acquirePartitionLock`
+  call sites (mirrors `now`/`guardMs`); doc-comment `unconfirmed`. No logic change — both
+  consumers already gate on `outcome !== "acquired"`.
+- `batch-write-coordinator.ts`: comment that `refresh() === false` now includes
+  `unconfirmed` and that the confirmatory `isDisplaced` read is the healthy-holder
+  protection.
+- Tests (`partition-lock.test.ts`, existing MockBee/MockChunkStore harness):
+  - changed: "acquires optimistically when the verify-read can't confirm" → expects
+    `unconfirmed` for initial claims;
+  - unchanged: stale-verify split-brain and `guardMs = 0` TOCTOU known-failure tests (the
+    first sample confirms equal generation — sampling deliberately does not fix those);
+  - new: transient verify failure recovers by sample 2 → `acquired`; all-samples-fail with
+    live own pre-read → `acquired` (refresh optimism); with expired own pre-read →
+    `unconfirmed`; higher generation at sample 2 → `lost-race`; live foreign
+    lower-generation during guard → `lost-race` with no rewrite; stale-own-then-current →
+    `acquired` with current payload; first-read confirmation does exactly one wait.
+  - `partition-lease.integration.test.ts`: `unconfirmed` → `isReadOnly: true`; refresh
+    stays held when sampling can't confirm but the pre-read showed us live.
+- Docs (`docs-site/.../multi-device-postage-batches.mdx`): Acquire/refresh protocol steps
+  4–6 (sampled verify, equal-generation confirmation, live-foreign back-off,
+  `unconfirmed`), constants table, Design assumptions → Network bullet, porting checklist
+  item 3.
+
+### What Phase 1 wins / does not win
+
+Wins: failed-read optimism eliminated for initial claims (fail-safe to read-only); broken
+read-your-writes environments (misrouted gateway, flaky node) become a *liveness* problem
+instead of a *safety* problem; LWW inversion resolved at acquire time with exactly one
+winner; stale-payload `leasedUntil` regression fixed. Healthy-path latency unchanged
+(~2 s); degraded paths add ≤ 3 s before failing safe.
+
+Does NOT win: the disjoint-gateway race below.
+
+## The remaining hole: disjoint-gateway dual-acquire
+
+Device A writes its claim through gateway/node X; device B through node Y. Each verify-read
+is served from the device's own node, which holds (and keeps serving) the device's own
+version of the lock SOC. Both confirm their own writes; neither sees the rival within the
+guard. Both acquire. Phase 1 cannot help: *reading back your own write through your own
+node proves nothing about what the rest of the network sees.*
+
+Root cause: a single mutable address whose value can diverge across nodes. A Bee node
+serves a SOC from its local store when it has one — a node that stored your write has no
+reason to re-fetch the address from the network, so it may never show you the rival's
+version. The read path's freshness depends on cache coherence Swarm does not promise.
+
+**It is worse than the own-write case (verified in Bee source, see "Key Bee facts"
+below):** a node also caches chunks it *retrieved* (LRU, no TTL, no invalidation), and
+non-neighborhood nodes never participate in pull-sync for the address. So ANY reader
+behind a gateway gets a frozen view of the lock SOC after its first read — not just the
+writer. Displacement detection and Case C polling through a caching gateway degrade the
+same way.
+
+## Phase 2 direction — contest SOCs (exploration)
+
+Intuition (AG): alongside the lock SOC, a second SOC whose address is **deterministically
+derived from the lock SOC**, used to *contest* the existing holder.
+
+### The kernel that makes this work
+
+The disjoint-gateway failure is a *local short-circuit*: your node serves its local copy
+of an address it has — because you wrote it, **or because it retrieved it once before**
+(retrieved chunks are cached with no TTL and no invalidation; see Key Bee facts). But a
+read of an address your node has **never seen** must trigger a network retrieval (routed
+to the address's storage neighborhood, where the rival's receipt-backed push-sync placed
+~3 replicas) or fail. So the fix direction is:
+
+> Make race/displacement detection depend on reading addresses that **only the rival
+> writes** and that are **fresh per contention round** (never previously retrieved by
+> your node either).
+
+That converts the problem from "mutable-SOC cache coherence" (which Swarm doesn't
+guarantee) to "push-sync receipt + retrieval routing" (which is Swarm's core mechanism).
+
+### Where the idea works directly: challenger vs holder
+
+Derive the contest address from the holder's **device id plus a time bucket** — NOT from
+the holder's generation, and not from the static lock-SOC address:
+
+```
+contestId = keccak256("swarm-id-partition-contest-v1" ‖ partition ‖ holderDeviceId ‖ epochBucket)
+```
+
+- Generation is the wrong key (research finding): every 10 s refresh tick re-runs the lock
+  protocol and mints a **fresh generation**, so a generation-derived contest address would
+  rotate out from under the challenger before its contest is seen. `holderDeviceId` is
+  stable for the whole holdership and the challenger learns it from its (possibly stale)
+  lock-SOC read; the epoch bucket provides the freshness rotation instead.
+- A static address is also wrong: after the first retrieval, both nodes hold cached copies
+  and re-reads are served locally forever.
+- A challenger that wants partition `p` held by device `H` writes a contest SOC at
+  `f(p, H, bucket(now))` (non-deferred, receipt-backed).
+- The holder, on each refresh tick, polls `f(p, ownDeviceId, bucket(now))` — one address,
+  which its node has never written; the first poll of each bucket is a genuine network
+  retrieval. (After a contest is retrieved once it is cached — harmless, it was already
+  seen.)
+- Staleness edge: if the challenger's frozen lock-SOC view names an OLD holder, its
+  contest goes to an address nobody polls — the challenger falls back to today's TTL /
+  turn-taking wait. Liveness degradation only, never a safety problem.
+
+This fixes the displacement-detection direction of the disjoint-gateway problem: today a
+holder can also miss a rival's lock-SOC overwrite for the same stale-read reason.
+
+**Negative-poll cost (research finding):** Bee has no fast authoritative "not found" — a
+retrieval of an absent chunk fails only after exhausting peers (30 s per-peer timeout, up
+to 32 origin attempts), and the error is indistinguishable from a transient network
+failure. The holder's per-tick poll must therefore use a short client-side timeout
+(~2–3 s): a chunk that exists in its neighborhood typically retrieves in well under that;
+a timed-out poll is treated as "no contest" and simply repeats next tick. Cost: one
+bounded outstanding request per 10 s tick, only while holding.
+
+### Where it does not work directly: the symmetric free-partition race
+
+Two contenders claiming a *free* partition cannot derive each other's contest address: the
+derivation needs the rival's generation, which is exactly what neither can read (that's the
+premise of the failure). A shared per-round address (e.g. derived from a time epoch) puts
+both writers back on one mutable address — same divergence problem.
+
+### Extension that covers the symmetric case: per-device intent SOCs
+
+> **Shipped** in `lib/src/sync/partition-intent.ts` + wired through
+> `PartitionLease.claimPartition` (gated on a fresh claim with ≥1 known rival) and the
+> `knownDeviceIds` getter threaded from the proxy's account device registry. Constants:
+> `INTENT_EPOCH_MS = 30_000`, `INTENT_READ_TIMEOUT_MS = 2500`. The winner = strictly-minimum
+> generation; losers fall back to read-only. Description below is the original design.
+
+The account already maintains a synced **device registry** (account-state sync, device
+announce). Use it for enumeration:
+
+```
+intentId = keccak256("swarm-id-partition-intent-v1" ‖ partition ‖ deviceId ‖ epochBucket)
+```
+
+- Before (or while guarding) a claim on a free partition, a contender writes its intent at
+  its own address and reads every *other known device's* intent address for the current
+  (and previous) epoch bucket — all addresses it never wrote → network retrievals.
+- Intents carry the generation; the existing fence decides; the loser backs off before
+  binding.
+- `epochBucket = floor(now / EPOCH_MS)` (TTL-sized, e.g. 30 s) makes every contention round
+  use **fresh addresses**, so no node ever has a stale cached copy of a rival's intent.
+- A brand-new device not yet in the registry falls back to today's behavior (guard + TTL +
+  turn-taking) until its announce propagates — the common contention case is between
+  registered devices.
+
+Cost per acquire: one extra small write + (N−1) retrieval attempts (N = known devices,
+small), each with a short client-side timeout (~2–3 s, run in parallel) since a no-rival
+check usually targets an absent address and Bee has no fast authoritative not-found. Only
+on the initial-claim path; refresh unaffected.
+
+### The irreducible limit
+
+Absence is unprovable on Swarm: a retrieval timeout cannot distinguish "no rival intent
+exists" from "the network failed to find it" (verified — Bee collapses all peer errors
+into one `storage.ErrNotFound` after exhaustion). Treating timeout as "rival may exist"
+would read-only every flaky single device (unacceptable); treating it as "no rival" keeps
+liveness but means the guarantee is "when the network works, rivals are seen". The honest
+claim for Phase 2 is therefore: it removes *gateway cache staleness* — the systematic,
+silent failure mode — leaving only genuine network partition/timeout, which the existing
+TTL + refresh backstop already bounds.
+
+## Open questions — researched answers (2026-06-12)
+
+Researched against the Bee source checkout (`./bee`, 2.x) and bee-js. Key supporting
+facts with file references are collected in the appendix below.
+
+### 1. Holder reaction protocol on observing a contest
+
+**Answer: yield-if-idle, ignore-if-busy. No generation bump. `IDLE_YIELD_MS` stays as the
+fallback.**
+
+- **Idle** (`activeUploadCount === 0`): run the existing `yieldIdleLease` path
+  (`batch-write-coordinator.ts:710` — publish counter via `lease.release`, write the
+  release sentinel, unbind under the write lock), *skipping* the `IDLE_YIELD_MS` wait. The
+  contest is precisely an explicit version of the signal idle-yield currently infers from
+  a 30 s silence, so it reuses the machinery and just accelerates it (worst-case handoff
+  drops from ~30 s idle + TTL discovery to ~one refresh tick).
+- **Busy** (upload in flight): ignore the contest. The challenger keeps waiting exactly as
+  in today's Case C. No "busy ack" chunk is needed: the holder's 10 s refresh keeps
+  overstamping the lock SOC with fresh stamp timestamps, and Bee's conflict rule is
+  *deterministic by stamp timestamp* (newer wins, `reserve.go:141-145`), so within the
+  neighborhood the live holder keeps winning over any challenger write automatically.
+- **No generation bump as a denial signal**: refresh already mints a fresh generation
+  every tick (`acquirePartitionLock` writes `timestampMs: now()` on each re-acquire), so
+  "the holder is alive" is already continuously signalled; an extra bump channel adds
+  nothing.
+- `IDLE_YIELD_MS` remains the fallback for lost/unseen contests (frozen-gateway challenger
+  writing to a stale holder's address, dropped chunk, etc.) — contests improve latency,
+  never replace the TTL/turn-taking safety net.
+
+### 2. Epoch bucket size vs clock skew
+
+**Answer: `EPOCH_MS = LEASE_TTL_MS = 30 s`, unix-time aligned; writers write the current
+bucket; readers poll the current AND previous bucket.**
+
+- Lower bound: a bucket must comfortably contain one receipt-backed write (~1–2 s) plus a
+  short-timeout retrieval (~2–3 s) plus the assumed ≤ ~1 s clock skew — 30 s is ~5× that.
+- Upper bound: bucket length is the address-rotation period; rotation is what defeats the
+  no-TTL retrieval cache, and it also bounds how long a contest written "into the past"
+  stays visible. TTL-sized alignment means one contest round and one lease lifetime have
+  the same horizon — easy to reason about.
+- Two-bucket reads make boundary skew a non-issue: with ≤ 1 s skew against a 30 s bucket,
+  a writer and reader can disagree on the bucket only within ~1 s of a boundary, and the
+  previous-bucket poll covers exactly that case (plus write-to-read latency).
+- One write per (device, partition, bucket) also sidesteps Bee's same-address rule —
+  re-writing the same SOC address requires a *strictly newer* stamp timestamp (equal is
+  rejected, `reserve.go:143-144`); fresh per-bucket addresses never hit that path.
+
+### 3. Intents: replace or augment the lock-SOC guard?
+
+**Answer: augment, never replace.**
+
+- The lock SOC + generation fence + TTL is the only layer with no enumeration gap: a
+  brand-new device (not yet in the synced device registry) is invisible to per-device
+  intent reads but still participates correctly in the lock protocol.
+- Negative intent checks are inherently ambiguous (timeout ≠ absence), so intents can only
+  ever be an *additional* detection channel, not a correctness foundation.
+- The guard verify also covers the same-node case for free — where it is already reliable
+  (deterministic stamp-timestamp replacement on one node) and costs nothing extra.
+- Layering: lock SOC for correctness, Phase 1 sampling for own-path integrity, intents for
+  cross-node visibility. Each layer fails toward read-only (safety), never toward
+  dual-hold.
+
+### 4. Storage hygiene: routing and eviction collisions
+
+**Answer: route intent/contest chunks to the partition's reserved slot in their own bucket
+(the counter-chunk mechanism), nonce-avoid the lock-SOC buckets, accept the residual
+2⁻¹⁶-class collisions.**
+
+- Overstamping eviction is real and deterministic: two chunks stamped by the same batch at
+  the same `(bucket, slot)` → the newer stamp timestamp **evicts the older chunk's data
+  entirely** (`reserve.go:221-237`, old chunk removed from the chunkstore). So an
+  intent/contest chunk routed to a reserved slot evicts whatever lived there.
+- Therefore: register each intent address with the stamper before upload (the existing
+  `markReservedUtilizationChunk` routing — `batch-utilization.ts`), so it overstamps
+  `reserved slot = partition` in its own bucket and never consumes data-lane slots or
+  bumps counters.
+- Lock-SOC bucket collision must be avoided deterministically: derivation appends a uint8
+  nonce, incremented until `bucket(address) ∉ lockSocBuckets`. Both writers and readers
+  compute the same nonce (lock-SOC addresses are deterministic per account); expected
+  iterations ≈ 1 (collision chance `K/65536` per try).
+- Residual collisions are accepted and documented: two intents in the same bucket's
+  reserved slot (≈ 2⁻¹⁶ per pair per round) — newer evicts older, which can hide a rival's
+  intent for one round (the guard + TTL layer still applies); an intent landing on a
+  counter chunk's bucket evicts that counter chunk from the reserve — transient, since
+  counter chunks are re-uploaded on every save and resumable from the local cache.
+
+### 5. Liveness canary (holder reads its own next-epoch intent address)
+
+**Answer: drop it — it is either meaningless or already covered by receipts.**
+
+- A self-read through your own node proves nothing: if your node stored the write, the
+  read short-circuits locally (`netstore.go:96-100`) and never touches the network path
+  the canary was meant to test.
+- A poll of an address that usually does not exist has the negative-check cost problem
+  (hangs until client timeout, every tick).
+- The push-sync **receipt already is the network-path proof**: it is issued only after the
+  chunk is stored in the reserve of a proximity-verified peer in the address's
+  neighborhood, with ~3 replicas via multiplexed forwarding (`pushsync.go:268-287`, `:55`).
+  A receipt-backed intent/lock write therefore proves durable network placement strictly
+  better than any read-back canary could.
+
+## Consequences of overstamping eviction for the CURRENT implementation (2026-06-12)
+
+The eviction rule behind answer 4 (same batch, same `(bucket, slot)` → newer stamp
+timestamp **deletes** the older chunk from the reserve) is not only a constraint on the
+future intent design — it exposes two real gaps in the shipped protocol. The codebase
+clearly knows about the hazard (utilization saves avoid lock-SOC buckets; the
+partition-state publish avoids its own lock bucket and self-collisions,
+`partition-state.ts:215`; data slots and reserved slots are disjoint by the slot formula),
+but two paths slipped through:
+
+### Gap 1 — the release-path feed SOC consumes an unrecorded data slot
+
+`writePartitionState` (partition-state.ts:185-252) extracts and uploads the counter
+snapshot (steps 1–2), **then** writes the epoch-feed SOC (step 3,
+`BasicEpochUpdater.update` → `uploadSOC`) — and `clearReservedUtilizationChunks()` runs
+*before* the feed write (line 238), so the feed SOC takes the **data-slot path** in
+`UtilizationAwareStamper.stamp()`: it occupies `slot(j)` in its bucket and bumps the live
+counter to `j+1` — *after* the snapshot was already extracted with `j`.
+
+Consequence: the next holder seeds the published counter and its **first data chunk in
+that bucket lands on the feed chunk's exact slot** → newer stamp evicts the feed-update
+chunk from the reserve. A later takeover walking the feed then misses the newest entry
+and resumes from an **older** (or no) counter → bulk slot reuse → silent overwrite of the
+partition's data. Probability per handoff ≈ `n/65536` (n = chunks the next holder stamps)
+— small per cycle, but systematic, accumulating, and the failure is severe and silent.
+This also falsifies the docs-site claim that "an orderly hand-off never re-uses a slot."
+
+Fix sketch: the feed SOC's address is computable *before* upload (identifier =
+f(topic, epoch), owner = backup signer; payload-independent). Snapshot the counter from a
+copy with the feed chunk's bucket pre-incremented (`snapshot[b] = live[b] + 1`), extract
+and upload state chunks from the copy, then let the feed stamp consume `slot(live[b])` —
+snapshot and post-release live state then agree. (Routing the feed SOC to the reserved
+slot is the alternative, but needs its bucket added to the publish's `claimedBuckets`
+before the state chunks are placed.)
+
+### Gap 2 — utilization saves can evict published partition-state chunks, and the
+### zero-counter fallback amplifies a 1-chunk loss into a full-partition overwrite
+
+Published state chunks (counter chunks + reference chunk) sit at
+`(random bucket, reserved slot p)`. Subsequent utilization saves by the next holder
+(`saveUtilizationState` / `flush`) overstamp reserved slot `p` in *their* buckets,
+nonce-avoiding clean utilization chunks and lock-SOC buckets — **but not the published
+state chunks' buckets** (unknown to that code). A collision evicts a published state
+chunk (~`33 × 32 / 65536` ≈ 1.6 % per full save, accumulating over a holdership).
+
+The amplification: on the next takeover that actually needs that publish (typically
+Case D — the interim holder crashed without publishing), `readPartitionState` hits the
+missing chunk and its catch block **seeds a fresh zero counter**
+(partition-state.ts:161-168, deliberately, as "resilience") → the taker resumes every
+bucket at `j = 0` → re-issues every used slot → each new chunk evicts the partition's
+existing data chunks network-wide. A one-chunk eviction becomes a whole-partition data
+loss.
+
+Fix sketch, two independent layers:
+1. **Fail safe instead of zero-seeding**: when the feed HAS an entry but its chunks can't
+   be read, abort the acquisition (read-only this round, retry later) instead of seeding
+   zero. Zero-seed only when the feed provably has no entry. This alone downgrades the
+   failure from "overwrite everything" to "delayed takeover".
+2. **Bucket avoidance**: persist the published state-chunk buckets (the publisher knows
+   them; a taker learns them from the reference chunk — ≤ 65 buckets) and include them in
+   `claimedBuckets` for `flush()` and `saveUtilizationState`.
+
+### Gap 3 (minor, verify) — publish chunks can evict the holder's own on-Swarm
+### utilization chunks
+
+The publish's `claimedBuckets` starts from only the lock bucket, so a state chunk can land
+in a bucket occupied by a current on-Swarm utilization chunk (same reserved slot p) and
+evict it. Likely benign — cross-device counter resume goes through the partition-state
+feed, and `loadUtilizationState` reads only the local IndexedDB cache — but worth
+verifying that no path ever re-downloads utilization chunks by their `contentHash` from
+Swarm before relying on it.
+
+## Fix plan — partition-state eviction gaps (2026-06-12)
+
+One branch (`fix/partition-state-eviction`), three commits in this order — each
+independently shippable, ordered by value/risk. No wire-format changes anywhere: fix B is
+reader-local arithmetic and fix C is writer-local placement, so old and new clients
+interoperate (an old client simply keeps the old bugs).
+
+Verified call graph: `readPartitionState`/`writePartitionState` are consumed only by
+`PartitionLease.claimPartition`/`release` (plus the public lib export — no UI/demo
+usage). The epoch SOC identifier derivation is inline in
+`proxy/feeds/epochs/updater.ts:161-163` (`keccak(topic ‖ keccak(start ‖ level))`).
+`AsyncEpochFinder.findAtWithMetadata` already returns the winning entry's `epoch`.
+
+### Commit A — fail-safe counter reads (kills the amplifier)
+
+`lib/src/sync/partition-state.ts`:
+
+- `readPartitionState` return type gains a discriminated failure:
+  `{ readFailed: true }` (no `localCounter`, no `referenceHex`). Emitted from the
+  current catch block (lines 161-168) — i.e. the feed HAS an entry but the reference
+  chunk or any counter chunk is unreadable. The no-entry path (`!refBytes`) keeps
+  returning a zero counter (legitimate Case A/B fresh seed).
+- `PartitionLease.claimPartition` (`partition-lease.ts:283`): on `readFailed`, return the
+  read-only `AcquireResult` WITHOUT running the lock protocol (do not write a claim over
+  a partition whose resume point is unknown). The coordinator's existing
+  `acquireWithSlotWait` retry cadence (~10 s) provides the retry loop.
+- Tests: flip `partition-lease.integration.test.ts:184` ("returns a fresh zero counter
+  when the feed entry is unreadable" → "fails the read; claimPartition degrades to
+  read-only without writing the lock"). Add: missing ONE counter chunk (not just the
+  reference chunk) → same; feed genuinely empty → still zero-seeds and proceeds.
+
+### Commit B — account for the release-path feed SOC slot (reader-side bump)
+
+Insight that makes this trivial and backward compatible: the reader can reconstruct
+exactly which slot the feed SOC consumed — it sits at `slot(snapshot[bucket])` of the
+bucket of the feed entry's own SOC address. So instead of changing the publish (which
+would need format versioning), the READER compensates:
+
+- Extract the identifier derivation from `updater.ts:161-163` into an exported helper
+  (`makeEpochIdentifier(topic, epoch)`) and add a small
+  `epochSocAddress(topic, epoch, owner)` (keccak(identifier ‖ owner), same formula as
+  `lockSocAddress`).
+- `readPartitionState`: use `finder.findAtWithMetadata(now)` instead of `findAt`; after a
+  successful counter reconstruction, compute the entry's SOC address from the returned
+  `epoch`, and `localCounter[toBucket(addr)] += 1`.
+- Correctness notes (encode as comments + tests):
+  - the `unchanged: true` short-circuit must NOT bump — the local live counter already
+    includes the bump (the stamper incremented it when the feed SOC was stamped);
+  - only the latest entry needs compensation: any earlier entry was compensated by the
+    reader that consumed it, and a same-device re-acquire uses the live counter;
+  - for pre-fix publishes this exactly fixes the collision; for hypothetical future
+    writer-side accounting it would waste one slot in one bucket — harmless, so the rule
+    is unconditional (no format detection).
+- Tests (`partition-lease.integration.test.ts` round-trip): after
+  `writePartitionState`, assert `readPartitionState` returns a counter where the feed
+  entry's bucket equals the publisher's LIVE post-release counter (not the snapshot);
+  assert a next-holder stamp into that bucket gets a fresh slot (no collision with the
+  feed SOC's `(bucket, slot)`).
+
+### Commit C — bucket avoidance for reserved-slot writers
+
+Three placement rules, all same-partition (`slot p`) since cross-partition slots are
+disjoint:
+
+1. **Saves must avoid the published state chunks.** Persist the protected bucket set per
+   `(batchId, partition)`:
+   - `writePartitionState` already knows every bucket it used (`claimedBuckets`) — return
+     it; `PartitionLease.release` hands it to the stamper.
+   - `readPartitionState` derives the same set from the reference chunk (counter-chunk
+     addresses = first 32 bytes of each 64-byte ref) plus the reference chunk's own
+     bucket — return it; `claimPartition` hands it to the stamper.
+   - Stamper (`UtilizationAwareStamper`): hold it in memory
+     (`setProtectedStateBuckets`), persist alongside `syncedReferences` in the
+     utilization-store metadata (additive schema field `stateChunkBuckets` keyed by
+     partition; `storage/utilization-store.ts`), restore on create.
+   - Consume it: `flush()` adds it to `claimedBuckets` (next to the lock-SOC buckets),
+     and expose `getProtectedBuckets()` (= lock buckets ∪ state buckets) so the
+     `saveUtilizationState` call sites pass the union as `reservedBuckets`.
+2. **The publish must avoid the live clean utilization chunks** (Gap 3 hardening, even
+   though nothing downloads them today — verified: no Swarm read path for utilization
+   chunks exists, `contentHash` is dedup bookkeeping only): seed `writePartitionState`'s
+   `claimedBuckets` from the stamper's clean-chunk buckets when available (pass through
+   from `release`, which has the `UtilizationAwareStamper`).
+3. Comment the residual accepted risks at the derivation sites (intent-vs-intent class
+   collisions, ≈ 2⁻¹⁶ per pair per round).
+
+Tests: plumbing-level — after a publish + reload, `flush()`'s claimed-bucket set includes
+the persisted state buckets (assert via `getProtectedBuckets()`); `writePartitionState`
+skips a bucket occupied by a clean utilization chunk (craft via the random-key re-roll
+loop with a stubbed RNG or by asserting `claimedBuckets` input).
+
+### Docs (same branch)
+
+`docs-site/.../multi-device-postage-batches.mdx`:
+
+- Partition-state feed section: replace "A failed counter read falls back to a fresh zero
+  counter rather than aborting" with the fail-safe semantics; document the reader-side
+  feed-bucket bump as part of the read algorithm (porting-relevant: a port that skips the
+  bump re-introduces the feed-chunk collision — reader-local, so no interop break, but
+  spec it).
+- Lease lifecycle / Case D: "resume from the last published counter, +1 in the feed
+  entry's bucket".
+- The "orderly hand-off never re-uses a slot" claim becomes true; keep it, with the bump
+  as the reason.
+
+### Verification
+
+1. `pnpm --filter @snaha/swarm-id test` — flipped + new integration tests green.
+2. `pnpm check:all`; prettier on touched files.
+3. Manual, local bee cluster: two browser profiles (agent accounts) on one batch; device A
+   uploads + releases (idle yield), device B takes over and uploads into the same buckets;
+   then kill B mid-hold and let A reclaim (Case D) — assert A's resume counter ≥ B's
+   published counter and that previously uploaded content stays retrievable (the
+   regression that Gap 1/2 would corrupt).
+4. Negative: with one published counter chunk manually deleted from the queen's store,
+   the taker goes read-only and retries instead of zero-seeding (commit A behavior).
+
+## Appendix — key Bee facts (verified in source, bee 2.x)
+
+| Fact | Evidence |
+| --- | --- |
+| Same-address SOC conflict: replace iff strictly newer **postage stamp timestamp**, else `ErrOverwriteNewerChunk`. Deterministic, not arrival order. | `pkg/storer/internal/reserve/reserve.go:139-219` |
+| Stamp-index (overstamp) collision, different addresses: newer stamp timestamp evicts the older chunk's data entirely. | `reserve.go:221-237`, `chunkstore.go:97-119` |
+| Stamp timestamps are minted by the client at stamping time (`Date.now()`), so the network's LWW aligns with the generation fence under the clock-sync assumption. | bee-js `src/stamper/stamper.ts:48` |
+| Reads short-circuit on local store; network retrieval only on local miss. | `pkg/storer/netstore.go:96-105` |
+| Successfully retrieved chunks are cached locally (LRU on access time, **no TTL, no invalidation**) — a gateway's view of a mutable SOC freezes after first contact. | `netstore.go:106-124`, `pkg/storer/internal/cache/cache.go:128-182` |
+| Pull-sync converges replicas on the highest stamp timestamp **within the storage neighborhood only**; non-neighborhood nodes never update their copies. | `pkg/pullsync/pullsync.go:379-390`, `pkg/storer/reserve.go:295` |
+| Push-sync receipt = chunk stored in the reserve of a proximity-verified neighborhood peer; ~3 replicas via multiplexing (`maxMultiplexForwards = 2`). | `pkg/pushsync/pushsync.go:268-287, :456-463, :55, :567-603` |
+| Retrieval of an absent chunk: per-peer timeout 30 s, up to 32 origin attempts, all errors collapse into `storage.ErrNotFound` — absence is indistinguishable from failure. | `pkg/retrieval/retrieval.go:125-130, :269-287` |
+| Bee notifies GSOC subscribers when a SOC push passes through a node responsible for the address — a possible future *notification* channel if contest addresses were mined into the holder's node's neighborhood (requires knowing the holder node's overlay + a gateway exposing the GSOC API; out of scope here, needs its own research). | `pkg/pushsync/pushsync.go:242-248`, `pkg/gsoc` |

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -436,6 +436,15 @@ export {
 // Download data utility
 export { downloadDataWithChunkAPI } from "./proxy/download-data"
 
+// SOC write/read primitives (used by dev tooling, e.g. the gateway
+// retrievability self-check: write a SOC then read it back).
+export { downloadEncryptedSOC } from "./proxy/download-data"
+export {
+  uploadSOC,
+  type UploadTarget,
+  type UploadSOCOptions,
+} from "./proxy/upload"
+
 // ACT (Access Control Tries) exports
 export {
   createActForContent,

--- a/lib/src/schemas.ts
+++ b/lib/src/schemas.ts
@@ -329,16 +329,21 @@ export type PartitionLockGeneration = z.infer<
 export type PartitionLockPayload = z.infer<typeof PartitionLockPayloadSchemaV1>
 
 /**
- * Payload stored (as encrypted JSON) in a per-device partition-INTENT SOC.
- * Written before a fresh claim on a free partition so rival contenders — who
- * read each other's intent at a fresh per-epoch address that forces a network
- * retrieval (bypassing the gateway's frozen lock-SOC cache) — can agree on a
- * single winner by `generation` before any of them binds the lock. `deviceId`
- * is carried for diagnostics/sanity; the address already encodes it.
+ * Payload stored (as encrypted JSON) in a per-device partition-INTENT SOC,
+ * which doubles as a holder PRESENCE BEACON. Written before a fresh claim so
+ * rival contenders agree on a single winner by `generation`, AND re-published
+ * by the holder on every refresh tick so a later joiner can detect the live
+ * holder — both via a fresh per-epoch address that forces a network retrieval
+ * (bypassing the gateway's frozen lock-SOC cache). `deviceId` is carried for
+ * diagnostics (the address already encodes it). `leasedUntil` is present on a
+ * heartbeat so a reader can apply the same `leasedUntil > now` liveness test
+ * the lock SOC uses; it is omitted on a legacy pre-claim intent (then the
+ * reader falls back to epoch-bucket freshness).
  */
 export const PartitionIntentPayloadSchemaV1 = z.object({
   deviceId: z.string(),
   generation: PartitionLockGenerationSchemaV1,
+  leasedUntil: z.number().int().nonnegative().optional(),
 })
 
 export type PartitionIntentPayload = z.infer<

--- a/lib/src/schemas.ts
+++ b/lib/src/schemas.ts
@@ -328,6 +328,23 @@ export type PartitionLockGeneration = z.infer<
 >
 export type PartitionLockPayload = z.infer<typeof PartitionLockPayloadSchemaV1>
 
+/**
+ * Payload stored (as encrypted JSON) in a per-device partition-INTENT SOC.
+ * Written before a fresh claim on a free partition so rival contenders — who
+ * read each other's intent at a fresh per-epoch address that forces a network
+ * retrieval (bypassing the gateway's frozen lock-SOC cache) — can agree on a
+ * single winner by `generation` before any of them binds the lock. `deviceId`
+ * is carried for diagnostics/sanity; the address already encodes it.
+ */
+export const PartitionIntentPayloadSchemaV1 = z.object({
+  deviceId: z.string(),
+  generation: PartitionLockGenerationSchemaV1,
+})
+
+export type PartitionIntentPayload = z.infer<
+  typeof PartitionIntentPayloadSchemaV1
+>
+
 // ============================================================================
 // Network Settings Schema
 // ============================================================================

--- a/lib/src/swarm-id-proxy.ts
+++ b/lib/src/swarm-id-proxy.ts
@@ -693,6 +693,8 @@ export class SwarmIdProxy {
       batchId: this.postageBatchId,
       stamper: this.stamper,
       deviceId: this.requireDeviceId(),
+      knownDeviceIds: () =>
+        this.knownDeviceIdsForAccount(accountInfo.accountId),
       accountId: accountInfo.accountId,
       backupSigner: new PrivateKey(backupKeyHex),
       swarmEncryptionKey: accountInfo.encryptionKey,
@@ -1275,6 +1277,22 @@ export class SwarmIdProxy {
     } catch (error) {
       console.error("[Proxy] Error looking up account:", error)
       return undefined
+    }
+  }
+
+  /**
+   * Current device IDs registered for `accountId`, read fresh from shared
+   * storage so the partition-intent round (Phase 2) reflects devices that
+   * announced after the coordinator was built. Returns [] on any error — the
+   * lease then falls back to the guard+TTL acquire path.
+   */
+  private knownDeviceIdsForAccount(accountId: string): string[] {
+    try {
+      const accounts = createAccountsStorageManager().load()
+      const account = accounts.find((a) => a.id.toHex() === accountId)
+      return account?.devices.map((d) => d.deviceId) ?? []
+    } catch {
+      return []
     }
   }
 

--- a/lib/src/swarm-id-proxy.ts
+++ b/lib/src/swarm-id-proxy.ts
@@ -154,6 +154,36 @@ const DEFAULT_ACT_CONTENT_TYPE = "application/octet-stream"
 const SEQUENTIAL_INDEX_LOOKUP_TIMEOUT_MS = 2000
 
 /**
+ * localStorage key holding optional partition-coordination timing overrides
+ * (`{ guardWindowMs?, guardPollMs?, readTimeoutMs? }`). Lets the gateway's
+ * propagation tuning be adjusted at runtime (set by the /dev "Partition tuning"
+ * panel) and picked up on the next connect — no rebuild. Absent → code defaults.
+ */
+const PARTITION_TUNING_KEY = "swarm-id-partition-tuning"
+
+function readPartitionTuningOverride():
+  | { guardWindowMs?: number; guardPollMs?: number; readTimeoutMs?: number }
+  | undefined {
+  try {
+    if (typeof localStorage === "undefined") return undefined
+    const raw = localStorage.getItem(PARTITION_TUNING_KEY)
+    if (!raw) return undefined
+    const parsed: unknown = JSON.parse(raw)
+    if (typeof parsed !== "object" || parsed === null) return undefined
+    const pick = (v: unknown): number | undefined =>
+      typeof v === "number" && Number.isFinite(v) && v >= 0 ? v : undefined
+    const o = parsed as Record<string, unknown>
+    return {
+      guardWindowMs: pick(o.guardWindowMs),
+      guardPollMs: pick(o.guardPollMs),
+      readTimeoutMs: pick(o.readTimeoutMs),
+    }
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * Swarm ID Proxy - Runs inside the iframe
  *
  * Responsibilities:
@@ -688,6 +718,7 @@ export class SwarmIdProxy {
       uint8ArrayToHex(accountInfo.encryptionKey),
       "backup-key",
     )
+    const tuning = readPartitionTuningOverride()
     this.coordinator = new BatchWriteCoordinator({
       bee: this.bee,
       batchId: this.postageBatchId,
@@ -695,6 +726,9 @@ export class SwarmIdProxy {
       deviceId: this.requireDeviceId(),
       knownDeviceIds: () =>
         this.knownDeviceIdsForAccount(accountInfo.accountId),
+      intentReadTimeoutMs: tuning?.readTimeoutMs,
+      intentGuardWindowMs: tuning?.guardWindowMs,
+      intentGuardPollMs: tuning?.guardPollMs,
       accountId: accountInfo.accountId,
       backupSigner: new PrivateKey(backupKeyHex),
       swarmEncryptionKey: accountInfo.encryptionKey,

--- a/lib/src/sync/batch-write-coordinator.test.ts
+++ b/lib/src/sync/batch-write-coordinator.test.ts
@@ -42,6 +42,7 @@ import {
   type BatchWriteCoordinatorDeps,
 } from "./batch-write-coordinator"
 import { NO_HOLDER_DEVICE_ID } from "./partition-lock"
+import type { LeaseRefreshOutcome } from "./partition-lease"
 import { LEASE_REFRESH_MS, LEASE_TTL_MS } from "../utils/batch-utilization"
 
 const SELF = "self-device"
@@ -75,7 +76,7 @@ function makeLease(
     }
     /** Make `acquire` reject — an operational failure, not contention. */
     acquireError?: Error
-    refreshResult?: boolean
+    refreshResult?: LeaseRefreshOutcome
   } = {},
 ) {
   let partition = opts.partition
@@ -94,7 +95,7 @@ function makeLease(
       if (r.partition !== undefined) partition = r.partition
       return r
     }),
-    refresh: vi.fn(async () => opts.refreshResult ?? true),
+    refresh: vi.fn(async () => opts.refreshResult ?? "held"),
     release: vi.fn(async () => {}),
     bumpLocalLease: vi.fn(),
     serialize: vi.fn(() => ({ v: 1 })),
@@ -312,7 +313,7 @@ describe("BatchWriteCoordinator — displacement-during-upload race fix", () => 
     // Seed a held lease on partition 0 that fails its refresh (so the tick
     // falls back to the displacement read), and make the lock SOC name a live
     // peer. Keep the lease "active" so the idle-yield branch is skipped.
-    const lease = makeLease({ partition: 0, refreshResult: false })
+    const lease = makeLease({ partition: 0, refreshResult: "lost" })
     internals.partitionLease = lease
     internals.lastLeaseActivityAt = Date.now()
     internals.activeUploadCount = 1
@@ -346,7 +347,7 @@ describe("BatchWriteCoordinator — displacement-during-upload race fix", () => 
       }),
     )
     const internals = coordinator as unknown as Internals
-    const lease = makeLease({ partition: 0, refreshResult: false })
+    const lease = makeLease({ partition: 0, refreshResult: "lost" })
     internals.partitionLease = lease
     internals.lastLeaseActivityAt = Date.now()
     internals.activeUploadCount = 1
@@ -361,6 +362,52 @@ describe("BatchWriteCoordinator — displacement-during-upload race fix", () => 
     expect(stamper.unbindPartition).not.toHaveBeenCalled()
     expect(coordinator.currentPartition).toBe(0)
     expect(lease.bumpLocalLease).toHaveBeenCalled()
+  })
+
+  it("demotes on a beacon-confirmed displacement, even though the static lock SOC still shows us live", async () => {
+    // The refresh-time deconfliction backstop: `PartitionLease.refresh()` reads
+    // a rival's presence beacon at a fresh per-epoch address — the channel that
+    // stays readable on a disjoint gateway where the static lock SOC is frozen —
+    // and, finding an earlier-generation foreign holder, reports `"displaced"`.
+    //
+    // Regression guard for the no-op the backstop existed to avoid: `refresh()`
+    // ALSO just rewrote our own claim to the static lock SOC, so re-gating the
+    // demote on `readPartitionLock` would read SELF (live) and never confirm —
+    // and the device would keep a partition a peer already holds (dual-hold →
+    // silent overstamp). The coordinator must trust the beacon verdict directly.
+    const calls: string[] = []
+    const stamper = makeStamper(calls)
+    const onLeaseChange = vi.fn()
+    const coordinator = new BatchWriteCoordinator(
+      makeDeps({
+        stamper: stamper as unknown as BatchWriteCoordinatorDeps["stamper"],
+        onLeaseChange,
+      }),
+    )
+    const internals = coordinator as unknown as Internals
+    const lease = makeLease({ partition: 0, refreshResult: "displaced" })
+    internals.partitionLease = lease
+    internals.lastLeaseActivityAt = Date.now()
+    internals.activeUploadCount = 1
+    // The frozen-gateway view: the static lock SOC shows OURSELVES as the live
+    // holder (we just rewrote it on this very refresh). Pre-fix, the coordinator
+    // re-gated on this read and so kept the lease — the bug.
+    lockController.payload = {
+      holderDeviceId: SELF,
+      leasedUntil: Date.now() + 10_000,
+    }
+
+    await internals.refreshTick(lease)
+
+    // Mirrors the displacement-race fix: invalidate the breaker, then unbind.
+    expect(calls).toEqual(["invalidate", "unbind"])
+    expect(coordinator.currentPartition).toBeUndefined()
+    expect(coordinator.isReadOnly).toBe(true)
+    expect(internals.pendingAcquire).toBe(true)
+    expect(onLeaseChange).toHaveBeenLastCalledWith({
+      currentPartition: undefined,
+      isReadOnly: true,
+    })
   })
 })
 
@@ -386,7 +433,7 @@ describe("BatchWriteCoordinator — sentinel re-assert at upload start", () => {
   }
 
   it("re-asserts the claim when a sentinel is visible while holding", async () => {
-    const lease = makeLease({ partition: 0, refreshResult: true })
+    const lease = makeLease({ partition: 0, refreshResult: "held" })
     const { internals, stamper, writeLeaseCache } = setup(lease)
 
     await internals.ensureLeaseStillValid()
@@ -398,7 +445,7 @@ describe("BatchWriteCoordinator — sentinel re-assert at upload start", () => {
   })
 
   it("demotes and throws when the re-assert loses to a peer", async () => {
-    const lease = makeLease({ partition: 0, refreshResult: false })
+    const lease = makeLease({ partition: 0, refreshResult: "lost" })
     const { coordinator, internals, stamper } = setup(lease)
 
     await expect(internals.ensureLeaseStillValid()).rejects.toThrow(/reclaimed/)
@@ -799,7 +846,7 @@ describe("BatchWriteCoordinator — stale refresh-tick guards", () => {
 
     // Lease A on partition 0: refresh fails, lock SOC names a live peer →
     // the tick confirms displacement and queues finalizeDemote on the lock.
-    const leaseA = makeLease({ partition: 0, refreshResult: false })
+    const leaseA = makeLease({ partition: 0, refreshResult: "lost" })
     internals.partitionLease = leaseA
     internals.lastLeaseActivityAt = Date.now()
     internals.activeUploadCount = 1 // skip the idle-yield branch

--- a/lib/src/sync/batch-write-coordinator.ts
+++ b/lib/src/sync/batch-write-coordinator.ts
@@ -423,6 +423,12 @@ export class BatchWriteCoordinator {
       // reconciles with Swarm and demotes only on a confirmed foreign holder.
       const adopted = lease.adoptIfLive()
       if (adopted !== undefined) {
+        // Diagnostic: this re-binds a CACHED lease with no Swarm scan and no
+        // intent round. If two devices both adopt partition 0 from stale
+        // caches, that's a dual-hold the intent round never gets to arbitrate.
+        console.log(
+          `[BatchWriteCoordinator] Adopted cached lease p=${adopted} (no acquire/intent round) for device=${this.deps.deviceId}`,
+        )
         this.partitionLease = lease
         this.readOnly = false
         stamper.bindPartition({

--- a/lib/src/sync/batch-write-coordinator.ts
+++ b/lib/src/sync/batch-write-coordinator.ts
@@ -127,6 +127,13 @@ export interface BatchWriteCoordinatorDeps {
    * single-device / legacy callers — acquire falls back to guard+TTL only.
    */
   knownDeviceIds?: () => string[]
+  /**
+   * Gateway-propagation tuning for the intent round (optional overrides; default
+   * to the `INTENT_*` constants). Lets the proxy pass runtime-tunable values.
+   */
+  intentReadTimeoutMs?: number
+  intentGuardWindowMs?: number
+  intentGuardPollMs?: number
   accountId: string
   /** Owns the per-partition lock SOCs (derived from the account key). */
   backupSigner: PrivateKey
@@ -412,6 +419,9 @@ export class BatchWriteCoordinator {
         swarmEncryptionKey,
         stamper,
         knownDeviceIds: this.deps.knownDeviceIds,
+        intentReadTimeoutMs: this.deps.intentReadTimeoutMs,
+        intentGuardWindowMs: this.deps.intentGuardWindowMs,
+        intentGuardPollMs: this.deps.intentGuardPollMs,
       })
       if (this.leaseEpoch !== epoch) return
       const cached = this.deps.readLeaseCache?.()

--- a/lib/src/sync/batch-write-coordinator.ts
+++ b/lib/src/sync/batch-write-coordinator.ts
@@ -46,7 +46,10 @@ import {
 } from "../utils/batch-utilization"
 import { withBatchWriteLock } from "../utils/batch-write-lock"
 import { PartitionLease } from "./partition-lease"
-import type { PartitionLeaseStateSnapshot } from "./partition-lease"
+import type {
+  LeaseRefreshOutcome,
+  PartitionLeaseStateSnapshot,
+} from "./partition-lease"
 import { readPartitionLock, NO_HOLDER_DEVICE_ID } from "./partition-lock"
 import type { UploadTarget } from "../proxy/upload"
 import type { StampWorkerPool } from "../proxy/stamp-worker-pool"
@@ -598,7 +601,7 @@ export class BatchWriteCoordinator {
       payload !== undefined &&
       payload.holderDeviceId === NO_HOLDER_DEVICE_ID
     ) {
-      let reasserted: boolean
+      let reasserted: LeaseRefreshOutcome
       try {
         reasserted = await this.partitionLease.refresh()
       } catch (err) {
@@ -610,9 +613,10 @@ export class BatchWriteCoordinator {
         )
         return
       }
-      if (!reasserted) {
-        // blocked / lost-race — a peer claimed after the sentinel. Mirror
-        // the displaced branch exactly (we are under the write lock).
+      if (reasserted !== "held") {
+        // blocked / lost-race (`"lost"`) or a beacon-confirmed peer
+        // (`"displaced"`) — a peer claimed after the sentinel. Mirror the
+        // displaced branch exactly (we are under the write lock).
         console.warn(
           `[BatchWriteCoordinator] Sentinel re-assert: partition ${partition} taken by a peer; demoting.`,
         )
@@ -724,8 +728,17 @@ export class BatchWriteCoordinator {
 
     let confirmedDisplaced = false
     try {
-      const ok = await lease.refresh()
-      if (!ok) {
+      const outcome = await lease.refresh()
+      if (outcome === "displaced") {
+        // The lease read a foreign presence beacon (earlier generation) at a
+        // fresh per-epoch address and confirmed a peer holds this partition.
+        // That beacon channel is exactly what the static lock SOC cannot show
+        // on a disjoint gateway, so trust the verdict directly. Re-reading the
+        // lock SOC here would be the no-op the backstop exists to avoid:
+        // refresh() just rewrote our own claim to that address, so the read
+        // would return SELF and never confirm the displacement.
+        confirmedDisplaced = true
+      } else if (outcome === "lost") {
         // Couldn't confirm via write+verify — check for ACTUAL displacement
         // with one read. A 500 here returns undefined → not displaced.
         const payload = await readPartitionLock({

--- a/lib/src/sync/batch-write-coordinator.ts
+++ b/lib/src/sync/batch-write-coordinator.ts
@@ -119,6 +119,14 @@ export interface BatchWriteCoordinatorDeps {
   stamper: UtilizationAwareStamper
   /** This device's identity, captured once by the caller. */
   deviceId: string
+  /**
+   * Current known device IDs for this account (from the synced device
+   * registry). Read fresh per acquire so it reflects late-announced devices.
+   * Drives the Phase-2 intent round that lets disjoint-gateway contenders for
+   * a free partition agree on one winner (see partition-intent.ts). Omit for
+   * single-device / legacy callers — acquire falls back to guard+TTL only.
+   */
+  knownDeviceIds?: () => string[]
   accountId: string
   /** Owns the per-partition lock SOCs (derived from the account key). */
   backupSigner: PrivateKey
@@ -403,6 +411,7 @@ export class BatchWriteCoordinator {
         batchDepth: stamper.depth,
         swarmEncryptionKey,
         stamper,
+        knownDeviceIds: this.deps.knownDeviceIds,
       })
       if (this.leaseEpoch !== epoch) return
       const cached = this.deps.readLeaseCache?.()

--- a/lib/src/sync/partition-intent.test.ts
+++ b/lib/src/sync/partition-intent.test.ts
@@ -134,28 +134,10 @@ describe("readPartitionIntent / writePartitionIntent round-trip", () => {
     expect(read).toBeUndefined()
   })
 
-  it("writes the intent non-deferred so a peer's gateway can retrieve it", async () => {
-    // Regression: a deferred write stays on the writer's gateway and is never
-    // push-synced into the neighborhood, so a peer's retrieval of the fresh
-    // address finds nothing → the intent round is a no-op and both devices win.
-    const fetchSpy = vi.spyOn(global, "fetch")
-    await writePartitionIntent({
-      bee: bee as unknown as Bee,
-      stamper,
-      backupSigner: BACKUP_SIGNER,
-      swarmEncryptionKey: TEST_ENC_KEY,
-      partition: PARTITION,
-      deviceId: DEVICE_A,
-      epochBucket: intentEpochBucket(NOW),
-      generation: gen(1000, DEVICE_A),
-    })
-    const socCall = fetchSpy.mock.calls.find(([u]) =>
-      (typeof u === "string" ? u : String(u)).includes("/soc/"),
-    )
-    expect(socCall).toBeDefined()
-    const headers = (socCall![1]?.headers ?? {}) as Record<string, string>
-    expect(headers["swarm-deferred-upload"]).toBe("false")
-  })
+  // Note: no "non-deferred" assertion — Bee's /soc handler hardcodes
+  // Deferred:false and ignores the Swarm-Deferred-Upload header (bee 2.8.0
+  // pkg/api/soc.go), so SOC writes are always synchronous regardless of the
+  // client flag. The deferred flag is only meaningful for /bytes data uploads.
 })
 
 describe("resolveIntentRound", () => {
@@ -273,5 +255,44 @@ describe("resolveIntentRound", () => {
     expect([a, b].filter((o) => o === "win")).toHaveLength(1)
     expect(a).toBe("win")
     expect(b).toBe("lose")
+  })
+
+  it("polls across a guard window and yields to a live beacon", async () => {
+    // A live holder beacon (leasedUntil > now) for DEVICE_A on this partition.
+    await writePartitionIntent({
+      bee: bee as unknown as Bee,
+      stamper,
+      backupSigner: BACKUP_SIGNER,
+      swarmEncryptionKey: TEST_ENC_KEY,
+      partition: PARTITION,
+      deviceId: DEVICE_A,
+      epochBucket: intentEpochBucket(NOW),
+      generation: gen(1000, DEVICE_A),
+      leasedUntil: NOW + INTENT_EPOCH_MS,
+    })
+    const outcome = await resolveIntentRound({
+      ...common(),
+      deviceId: DEVICE_B,
+      generation: gen(2000, DEVICE_B),
+      knownDeviceIds: [DEVICE_A, DEVICE_B],
+      guardWindowMs: 120,
+      guardPollMs: 40,
+    })
+    expect(outcome).toBe("lose")
+  })
+
+  it("polls the full guard window then wins when no rival surfaces", async () => {
+    const t0 = Date.now()
+    const outcome = await resolveIntentRound({
+      ...common(),
+      deviceId: DEVICE_B,
+      generation: gen(2000, DEVICE_B),
+      knownDeviceIds: [DEVICE_A, DEVICE_B],
+      guardWindowMs: 120,
+      guardPollMs: 40,
+    })
+    expect(outcome).toBe("win")
+    // It actually waited out the window (didn't bind on the first immediate read).
+    expect(Date.now() - t0).toBeGreaterThanOrEqual(100)
   })
 })

--- a/lib/src/sync/partition-intent.test.ts
+++ b/lib/src/sync/partition-intent.test.ts
@@ -1,0 +1,254 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Tests for the per-device partition-intent SOCs (Phase 2 of the
+ * partition-lock hardening). Uses MockBee + mockFetch from the epoch-feeds
+ * test utilities so the SOC round-trip exercises real bee-js code paths
+ * (`uploadSOC`, `downloadEncryptedSOC`) against an in-memory store.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { PrivateKey, type Bee, type Stamper } from "@ethersphere/bee-js"
+import {
+  INTENT_EPOCH_MS,
+  intentEpochBucket,
+  makePartitionIntentIdentifier,
+  readPartitionIntent,
+  resolveIntentRound,
+  writePartitionIntent,
+} from "./partition-intent"
+import { makeDeviceTiebreaker } from "./partition-lock"
+import {
+  MockBee,
+  MockChunkStore,
+  createMockStamper,
+  createTestSigner,
+  mockFetch,
+} from "../proxy/feeds/epochs/test-utils"
+
+const DEVICE_A = "device-alpha-111"
+const DEVICE_B = "device-beta-222"
+const TEST_ENC_KEY = new Uint8Array(32).map((_, i) => (i * 7 + 3) & 0xff)
+const BACKUP_SIGNER = createTestSigner() as PrivateKey
+const OWNER = BACKUP_SIGNER.publicKey().address()
+
+const PARTITION = 0
+const NOW = 5 * INTENT_EPOCH_MS + 1234 // arbitrary point inside an epoch
+
+let store: MockChunkStore
+let bee: MockBee
+let stamper: Stamper
+
+beforeEach(() => {
+  store = new MockChunkStore()
+  bee = new MockBee(store)
+  stamper = createMockStamper() as unknown as Stamper
+  mockFetch(store, OWNER)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function gen(timestampMs: number, deviceId: string) {
+  return { timestampMs, tiebreaker: makeDeviceTiebreaker(deviceId) }
+}
+
+describe("intentEpochBucket", () => {
+  it("is floor(now / INTENT_EPOCH_MS)", () => {
+    expect(intentEpochBucket(0)).toBe(0)
+    expect(intentEpochBucket(INTENT_EPOCH_MS - 1)).toBe(0)
+    expect(intentEpochBucket(INTENT_EPOCH_MS)).toBe(1)
+    expect(intentEpochBucket(NOW)).toBe(5)
+  })
+})
+
+describe("makePartitionIntentIdentifier", () => {
+  it("is deterministic for the same (partition, device, epoch)", () => {
+    expect(makePartitionIntentIdentifier(0, DEVICE_A, 5).toHex()).toBe(
+      makePartitionIntentIdentifier(0, DEVICE_A, 5).toHex(),
+    )
+  })
+
+  it("rotates across epoch buckets, devices, and partitions", () => {
+    const base = makePartitionIntentIdentifier(0, DEVICE_A, 5).toHex()
+    expect(makePartitionIntentIdentifier(0, DEVICE_A, 6).toHex()).not.toBe(base)
+    expect(makePartitionIntentIdentifier(0, DEVICE_B, 5).toHex()).not.toBe(base)
+    expect(makePartitionIntentIdentifier(1, DEVICE_A, 5).toHex()).not.toBe(base)
+  })
+})
+
+describe("readPartitionIntent / writePartitionIntent round-trip", () => {
+  it("returns undefined when the intent was never written", async () => {
+    const read = await readPartitionIntent({
+      bee: bee as unknown as Bee,
+      backupSigner: BACKUP_SIGNER,
+      swarmEncryptionKey: TEST_ENC_KEY,
+      partition: PARTITION,
+      deviceId: DEVICE_A,
+      epochBucket: intentEpochBucket(NOW),
+    })
+    expect(read).toBeUndefined()
+  })
+
+  it("reads back the exact payload that was written", async () => {
+    await writePartitionIntent({
+      bee: bee as unknown as Bee,
+      stamper,
+      backupSigner: BACKUP_SIGNER,
+      swarmEncryptionKey: TEST_ENC_KEY,
+      partition: PARTITION,
+      deviceId: DEVICE_A,
+      epochBucket: intentEpochBucket(NOW),
+      generation: gen(1000, DEVICE_A),
+    })
+    const read = await readPartitionIntent({
+      bee: bee as unknown as Bee,
+      backupSigner: BACKUP_SIGNER,
+      swarmEncryptionKey: TEST_ENC_KEY,
+      partition: PARTITION,
+      deviceId: DEVICE_A,
+      epochBucket: intentEpochBucket(NOW),
+    })
+    expect(read).toEqual({
+      deviceId: DEVICE_A,
+      generation: gen(1000, DEVICE_A),
+    })
+  })
+
+  it("treats a slow read as 'no intent' (returns undefined on timeout)", async () => {
+    // Make the chunk download hang so the client-side timeout fires.
+    vi.spyOn(bee, "downloadChunk").mockImplementation(
+      () => new Promise(() => {}) as never,
+    )
+    const read = await readPartitionIntent({
+      bee: bee as unknown as Bee,
+      backupSigner: BACKUP_SIGNER,
+      swarmEncryptionKey: TEST_ENC_KEY,
+      partition: PARTITION,
+      deviceId: DEVICE_A,
+      epochBucket: intentEpochBucket(NOW),
+      timeoutMs: 20,
+    })
+    expect(read).toBeUndefined()
+  })
+})
+
+describe("resolveIntentRound", () => {
+  const common = () => ({
+    bee: bee as unknown as Bee,
+    stamper,
+    backupSigner: BACKUP_SIGNER,
+    swarmEncryptionKey: TEST_ENC_KEY,
+    partition: PARTITION,
+    now: NOW,
+    timeoutMs: 50,
+  })
+
+  it("wins by default when there are no known rivals", async () => {
+    const outcome = await resolveIntentRound({
+      ...common(),
+      deviceId: DEVICE_A,
+      generation: gen(1000, DEVICE_A),
+      knownDeviceIds: [DEVICE_A],
+    })
+    expect(outcome).toBe("win")
+  })
+
+  it("wins when the only rival has no intent present", async () => {
+    const outcome = await resolveIntentRound({
+      ...common(),
+      deviceId: DEVICE_B,
+      generation: gen(2000, DEVICE_B),
+      knownDeviceIds: [DEVICE_A, DEVICE_B],
+    })
+    expect(outcome).toBe("win")
+  })
+
+  it("loses to a rival advertising an earlier (smaller) generation", async () => {
+    // DEVICE_A advertised first (smaller timestamp) in the same epoch.
+    await writePartitionIntent({
+      bee: bee as unknown as Bee,
+      stamper,
+      backupSigner: BACKUP_SIGNER,
+      swarmEncryptionKey: TEST_ENC_KEY,
+      partition: PARTITION,
+      deviceId: DEVICE_A,
+      epochBucket: intentEpochBucket(NOW),
+      generation: gen(1000, DEVICE_A),
+    })
+
+    const outcome = await resolveIntentRound({
+      ...common(),
+      deviceId: DEVICE_B,
+      generation: gen(2000, DEVICE_B),
+      knownDeviceIds: [DEVICE_A, DEVICE_B],
+    })
+    expect(outcome).toBe("lose")
+  })
+
+  it("wins over a rival advertising a later (greater) generation", async () => {
+    await writePartitionIntent({
+      bee: bee as unknown as Bee,
+      stamper,
+      backupSigner: BACKUP_SIGNER,
+      swarmEncryptionKey: TEST_ENC_KEY,
+      partition: PARTITION,
+      deviceId: DEVICE_A,
+      epochBucket: intentEpochBucket(NOW),
+      generation: gen(3000, DEVICE_A),
+    })
+
+    const outcome = await resolveIntentRound({
+      ...common(),
+      deviceId: DEVICE_B,
+      generation: gen(2000, DEVICE_B),
+      knownDeviceIds: [DEVICE_A, DEVICE_B],
+    })
+    expect(outcome).toBe("win")
+  })
+
+  it("sees a rival's intent from the previous epoch bucket (boundary)", async () => {
+    // DEVICE_A advertised in the previous bucket; DEVICE_B contends now.
+    await writePartitionIntent({
+      bee: bee as unknown as Bee,
+      stamper,
+      backupSigner: BACKUP_SIGNER,
+      swarmEncryptionKey: TEST_ENC_KEY,
+      partition: PARTITION,
+      deviceId: DEVICE_A,
+      epochBucket: intentEpochBucket(NOW) - 1,
+      generation: gen(1000, DEVICE_A),
+    })
+
+    const outcome = await resolveIntentRound({
+      ...common(),
+      deviceId: DEVICE_B,
+      generation: gen(2000, DEVICE_B),
+      knownDeviceIds: [DEVICE_A, DEVICE_B],
+    })
+    expect(outcome).toBe("lose")
+  })
+
+  it("exactly one of two symmetric contenders wins", async () => {
+    // Both run the round against each other in the same epoch. Whichever
+    // advertises the smaller generation wins; the other loses. Run A first so
+    // its intent is visible when B reads.
+    const a = await resolveIntentRound({
+      ...common(),
+      deviceId: DEVICE_A,
+      generation: gen(1000, DEVICE_A),
+      knownDeviceIds: [DEVICE_A, DEVICE_B],
+    })
+    const b = await resolveIntentRound({
+      ...common(),
+      deviceId: DEVICE_B,
+      generation: gen(2000, DEVICE_B),
+      knownDeviceIds: [DEVICE_A, DEVICE_B],
+    })
+    expect([a, b].filter((o) => o === "win")).toHaveLength(1)
+    expect(a).toBe("win")
+    expect(b).toBe("lose")
+  })
+})

--- a/lib/src/sync/partition-intent.test.ts
+++ b/lib/src/sync/partition-intent.test.ts
@@ -133,6 +133,29 @@ describe("readPartitionIntent / writePartitionIntent round-trip", () => {
     })
     expect(read).toBeUndefined()
   })
+
+  it("writes the intent non-deferred so a peer's gateway can retrieve it", async () => {
+    // Regression: a deferred write stays on the writer's gateway and is never
+    // push-synced into the neighborhood, so a peer's retrieval of the fresh
+    // address finds nothing → the intent round is a no-op and both devices win.
+    const fetchSpy = vi.spyOn(global, "fetch")
+    await writePartitionIntent({
+      bee: bee as unknown as Bee,
+      stamper,
+      backupSigner: BACKUP_SIGNER,
+      swarmEncryptionKey: TEST_ENC_KEY,
+      partition: PARTITION,
+      deviceId: DEVICE_A,
+      epochBucket: intentEpochBucket(NOW),
+      generation: gen(1000, DEVICE_A),
+    })
+    const socCall = fetchSpy.mock.calls.find(([u]) =>
+      (typeof u === "string" ? u : String(u)).includes("/soc/"),
+    )
+    expect(socCall).toBeDefined()
+    const headers = (socCall![1]?.headers ?? {}) as Record<string, string>
+    expect(headers["swarm-deferred-upload"]).toBe("false")
+  })
 })
 
 describe("resolveIntentRound", () => {

--- a/lib/src/sync/partition-intent.ts
+++ b/lib/src/sync/partition-intent.ts
@@ -1,0 +1,251 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Per-device partition-INTENT SOCs — Phase 2 of the partition-lock hardening
+ * (see docs/Partition-Lock-Hardening-Plan.md, "Extension that covers the
+ * symmetric case: per-device intent SOCs").
+ *
+ * The lock SOC lives at a single static address. Across disjoint gateways a
+ * node serves that address from a frozen cache (no TTL, no invalidation), so
+ * contenders for a *free* partition never see each other and all bind it —
+ * the disjoint-gateway dual-acquire bug. Tweaking the guard/TTL timeouts can't
+ * help: the failure is non-visibility, not propagation latency.
+ *
+ * Intent SOCs convert "mutable-SOC cache coherence" (which Swarm doesn't
+ * guarantee) into "push-sync receipt + retrieval routing" (which it does):
+ *
+ *   identifier = keccak256("swarm-id-partition-intent-v1:" || partition
+ *                          || ":" || deviceId || ":" || epochBucket)
+ *   owner       = backup signer (shared across the account's devices)
+ *   encryption  = swarmEncryptionKey
+ *
+ * Each contender writes ONLY its own intent address and reads every other
+ * known device's intent address. A read of an address your node has never
+ * written (and, because the address rotates per epoch, never retrieved
+ * before) cannot be short-circuited from the local store — it forces a
+ * network retrieval to the address's storage neighborhood, where the rival's
+ * receipt-backed push-sync placed its replicas. So contenders see each other,
+ * order themselves by `generation`, and only the unique global-minimum binds
+ * the lock.
+ *
+ * Irreducible limit (documented): absence is unprovable on Swarm — a retrieval
+ * timeout can't distinguish "no rival intent" from "the network failed to find
+ * it". We treat a timed-out read as "no intent" to keep liveness (a single
+ * flaky device must not deadlock), so the guarantee is "when the network
+ * works, rivals are seen"; genuine network partition still falls back to the
+ * existing guard + TTL + refresh backstop.
+ */
+
+import { Bee, Identifier, PrivateKey, type Stamper } from "@ethersphere/bee-js"
+import { Binary } from "cafe-utility"
+import { downloadEncryptedSOC } from "../proxy/download-data"
+import { uploadSOC, type UploadTarget } from "../proxy/upload"
+import { rejectAfter } from "../utils/promise"
+import {
+  PartitionIntentPayloadSchemaV1,
+  type PartitionIntentPayload,
+} from "../schemas"
+import {
+  compareGenerations,
+  type PartitionLockGeneration,
+} from "./partition-lock"
+
+export type { PartitionIntentPayload }
+
+/** Domain-separation tag for the intent-SOC identifier. */
+const PARTITION_INTENT_DOMAIN = "swarm-id-partition-intent-v1"
+
+/**
+ * Epoch length for the rotating intent address. TTL-sized so a contention
+ * round and its immediate retries share a bucket (and the previous bucket
+ * covers the boundary), while every fresh round rotates to an address no node
+ * has cached. Kept independent of the lock TTL constant to avoid a circular
+ * import through batch-utilization; the two are intended to track each other.
+ */
+export const INTENT_EPOCH_MS = 30_000
+
+/**
+ * Client-side timeout for a single rival-intent read. Bee has no fast
+ * authoritative "not found" — a retrieval of an absent chunk fails only after
+ * exhausting peers — so an absent rival would otherwise block for tens of
+ * seconds. A present chunk in its neighborhood retrieves well under this; a
+ * timed-out read is treated as "no intent from that device".
+ */
+export const INTENT_READ_TIMEOUT_MS = 2500
+
+/** `floor(nowMs / INTENT_EPOCH_MS)` — the current intent epoch bucket. */
+export function intentEpochBucket(nowMs: number): number {
+  return Math.floor(nowMs / INTENT_EPOCH_MS)
+}
+
+/**
+ * Build the per-(partition, device, epoch) intent-SOC identifier. The address
+ * rotates with `epochBucket`, so it is fresh per contention round — neither
+ * the writer's nor a reader's node has a cached copy.
+ */
+export function makePartitionIntentIdentifier(
+  partition: number,
+  deviceId: string,
+  epochBucket: number,
+): Identifier {
+  const hash = Binary.keccak256(
+    new TextEncoder().encode(
+      `${PARTITION_INTENT_DOMAIN}:${partition}:${deviceId}:${epochBucket}`,
+    ),
+  )
+  return new Identifier(hash)
+}
+
+/**
+ * Write this device's intent for (partition, epochBucket). The payload carries
+ * the generation the device intends to claim with, so rivals can order against
+ * it. Uses the shared backup signer as owner (same as the lock SOC); each
+ * device only ever writes its own identifier.
+ */
+export async function writePartitionIntent(opts: {
+  bee: Bee
+  stamper: Stamper
+  backupSigner: PrivateKey
+  swarmEncryptionKey: Uint8Array
+  partition: number
+  deviceId: string
+  epochBucket: number
+  generation: PartitionLockGeneration
+}): Promise<void> {
+  const identifier = makePartitionIntentIdentifier(
+    opts.partition,
+    opts.deviceId,
+    opts.epochBucket,
+  )
+  const payload: PartitionIntentPayload = {
+    deviceId: opts.deviceId,
+    generation: opts.generation,
+  }
+  const data = new TextEncoder().encode(JSON.stringify(payload))
+  const target: UploadTarget = {
+    mode: "stamper",
+    bee: opts.bee,
+    stamper: opts.stamper,
+  }
+  await uploadSOC(target, opts.backupSigner, identifier, data, {
+    encryptionKey: opts.swarmEncryptionKey,
+  })
+}
+
+/**
+ * Read a single rival's intent for (partition, epochBucket), bounded by
+ * `timeoutMs`. Returns `undefined` when the chunk is missing, the read times
+ * out (treated as "no intent" — see module header), or the payload is
+ * malformed.
+ */
+export async function readPartitionIntent(opts: {
+  bee: Bee
+  backupSigner: PrivateKey
+  swarmEncryptionKey: Uint8Array
+  partition: number
+  deviceId: string
+  epochBucket: number
+  timeoutMs?: number
+}): Promise<PartitionIntentPayload | undefined> {
+  const identifier = makePartitionIntentIdentifier(
+    opts.partition,
+    opts.deviceId,
+    opts.epochBucket,
+  )
+  const owner = opts.backupSigner.publicKey().address()
+  try {
+    const soc = await Promise.race([
+      downloadEncryptedSOC(
+        opts.bee,
+        owner,
+        identifier,
+        opts.swarmEncryptionKey,
+      ),
+      rejectAfter(
+        opts.timeoutMs ?? INTENT_READ_TIMEOUT_MS,
+        "intent read timed out",
+      ),
+    ])
+    const parsed = PartitionIntentPayloadSchemaV1.safeParse(
+      JSON.parse(new TextDecoder().decode(soc.payload)),
+    )
+    return parsed.success ? parsed.data : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Run an intent round for a fresh claim of `partition`: announce our intent,
+ * then read every other known device's intent for the current AND previous
+ * epoch bucket (covering the rotation boundary). Returns whether this device
+ * is the round's winner.
+ *
+ * Winner = the strictly-minimum generation (earliest `timestampMs`, then
+ * smallest `tiebreaker`). We lose iff any rival's intent orders below ours.
+ * `compareGenerations` is a total order and distinct devices never tie
+ * (tiebreaker derives from `keccak256(deviceId)`), so exactly one contender
+ * wins. With no known rivals we win by default (a brand-new device not yet in
+ * the registry falls back to the existing guard + TTL behaviour).
+ *
+ * @returns `"win"` to proceed with the claim, `"lose"` to back off (read-only).
+ */
+export async function resolveIntentRound(opts: {
+  bee: Bee
+  stamper: Stamper
+  backupSigner: PrivateKey
+  swarmEncryptionKey: Uint8Array
+  partition: number
+  deviceId: string
+  generation: PartitionLockGeneration
+  knownDeviceIds: string[]
+  now: number
+  timeoutMs?: number
+}): Promise<"win" | "lose"> {
+  const rivals = opts.knownDeviceIds.filter((id) => id !== opts.deviceId)
+  if (rivals.length === 0) return "win"
+
+  const currentBucket = intentEpochBucket(opts.now)
+  const previousBucket = currentBucket - 1
+
+  // Announce our intent in the current bucket BEFORE reading rivals, so a rival
+  // racing us in the same round observes us too — no contender can both miss
+  // every rival and bind.
+  await writePartitionIntent({
+    bee: opts.bee,
+    stamper: opts.stamper,
+    backupSigner: opts.backupSigner,
+    swarmEncryptionKey: opts.swarmEncryptionKey,
+    partition: opts.partition,
+    deviceId: opts.deviceId,
+    epochBucket: currentBucket,
+    generation: opts.generation,
+  })
+
+  // Read every rival's intent for both buckets in parallel; each read is
+  // individually time-bounded so an absent rival doesn't stall the round.
+  const reads = rivals.flatMap((rivalId) =>
+    [currentBucket, previousBucket].map((bucket) =>
+      readPartitionIntent({
+        bee: opts.bee,
+        backupSigner: opts.backupSigner,
+        swarmEncryptionKey: opts.swarmEncryptionKey,
+        partition: opts.partition,
+        deviceId: rivalId,
+        epochBucket: bucket,
+        timeoutMs: opts.timeoutMs,
+      }),
+    ),
+  )
+  const observed = await Promise.all(reads)
+
+  for (const intent of observed) {
+    if (!intent) continue
+    // A rival ordering strictly below us wins the partition; we back off.
+    if (compareGenerations(intent.generation, opts.generation) < 0) {
+      return "lose"
+    }
+  }
+  return "win"
+}

--- a/lib/src/sync/partition-intent.ts
+++ b/lib/src/sync/partition-intent.ts
@@ -98,6 +98,9 @@ export const INTENT_EPOCH_MS = 30_000
  */
 export const INTENT_READ_TIMEOUT_MS = 2500
 
+/** Internal marker so a timed-out read is distinguishable from a real error. */
+const INTENT_TIMEOUT_MESSAGE = "intent read timed out"
+
 /** `floor(nowMs / INTENT_EPOCH_MS)` — the current intent epoch bucket. */
 export function intentEpochBucket(nowMs: number): number {
   return Math.floor(nowMs / INTENT_EPOCH_MS)
@@ -192,6 +195,11 @@ export async function writePartitionIntent(opts: {
     try {
       await uploadSOC(target, opts.backupSigner, identifier, data, {
         encryptionKey: opts.swarmEncryptionKey,
+        // Non-deferred = receipt-backed push-sync into the storage
+        // neighborhood. The whole point of the intent SOC is cross-gateway
+        // visibility; a deferred write would sit on this device's gateway and
+        // a peer's retrieval of the fresh address would never find it.
+        deferred: false,
       })
     } finally {
       stamper.clearIntentSocSlot()
@@ -201,6 +209,7 @@ export async function writePartitionIntent(opts: {
 
   await uploadSOC(target, opts.backupSigner, identifier, data, {
     encryptionKey: opts.swarmEncryptionKey,
+    deferred: false,
   })
 }
 
@@ -235,14 +244,23 @@ export async function readPartitionIntent(opts: {
       ),
       rejectAfter(
         opts.timeoutMs ?? INTENT_READ_TIMEOUT_MS,
-        "intent read timed out",
+        INTENT_TIMEOUT_MESSAGE,
       ),
     ])
     const parsed = PartitionIntentPayloadSchemaV1.safeParse(
       JSON.parse(new TextDecoder().decode(soc.payload)),
     )
     return parsed.success ? parsed.data : undefined
-  } catch {
+  } catch (error) {
+    // A timeout means the rival's chunk may well exist but the gateway didn't
+    // retrieve it within the budget — distinct from a genuine "not found", and
+    // worth surfacing because a too-short timeout would silently re-enable the
+    // dual-acquire this whole mechanism exists to prevent.
+    if (error instanceof Error && error.message === INTENT_TIMEOUT_MESSAGE) {
+      console.warn(
+        `[partition-intent] read TIMEOUT for device=${opts.deviceId} p=${opts.partition} bucket=${opts.epochBucket} (>${opts.timeoutMs ?? INTENT_READ_TIMEOUT_MS}ms) — treated as no-intent`,
+      )
+    }
     return undefined
   }
 }
@@ -296,27 +314,36 @@ export async function resolveIntentRound(opts: {
 
   // Read every rival's intent for both buckets in parallel; each read is
   // individually time-bounded so an absent rival doesn't stall the round.
-  const reads = rivals.flatMap((rivalId) =>
-    [currentBucket, previousBucket].map((bucket) =>
-      readPartitionIntent({
-        bee: opts.bee,
-        backupSigner: opts.backupSigner,
-        swarmEncryptionKey: opts.swarmEncryptionKey,
-        partition: opts.partition,
-        deviceId: rivalId,
-        epochBucket: bucket,
-        timeoutMs: opts.timeoutMs,
-      }),
+  const observed = await Promise.all(
+    rivals.flatMap((rivalId) =>
+      [currentBucket, previousBucket].map(async (bucket) => ({
+        rivalId,
+        intent: await readPartitionIntent({
+          bee: opts.bee,
+          backupSigner: opts.backupSigner,
+          swarmEncryptionKey: opts.swarmEncryptionKey,
+          partition: opts.partition,
+          deviceId: rivalId,
+          epochBucket: bucket,
+          timeoutMs: opts.timeoutMs,
+        }),
+      })),
     ),
   )
-  const observed = await Promise.all(reads)
 
-  for (const intent of observed) {
-    if (!intent) continue
-    // A rival ordering strictly below us wins the partition; we back off.
-    if (compareGenerations(intent.generation, opts.generation) < 0) {
-      return "lose"
-    }
-  }
-  return "win"
+  const found = observed.filter((r) => r.intent !== undefined)
+  // A rival ordering strictly below us wins the partition; we back off.
+  const beatenBy = found.find(
+    (r) => compareGenerations(r.intent!.generation, opts.generation) < 0,
+  )
+  const outcome = beatenBy ? "lose" : "win"
+
+  // One concise line per round so a gateway run shows whether peers were
+  // actually observed (the failure mode being "found=0 → everyone wins").
+  console.log(
+    `[partition-intent] round p=${opts.partition} self=${opts.deviceId} rivals=${rivals.length} found=${found.length} → ${outcome}` +
+      (beatenBy ? ` (beaten by ${beatenBy.rivalId})` : ""),
+  )
+
+  return outcome
 }

--- a/lib/src/sync/partition-intent.ts
+++ b/lib/src/sync/partition-intent.ts
@@ -98,8 +98,23 @@ export const INTENT_EPOCH_MS = 30_000
  */
 export const INTENT_READ_TIMEOUT_MS = 2500
 
+/**
+ * Total window an intent round polls rivals before binding a fresh claim.
+ * Sized to the gateway's write→cross-device-retrieve propagation delay: a peer
+ * that wrote its intent/beacon seconds ago isn't immediately readable, so a
+ * single read races ahead of propagation and misses it. Polling over this
+ * window lets the peer surface. Tunable per gateway (lease/coordinator opts +
+ * the `swarm-id-partition-tuning` localStorage override).
+ */
+export const INTENT_GUARD_WINDOW_MS = 12_000
+
+/** Interval between rival re-reads within the guard window. */
+export const INTENT_GUARD_POLL_MS = 2500
+
 /** Internal marker so a timed-out read is distinguishable from a real error. */
 const INTENT_TIMEOUT_MESSAGE = "intent read timed out"
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
 /** `floor(nowMs / INTENT_EPOCH_MS)` — the current intent epoch bucket. */
 export function intentEpochBucket(nowMs: number): number {
@@ -161,6 +176,12 @@ export async function writePartitionIntent(opts: {
   deviceId: string
   epochBucket: number
   generation: PartitionLockGeneration
+  /**
+   * Present when this write is a holder PRESENCE BEACON (re-published each
+   * refresh): lets a reading joiner apply a `leasedUntil > now` liveness test.
+   * Omitted for a pre-claim intent (the symmetric-race announce).
+   */
+  leasedUntil?: number
 }): Promise<void> {
   const identifier = makePartitionIntentIdentifier(
     opts.partition,
@@ -170,6 +191,9 @@ export async function writePartitionIntent(opts: {
   const payload: PartitionIntentPayload = {
     deviceId: opts.deviceId,
     generation: opts.generation,
+    ...(opts.leasedUntil !== undefined
+      ? { leasedUntil: opts.leasedUntil }
+      : {}),
   }
   const data = new TextEncoder().encode(JSON.stringify(payload))
   const target: UploadTarget = {
@@ -195,11 +219,6 @@ export async function writePartitionIntent(opts: {
     try {
       await uploadSOC(target, opts.backupSigner, identifier, data, {
         encryptionKey: opts.swarmEncryptionKey,
-        // Non-deferred = receipt-backed push-sync into the storage
-        // neighborhood. The whole point of the intent SOC is cross-gateway
-        // visibility; a deferred write would sit on this device's gateway and
-        // a peer's retrieval of the fresh address would never find it.
-        deferred: false,
       })
     } finally {
       stamper.clearIntentSocSlot()
@@ -209,7 +228,6 @@ export async function writePartitionIntent(opts: {
 
   await uploadSOC(target, opts.backupSigner, identifier, data, {
     encryptionKey: opts.swarmEncryptionKey,
-    deferred: false,
   })
 }
 
@@ -250,17 +268,30 @@ export async function readPartitionIntent(opts: {
     const parsed = PartitionIntentPayloadSchemaV1.safeParse(
       JSON.parse(new TextDecoder().decode(soc.payload)),
     )
-    return parsed.success ? parsed.data : undefined
-  } catch (error) {
-    // A timeout means the rival's chunk may well exist but the gateway didn't
-    // retrieve it within the budget — distinct from a genuine "not found", and
-    // worth surfacing because a too-short timeout would silently re-enable the
-    // dual-acquire this whole mechanism exists to prevent.
-    if (error instanceof Error && error.message === INTENT_TIMEOUT_MESSAGE) {
-      console.warn(
-        `[partition-intent] read TIMEOUT for device=${opts.deviceId} p=${opts.partition} bucket=${opts.epochBucket} (>${opts.timeoutMs ?? INTENT_READ_TIMEOUT_MS}ms) — treated as no-intent`,
+    if (!parsed.success) {
+      console.log(
+        `[partition-intent] read device=${opts.deviceId} p=${opts.partition} bucket=${opts.epochBucket}: malformed`,
       )
+      return undefined
     }
+    console.log(
+      `[partition-intent] read device=${opts.deviceId} p=${opts.partition} bucket=${opts.epochBucket}: FOUND (gen ts=${parsed.data.generation.timestampMs} leasedUntil=${parsed.data.leasedUntil ?? "none"})`,
+    )
+    return parsed.data
+  } catch (error) {
+    // Distinguish a timeout (the rival's chunk may well exist but the gateway
+    // didn't retrieve it within the budget) from a genuine not-found — a
+    // too-short timeout would silently re-enable the dual-acquire this whole
+    // mechanism exists to prevent.
+    const timedOut =
+      error instanceof Error && error.message === INTENT_TIMEOUT_MESSAGE
+    console.log(
+      `[partition-intent] read device=${opts.deviceId} p=${opts.partition} bucket=${opts.epochBucket}: ${
+        timedOut
+          ? `TIMEOUT (>${opts.timeoutMs ?? INTENT_READ_TIMEOUT_MS}ms)`
+          : `missing (${error instanceof Error ? error.message : String(error)})`
+      } — treated as no-intent`,
+    )
     return undefined
   }
 }
@@ -291,6 +322,14 @@ export async function resolveIntentRound(opts: {
   knownDeviceIds: string[]
   now: number
   timeoutMs?: number
+  /**
+   * Poll rivals over this window before deciding (default 0 = a single read,
+   * used by tests). Sized to the gateway propagation delay so a peer's recent
+   * intent/beacon surfaces before we bind. See `INTENT_GUARD_WINDOW_MS`.
+   */
+  guardWindowMs?: number
+  /** Interval between polls within the guard window. */
+  guardPollMs?: number
 }): Promise<"win" | "lose"> {
   const rivals = opts.knownDeviceIds.filter((id) => id !== opts.deviceId)
   if (rivals.length === 0) return "win"
@@ -312,37 +351,66 @@ export async function resolveIntentRound(opts: {
     generation: opts.generation,
   })
 
-  // Read every rival's intent for both buckets in parallel; each read is
-  // individually time-bounded so an absent rival doesn't stall the round.
-  const observed = await Promise.all(
-    rivals.flatMap((rivalId) =>
-      [currentBucket, previousBucket].map(async (bucket) => ({
-        rivalId,
-        intent: await readPartitionIntent({
-          bee: opts.bee,
-          backupSigner: opts.backupSigner,
-          swarmEncryptionKey: opts.swarmEncryptionKey,
-          partition: opts.partition,
-          deviceId: rivalId,
-          epochBucket: bucket,
-          timeoutMs: opts.timeoutMs,
-        }),
-      })),
-    ),
-  )
+  // One sweep: read every rival's intent for both buckets in parallel (each
+  // read individually time-bounded), and return the first rival that beats us:
+  //  - a LIVE holder (beacon with `leasedUntil > now`) — already holds it,
+  //    regardless of generation; or
+  //  - a contender ordering strictly below us (a pre-claim intent, no
+  //    `leasedUntil`, smaller generation).
+  // An EXPIRED beacon (`leasedUntil <= now`) is a departed holder — ignored.
+  const sweep = async (): Promise<
+    { rivalId: string; reason: "live-beacon" | "earlier-intent" } | undefined
+  > => {
+    const observed = await Promise.all(
+      rivals.flatMap((rivalId) =>
+        [currentBucket, previousBucket].map(async (bucket) => ({
+          rivalId,
+          intent: await readPartitionIntent({
+            bee: opts.bee,
+            backupSigner: opts.backupSigner,
+            swarmEncryptionKey: opts.swarmEncryptionKey,
+            partition: opts.partition,
+            deviceId: rivalId,
+            epochBucket: bucket,
+            timeoutMs: opts.timeoutMs,
+          }),
+        })),
+      ),
+    )
+    for (const r of observed) {
+      const intent = r.intent
+      if (!intent) continue
+      if (intent.leasedUntil !== undefined) {
+        if (intent.leasedUntil > opts.now)
+          return { rivalId: r.rivalId, reason: "live-beacon" }
+        continue
+      }
+      if (compareGenerations(intent.generation, opts.generation) < 0)
+        return { rivalId: r.rivalId, reason: "earlier-intent" }
+    }
+    return undefined
+  }
 
-  const found = observed.filter((r) => r.intent !== undefined)
-  // A rival ordering strictly below us wins the partition; we back off.
-  const beatenBy = found.find(
-    (r) => compareGenerations(r.intent!.generation, opts.generation) < 0,
-  )
+  // Poll across the guard window. A peer's freshly-written intent/beacon takes
+  // a few seconds to become cross-device-retrievable on a gateway, so a single
+  // immediate read races ahead of propagation. We back off as soon as ANY sweep
+  // finds a beating rival; we only win after the whole window stays clear.
+  const guardWindowMs = opts.guardWindowMs ?? 0
+  const guardPollMs = opts.guardPollMs ?? INTENT_GUARD_POLL_MS
+  const polls = Math.max(1, Math.floor(guardWindowMs / guardPollMs) + 1)
+  let beatenBy: Awaited<ReturnType<typeof sweep>>
+  for (let i = 0; i < polls; i++) {
+    if (i > 0) await sleep(guardPollMs)
+    beatenBy = await sweep()
+    if (beatenBy) break
+  }
+
   const outcome = beatenBy ? "lose" : "win"
-
-  // One concise line per round so a gateway run shows whether peers were
-  // actually observed (the failure mode being "found=0 → everyone wins").
   console.log(
-    `[partition-intent] round p=${opts.partition} self=${opts.deviceId} rivals=${rivals.length} found=${found.length} → ${outcome}` +
-      (beatenBy ? ` (beaten by ${beatenBy.rivalId})` : ""),
+    `[partition-intent] round p=${opts.partition} self=${opts.deviceId} rivals=${rivals.length} polls=${polls} → ${outcome}` +
+      (beatenBy
+        ? ` (beaten by ${beatenBy.rivalId} via ${beatenBy.reason})`
+        : ""),
   )
 
   return outcome

--- a/lib/src/sync/partition-intent.ts
+++ b/lib/src/sync/partition-intent.ts
@@ -35,12 +35,36 @@
  * flaky device must not deadlock), so the guarantee is "when the network
  * works, rivals are seen"; genuine network partition still falls back to the
  * existing guard + TTL + refresh backstop.
+ *
+ * Slot safety: an intent is stamped into the CONTENDED partition's reserved
+ * slot (= the partition index, `< DATA_COUNTER_START`), via
+ * `UtilizationAwareStamper.reserveIntentSocSlot`. It therefore can NEVER share
+ * a postage `(bucket, slot)` with user data (data lives at
+ * `>= DATA_COUNTER_START`) — a deterministic guarantee, not probabilistic.
+ *
+ * Two residuals remain (both ~1/65536 per contending pair per round, far rarer
+ * than the systematic disjoint-gateway failure, and NOT closed here):
+ *   - Two contenders for the same partition whose per-epoch intent addresses
+ *     hash into the same bucket both route to that partition's reserved slot;
+ *     the older loses its stamp and reads as "no intent", so on disjoint
+ *     gateways both may "win" → a rare dual-acquire. (A verify-own-intent
+ *     back-off or per-device slot would close it.)
+ *   - An intent may overstamp the contended partition's own (stale) lock SOC
+ *     (harmless — re-acquired) or a published state chunk (→ `readFailed` →
+ *     read-only fallback). Liveness-only, never data loss.
  */
 
-import { Bee, Identifier, PrivateKey, type Stamper } from "@ethersphere/bee-js"
+import {
+  Bee,
+  Identifier,
+  PrivateKey,
+  type EthAddress,
+  type Stamper,
+} from "@ethersphere/bee-js"
 import { Binary } from "cafe-utility"
 import { downloadEncryptedSOC } from "../proxy/download-data"
 import { uploadSOC, type UploadTarget } from "../proxy/upload"
+import { UtilizationAwareStamper } from "../utils/batch-utilization"
 import { rejectAfter } from "../utils/promise"
 import {
   PartitionIntentPayloadSchemaV1,
@@ -98,6 +122,28 @@ export function makePartitionIntentIdentifier(
 }
 
 /**
+ * 32-byte SOC chunk address for an intent — `keccak256(identifier ‖ owner)`,
+ * the same derivation `uploadSOC` uses. Computable before the upload so the
+ * stamper can reserve the chunk's slot (route it to the contended partition's
+ * reserved index instead of a data lane).
+ */
+export function intentSocAddress(
+  partition: number,
+  deviceId: string,
+  epochBucket: number,
+  owner: EthAddress,
+): Uint8Array {
+  const identifier = makePartitionIntentIdentifier(
+    partition,
+    deviceId,
+    epochBucket,
+  )
+  return Binary.keccak256(
+    Binary.concatBytes(identifier.toUint8Array(), owner.toUint8Array()),
+  )
+}
+
+/**
  * Write this device's intent for (partition, epochBucket). The payload carries
  * the generation the device intends to claim with, so rivals can order against
  * it. Uses the shared backup signer as owner (same as the lock SOC); each
@@ -128,6 +174,31 @@ export async function writePartitionIntent(opts: {
     bee: opts.bee,
     stamper: opts.stamper,
   }
+
+  // Route the intent to the contended partition's reserved slot so it can
+  // never land in a data lane and overstamp user data (see module header).
+  // Only the partition-aware stamper can do this; a plain stamper (legacy
+  // single-device) never contends, so a normal upload is fine there.
+  const stamper = opts.stamper
+  if (stamper instanceof UtilizationAwareStamper) {
+    const owner = opts.backupSigner.publicKey().address()
+    const address = intentSocAddress(
+      opts.partition,
+      opts.deviceId,
+      opts.epochBucket,
+      owner,
+    )
+    stamper.reserveIntentSocSlot(address, opts.partition)
+    try {
+      await uploadSOC(target, opts.backupSigner, identifier, data, {
+        encryptionKey: opts.swarmEncryptionKey,
+      })
+    } finally {
+      stamper.clearIntentSocSlot()
+    }
+    return
+  }
+
   await uploadSOC(target, opts.backupSigner, identifier, data, {
     encryptionKey: opts.swarmEncryptionKey,
   })

--- a/lib/src/sync/partition-lease.integration.test.ts
+++ b/lib/src/sync/partition-lease.integration.test.ts
@@ -73,7 +73,12 @@ import {
 const TEST_BATCH_ID = new BatchId("ab".repeat(32))
 const TEST_BATCH_DEPTH = 24
 const TEST_ENC_KEY = new Uint8Array(32).map((_, i) => (i * 7 + 3) & 0xff)
-const DEVICE_A = "device-alpha-111"
+// Selection scans from each device's deterministic home partition
+// (`deviceHomePartition`). These device IDs are chosen so DEVICE_A's home is
+// partition 0 at PARTITION_COUNT (2), keeping the selection/fencing scenarios
+// below readable in natural partition order. The home-offset spread itself is
+// covered directly in partition-lock.test.ts.
+const DEVICE_A = "device-alpha-1" // home partition 0 (keccak256 mod 2)
 const DEVICE_B = "device-beta-222"
 
 const BACKUP_SIGNER = createTestSigner() as PrivateKey

--- a/lib/src/sync/partition-lease.integration.test.ts
+++ b/lib/src/sync/partition-lease.integration.test.ts
@@ -48,6 +48,7 @@ import {
   readPartitionLock,
   writePartitionLock,
 } from "./partition-lock"
+import { intentEpochBucket, writePartitionIntent } from "./partition-intent"
 import { Binary } from "cafe-utility"
 import {
   LEASE_TTL_MS,
@@ -129,6 +130,8 @@ function makeLease(opts: {
   deviceId: string
   bee: Bee
   now?: () => number
+  knownDeviceIds?: () => string[]
+  intentReadTimeoutMs?: number
 }): PartitionLease {
   return new PartitionLease({
     bee: opts.bee,
@@ -140,6 +143,8 @@ function makeLease(opts: {
     stamper: createMockStamper() as unknown as Stamper,
     now: opts.now,
     guardMs: GUARD_MS,
+    knownDeviceIds: opts.knownDeviceIds,
+    intentReadTimeoutMs: opts.intentReadTimeoutMs,
   })
 }
 
@@ -1033,5 +1038,119 @@ describe("PartitionLease.serialize / hydrate", () => {
     const other = makeLease({ deviceId: DEVICE_B, bee: bee as unknown as Bee })
     other.hydrate(snap)
     expect(other.currentPartition).toBeUndefined()
+  })
+})
+
+describe("PartitionLease.acquire — intent round (Phase 2)", () => {
+  // DEVICE_A's home partition is 0 (see the constant above), so a fresh claim
+  // targets partition 0 and the intent round consults rivals for partition 0.
+  const NOW = 5_000_000
+
+  it("backs off to read-only when a rival advertises an earlier intent", async () => {
+    // A rival announced intent for partition 0 with a SMALLER generation than
+    // DEVICE_A will use (timestampMs NOW). No lock SOC exists, so without the
+    // intent round DEVICE_A would bind partition 0 — the disjoint-gateway bug.
+    await writePartitionIntent({
+      bee: bee as unknown as Bee,
+      stamper: createMockStamper() as unknown as Stamper,
+      backupSigner: BACKUP_SIGNER,
+      swarmEncryptionKey: TEST_ENC_KEY,
+      partition: 0,
+      deviceId: DEVICE_B,
+      epochBucket: intentEpochBucket(NOW),
+      generation: {
+        timestampMs: NOW - 1,
+        tiebreaker: makeDeviceTiebreaker(DEVICE_B),
+      },
+    })
+
+    const lease = makeLease({
+      deviceId: DEVICE_A,
+      bee: bee as unknown as Bee,
+      now: () => NOW,
+      knownDeviceIds: () => [DEVICE_A, DEVICE_B],
+      intentReadTimeoutMs: 50,
+    })
+    const result = await lease.acquire({ partitionCount: PARTITION_COUNT })
+
+    expect(result.isReadOnly).toBe(true)
+    expect(result.partition).toBeUndefined()
+    // Crucially: no lock claim was written over the contested partition.
+    const lock = await readPartitionLock({
+      bee: bee as unknown as Bee,
+      backupSigner: BACKUP_SIGNER,
+      swarmEncryptionKey: TEST_ENC_KEY,
+      partition: 0,
+    })
+    expect(lock?.holderDeviceId).not.toBe(DEVICE_A)
+  })
+
+  it("wins and binds when a rival advertises a later intent", async () => {
+    await writePartitionIntent({
+      bee: bee as unknown as Bee,
+      stamper: createMockStamper() as unknown as Stamper,
+      backupSigner: BACKUP_SIGNER,
+      swarmEncryptionKey: TEST_ENC_KEY,
+      partition: 0,
+      deviceId: DEVICE_B,
+      epochBucket: intentEpochBucket(NOW),
+      generation: {
+        timestampMs: NOW + 1,
+        tiebreaker: makeDeviceTiebreaker(DEVICE_B),
+      },
+    })
+
+    const lease = makeLease({
+      deviceId: DEVICE_A,
+      bee: bee as unknown as Bee,
+      now: () => NOW,
+      knownDeviceIds: () => [DEVICE_A, DEVICE_B],
+      intentReadTimeoutMs: 50,
+    })
+    const result = await lease.acquire({ partitionCount: PARTITION_COUNT })
+
+    expect(result.isReadOnly).toBe(false)
+    expect(result.partition).toBe(0)
+    const lock = await readPartitionLock({
+      bee: bee as unknown as Bee,
+      backupSigner: BACKUP_SIGNER,
+      swarmEncryptionKey: TEST_ENC_KEY,
+      partition: 0,
+    })
+    expect(lock?.holderDeviceId).toBe(DEVICE_A)
+  })
+
+  it("does not run an intent round when re-acquiring our own partition", async () => {
+    // First claim with no rivals.
+    const lease = makeLease({
+      deviceId: DEVICE_A,
+      bee: bee as unknown as Bee,
+      now: () => NOW,
+      knownDeviceIds: () => [DEVICE_A, DEVICE_B],
+      intentReadTimeoutMs: 50,
+    })
+    expect(
+      (await lease.acquire({ partitionCount: PARTITION_COUNT })).partition,
+    ).toBe(0)
+
+    // A rival now advertises an earlier intent — but a re-acquire of a
+    // partition we already hold must NOT be gated by the intent round.
+    await writePartitionIntent({
+      bee: bee as unknown as Bee,
+      stamper: createMockStamper() as unknown as Stamper,
+      backupSigner: BACKUP_SIGNER,
+      swarmEncryptionKey: TEST_ENC_KEY,
+      partition: 0,
+      deviceId: DEVICE_B,
+      epochBucket: intentEpochBucket(NOW),
+      generation: {
+        timestampMs: NOW - 1,
+        tiebreaker: makeDeviceTiebreaker(DEVICE_B),
+      },
+    })
+
+    const reacquire = await lease.acquire({ partitionCount: PARTITION_COUNT })
+    expect(reacquire.partition).toBe(0)
+    expect(reacquire.isReadOnly).toBe(false)
   })
 })

--- a/lib/src/sync/partition-lease.integration.test.ts
+++ b/lib/src/sync/partition-lease.integration.test.ts
@@ -48,7 +48,11 @@ import {
   readPartitionLock,
   writePartitionLock,
 } from "./partition-lock"
-import { intentEpochBucket, writePartitionIntent } from "./partition-intent"
+import {
+  intentEpochBucket,
+  readPartitionIntent,
+  writePartitionIntent,
+} from "./partition-intent"
 import { Binary } from "cafe-utility"
 import {
   LEASE_TTL_MS,
@@ -132,6 +136,7 @@ function makeLease(opts: {
   now?: () => number
   knownDeviceIds?: () => string[]
   intentReadTimeoutMs?: number
+  intentGuardWindowMs?: number
 }): PartitionLease {
   return new PartitionLease({
     bee: opts.bee,
@@ -145,6 +150,10 @@ function makeLease(opts: {
     guardMs: GUARD_MS,
     knownDeviceIds: opts.knownDeviceIds,
     intentReadTimeoutMs: opts.intentReadTimeoutMs,
+    // Default the intent-round poll-guard to a single immediate read in tests
+    // (MockBee has perfect visibility; the production ~12s window would just
+    // stall the suite). Individual tests can override.
+    intentGuardWindowMs: opts.intentGuardWindowMs ?? 0,
   })
 }
 
@@ -1152,5 +1161,213 @@ describe("PartitionLease.acquire — intent round (Phase 2)", () => {
     const reacquire = await lease.acquire({ partitionCount: PARTITION_COUNT })
     expect(reacquire.partition).toBe(0)
     expect(reacquire.isReadOnly).toBe(false)
+  })
+})
+
+describe("PartitionLease.acquire — holder presence beacons (gateway holder-exists)", () => {
+  // DEVICE_A's home partition is 0. To simulate the gateway (static lock SOC
+  // unreadable) we write NO lock SOC, only a foreign holder's presence beacon
+  // (an intent SOC carrying `leasedUntil`), and assert the joiner detects it
+  // and avoids that partition — the 3-device "join against an existing holder"
+  // collision the rework fixes.
+  const NOW = 5_000_000
+
+  function writeBeacon(opts: {
+    partition: number
+    deviceId: string
+    epochBucket: number
+    leasedUntil: number
+    genTimestamp?: number
+  }) {
+    return writePartitionIntent({
+      bee: bee as unknown as Bee,
+      stamper: createMockStamper() as unknown as Stamper,
+      backupSigner: BACKUP_SIGNER,
+      swarmEncryptionKey: TEST_ENC_KEY,
+      partition: opts.partition,
+      deviceId: opts.deviceId,
+      epochBucket: opts.epochBucket,
+      generation: {
+        timestampMs: opts.genTimestamp ?? NOW - 1000,
+        tiebreaker: makeDeviceTiebreaker(opts.deviceId),
+      },
+      leasedUntil: opts.leasedUntil,
+    })
+  }
+
+  function joinerLease() {
+    return makeLease({
+      deviceId: DEVICE_A,
+      bee: bee as unknown as Bee,
+      now: () => NOW,
+      knownDeviceIds: () => [DEVICE_A, DEVICE_B],
+      intentReadTimeoutMs: 50,
+    })
+  }
+
+  it("detects a live holder's beacon on its home partition and picks another", async () => {
+    await writeBeacon({
+      partition: 0,
+      deviceId: DEVICE_B,
+      epochBucket: intentEpochBucket(NOW),
+      leasedUntil: NOW + LEASE_TTL_MS,
+    })
+
+    const result = await joinerLease().acquire({
+      partitionCount: PARTITION_COUNT,
+    })
+
+    expect(result.isReadOnly).toBe(false)
+    expect(result.partition).toBe(1) // avoided the held partition 0
+    // No claim written on partition 0 by the joiner.
+    const p0 = await readPartitionLock({
+      bee: bee as unknown as Bee,
+      backupSigner: BACKUP_SIGNER,
+      swarmEncryptionKey: TEST_ENC_KEY,
+      partition: 0,
+    })
+    expect(p0?.holderDeviceId).not.toBe(DEVICE_A)
+  })
+
+  it("treats an expired beacon (leasedUntil <= now) as free", async () => {
+    await writeBeacon({
+      partition: 0,
+      deviceId: DEVICE_B,
+      epochBucket: intentEpochBucket(NOW),
+      leasedUntil: NOW - 1,
+    })
+
+    const result = await joinerLease().acquire({
+      partitionCount: PARTITION_COUNT,
+    })
+    expect(result.partition).toBe(0) // expired → partition is free → home wins
+  })
+
+  it("detects a live beacon left in the previous epoch bucket (boundary)", async () => {
+    await writeBeacon({
+      partition: 0,
+      deviceId: DEVICE_B,
+      epochBucket: intentEpochBucket(NOW) - 1,
+      leasedUntil: NOW + LEASE_TTL_MS,
+    })
+
+    const result = await joinerLease().acquire({
+      partitionCount: PARTITION_COUNT,
+    })
+    expect(result.partition).toBe(1) // detected via the previous-bucket read
+  })
+
+  it("a bare pre-claim intent (no leasedUntil) does NOT mark a partition held", async () => {
+    // Same address/bucket as a beacon but WITHOUT leasedUntil — a contender,
+    // not a holder. The joiner must still claim the partition (resolved by the
+    // intent round), not treat it as held.
+    await writePartitionIntent({
+      bee: bee as unknown as Bee,
+      stamper: createMockStamper() as unknown as Stamper,
+      backupSigner: BACKUP_SIGNER,
+      swarmEncryptionKey: TEST_ENC_KEY,
+      partition: 0,
+      deviceId: DEVICE_B,
+      epochBucket: intentEpochBucket(NOW),
+      generation: {
+        timestampMs: NOW + 1000, // later → joiner wins the intent round
+        tiebreaker: makeDeviceTiebreaker(DEVICE_B),
+      },
+      // no leasedUntil
+    })
+
+    const result = await joinerLease().acquire({
+      partitionCount: PARTITION_COUNT,
+    })
+    expect(result.partition).toBe(0) // claimed p0 (won the intent round), not avoided
+  })
+
+  it("a holder publishes a beacon on acquire (and not when it has no rival)", async () => {
+    const withRival = await joinerLease().acquire({
+      partitionCount: PARTITION_COUNT,
+    })
+    expect(withRival.partition).toBe(0)
+    const beacon = await readPartitionIntent({
+      bee: bee as unknown as Bee,
+      backupSigner: BACKUP_SIGNER,
+      swarmEncryptionKey: TEST_ENC_KEY,
+      partition: 0,
+      deviceId: DEVICE_A,
+      epochBucket: intentEpochBucket(NOW),
+    })
+    expect(beacon?.leasedUntil).toBeGreaterThan(NOW)
+  })
+
+  it("does not publish a beacon for a single-device account (no rival)", async () => {
+    const solo = makeLease({
+      deviceId: DEVICE_A,
+      bee: bee as unknown as Bee,
+      now: () => NOW,
+      knownDeviceIds: () => [DEVICE_A],
+      intentReadTimeoutMs: 50,
+    })
+    expect(
+      (await solo.acquire({ partitionCount: PARTITION_COUNT })).partition,
+    ).toBe(0)
+    const beacon = await readPartitionIntent({
+      bee: bee as unknown as Bee,
+      backupSigner: BACKUP_SIGNER,
+      swarmEncryptionKey: TEST_ENC_KEY,
+      partition: 0,
+      deviceId: DEVICE_A,
+      epochBucket: intentEpochBucket(NOW),
+    })
+    expect(beacon).toBeUndefined()
+  })
+
+  it("refresh yields when an earlier-generation peer holds the same partition (deconfliction backstop)", async () => {
+    // DEVICE_A claims p0 cleanly (no rival beacon yet at acquire).
+    const lease = makeLease({
+      deviceId: DEVICE_A,
+      bee: bee as unknown as Bee,
+      now: () => NOW,
+      knownDeviceIds: () => [DEVICE_A, DEVICE_B],
+      intentReadTimeoutMs: 50,
+    })
+    expect(
+      (await lease.acquire({ partitionCount: PARTITION_COUNT })).partition,
+    ).toBe(0)
+
+    // A collision slipped past the guard: DEVICE_B holds p0 too, with an EARLIER
+    // generation (claimed first). Its beacon has now propagated.
+    await writeBeacon({
+      partition: 0,
+      deviceId: DEVICE_B,
+      epochBucket: intentEpochBucket(NOW),
+      leasedUntil: NOW + LEASE_TTL_MS,
+    })
+
+    // On refresh, DEVICE_A (later generation) detects DEVICE_B and yields.
+    expect(await lease.refresh()).toBe(false)
+  })
+
+  it("refresh keeps the lease when only a LATER-generation peer is present", async () => {
+    const lease = makeLease({
+      deviceId: DEVICE_A,
+      bee: bee as unknown as Bee,
+      now: () => NOW,
+      knownDeviceIds: () => [DEVICE_A, DEVICE_B],
+      intentReadTimeoutMs: 50,
+    })
+    expect(
+      (await lease.acquire({ partitionCount: PARTITION_COUNT })).partition,
+    ).toBe(0)
+
+    // DEVICE_B's beacon is LATER than DEVICE_A's claim (DEVICE_A's generation
+    // is NOW; give B a later timestamp).
+    await writeBeacon({
+      partition: 0,
+      deviceId: DEVICE_B,
+      epochBucket: intentEpochBucket(NOW),
+      leasedUntil: NOW + LEASE_TTL_MS,
+      genTimestamp: NOW + 1000,
+    })
+    // DEVICE_A is the earlier holder → keeps the lease.
+    expect(await lease.refresh()).toBe(true)
   })
 })

--- a/lib/src/sync/partition-lease.integration.test.ts
+++ b/lib/src/sync/partition-lease.integration.test.ts
@@ -819,7 +819,7 @@ describe("PartitionLease.refresh", () => {
 
     nowValue = NOW1 + 10_000
     const ok = await lease.refresh()
-    expect(ok).toBe(true)
+    expect(ok).toBe("held")
 
     const observed = await readPartitionLock({
       bee: bee as unknown as Bee,
@@ -831,9 +831,9 @@ describe("PartitionLease.refresh", () => {
     expect(observed?.leasedUntil).toBe(nowValue + LEASE_TTL_MS)
   })
 
-  it("returns false when no lease is held", async () => {
+  it("returns 'lost' when no lease is held", async () => {
     const lease = makeLease({ deviceId: DEVICE_A, bee: bee as unknown as Bee })
-    expect(await lease.refresh()).toBe(false)
+    expect(await lease.refresh()).toBe("lost")
   })
 })
 
@@ -975,7 +975,7 @@ describe("PartitionLease.release — generation fencing (#349)", () => {
 
     // A refresh tick that slipped past teardown: must abort (no ghost claim
     // the fenced release would refuse to clear), not throw.
-    await expect(leaseA.refresh()).resolves.toBe(false)
+    await expect(leaseA.refresh()).resolves.toBe("lost")
 
     unblock()
     await releasing
@@ -1343,7 +1343,12 @@ describe("PartitionLease.acquire — holder presence beacons (gateway holder-exi
     })
 
     // On refresh, DEVICE_A (later generation) detects DEVICE_B and yields.
-    expect(await lease.refresh()).toBe(false)
+    // The verdict comes from the per-epoch beacon channel, so it is reported as
+    // a CONFIRMED `"displaced"` (not a plain `"lost"`): the coordinator must
+    // demote on this without re-reading the static lock SOC, which DEVICE_A
+    // just rewrote with its own claim. See the BatchWriteCoordinator test
+    // "demotes on a beacon-confirmed displacement …" for the end-to-end guard.
+    expect(await lease.refresh()).toBe("displaced")
   })
 
   it("refresh keeps the lease when only a LATER-generation peer is present", async () => {
@@ -1368,6 +1373,6 @@ describe("PartitionLease.acquire — holder presence beacons (gateway holder-exi
       genTimestamp: NOW + 1000,
     })
     // DEVICE_A is the earlier holder → keeps the lease.
-    expect(await lease.refresh()).toBe(true)
+    expect(await lease.refresh()).toBe("held")
   })
 })

--- a/lib/src/sync/partition-lease.ts
+++ b/lib/src/sync/partition-lease.ts
@@ -367,6 +367,12 @@ export class PartitionLease {
     // proceeds to bind; losers back off to read-only. See partition-intent.ts.
     const knownDeviceIds = this.opts.knownDeviceIds?.() ?? []
     const hasRival = knownDeviceIds.some((id) => id !== this.opts.deviceId)
+    // Diagnostic: shows whether the intent round even runs, and on how many
+    // peers. The dual-acquire failure is "freshClaim + no rival seen at acquire
+    // time" (registry not yet synced) or "round ran but found nothing".
+    console.log(
+      `[PartitionLease] claim p=${partition} self=${this.opts.deviceId} freshClaim=${freshClaim} knownDevices=${knownDeviceIds.length} intentRound=${freshClaim && hasRival}`,
+    )
     if (freshClaim && hasRival) {
       const outcome = await resolveIntentRound({
         bee: this.opts.bee,

--- a/lib/src/sync/partition-lease.ts
+++ b/lib/src/sync/partition-lease.ts
@@ -36,12 +36,14 @@ import {
 import {
   acquirePartitionLock,
   deviceHomePartition,
+  makeDeviceTiebreaker,
   NO_HOLDER_DEVICE_ID,
   readPartitionLock,
   releasePartitionLock,
   type PartitionLockGeneration,
   type PartitionLockPayload,
 } from "./partition-lock"
+import { resolveIntentRound } from "./partition-intent"
 import { readPartitionState, writePartitionState } from "./partition-state"
 
 /** Default guard time δ for the lock protocol (iteration-2 doc § δ tuning). */
@@ -131,6 +133,17 @@ export class PartitionLease {
       now?: () => number
       /** Override for tests; defaults to PARTITION_LOCK_GUARD_MS. */
       guardMs?: number
+      /**
+       * Current known device IDs for this account (from the synced device
+       * registry). Read fresh each round so it reflects late-announced
+       * devices. When provided with ≥1 rival, a fresh claim of a free
+       * partition first runs an intent round (Phase 2 — see
+       * `partition-intent.ts`) so disjoint-gateway contenders agree on one
+       * winner before binding. Omitted (or empty) → today's guard+TTL path.
+       */
+      knownDeviceIds?: () => string[]
+      /** Override for tests; per-rival intent-read timeout. */
+      intentReadTimeoutMs?: number
     },
   ) {}
 
@@ -149,6 +162,8 @@ export class PartitionLease {
     stamper?: Stamper
     now?: () => number
     guardMs?: number
+    knownDeviceIds?: () => string[]
+    intentReadTimeoutMs?: number
   }): Promise<PartitionLease> {
     const swarmEncryptionKeyHex = uint8ArrayToHex(opts.swarmEncryptionKey)
     const backupKeyHex = await deriveSecret(swarmEncryptionKeyHex, "backup-key")
@@ -262,8 +277,10 @@ export class PartitionLease {
     await this.refreshFromSwarm(partitionCount)
 
     // Prefer the partition we already hold; otherwise the first free/expired.
-    const chosenPartition =
-      this.heldPartition() ?? this.pickFreeOrExpired(partitionCount)
+    // A re-acquire of our own partition is not a contended claim — skip the
+    // intent round (which only guards taking a free/expired slot).
+    const held = this.heldPartition()
+    const chosenPartition = held ?? this.pickFreeOrExpired(partitionCount)
 
     if (chosenPartition === undefined) {
       // Every partition is live + foreign-held.
@@ -275,7 +292,11 @@ export class PartitionLease {
       }
     }
 
-    return this.claimPartition({ partition: chosenPartition, partitionCount })
+    return this.claimPartition({
+      partition: chosenPartition,
+      partitionCount,
+      freshClaim: held === undefined,
+    })
   }
 
   /**
@@ -287,8 +308,10 @@ export class PartitionLease {
   private async claimPartition(args: {
     partition: number
     partitionCount: number
+    /** A first-time claim of a free/expired slot (vs. a re-acquire of ours). */
+    freshClaim: boolean
   }): Promise<AcquireResult> {
-    const { partition, partitionCount } = args
+    const { partition, partitionCount, freshClaim } = args
     const { stamper, batchId, batchDepth } = this.requireWriteContext()
 
     // Cache-aware seed: pass the reference our local counter is already in
@@ -331,6 +354,45 @@ export class PartitionLease {
         ? stamper.buildLeaseLocalCounter()
         : (stateResult.localCounter ?? new Uint32Array(NUM_BUCKETS))
 
+    // The generation we will both advertise (intent round) and claim with, so
+    // the round's winner binds the lock with the exact generation it announced.
+    const generation: PartitionLockGeneration = {
+      timestampMs: this.now(),
+      tiebreaker: makeDeviceTiebreaker(this.opts.deviceId),
+    }
+
+    // Phase 2: for a fresh claim of a free/expired slot with known rivals, run
+    // an intent round at a fresh per-epoch address (forces a network read that
+    // bypasses the gateway's frozen lock-SOC cache). Only the round's winner
+    // proceeds to bind; losers back off to read-only. See partition-intent.ts.
+    const knownDeviceIds = this.opts.knownDeviceIds?.() ?? []
+    const hasRival = knownDeviceIds.some((id) => id !== this.opts.deviceId)
+    if (freshClaim && hasRival) {
+      const outcome = await resolveIntentRound({
+        bee: this.opts.bee,
+        stamper,
+        backupSigner: this.opts.backupSigner,
+        swarmEncryptionKey: this.opts.swarmEncryptionKey,
+        partition,
+        deviceId: this.opts.deviceId,
+        generation,
+        knownDeviceIds,
+        now: this.now(),
+        timeoutMs: this.opts.intentReadTimeoutMs,
+      })
+      if (outcome === "lose") {
+        console.warn(
+          `[PartitionLease] Lost intent round for partition ${partition}; falling back to read-only.`,
+        )
+        return {
+          partition: undefined,
+          partitionCount,
+          localCounter: new Uint32Array(NUM_BUCKETS),
+          isReadOnly: true,
+        }
+      }
+    }
+
     const lockResult = await acquirePartitionLock({
       bee: this.opts.bee,
       stamper,
@@ -340,6 +402,7 @@ export class PartitionLease {
       deviceId: this.opts.deviceId,
       ttlMs: LEASE_TTL_MS,
       guardMs: this.opts.guardMs ?? PARTITION_LOCK_GUARD_MS,
+      generation,
       now: () => this.now(),
     })
 

--- a/lib/src/sync/partition-lease.ts
+++ b/lib/src/sync/partition-lease.ts
@@ -93,6 +93,29 @@ export interface AcquireResult {
 }
 
 /**
+ * Outcome of a `refresh()` tick. Distinguishes the two ways a refresh can fail
+ * to keep the lease, because the coordinator must react to them differently:
+ *
+ * - `"held"`     — the lease is still ours and was extended.
+ * - `"lost"`     — could not confirm via write+verify (no lease, or the lock
+ *                  protocol returned `blocked`/`lost-race`/`aborted`). The
+ *                  caller should re-check the static lock SOC before demoting
+ *                  (a transient read-your-writes hiccup must not demote — the
+ *                  Phase-1 optimism).
+ * - `"displaced"` — a foreign PRESENCE BEACON with an earlier generation proved
+ *                  a peer already holds this partition. The beacon is read at a
+ *                  fresh per-epoch address — the channel that stays readable on
+ *                  a disjoint gateway where the static lock SOC is frozen — so
+ *                  this is a CONFIRMED displacement. The caller MUST demote
+ *                  directly and must NOT re-gate on the static lock SOC: by the
+ *                  time `refresh()` returns, it has already rewritten our own
+ *                  claim to that address, so a re-read there would see SELF and
+ *                  never confirm (the no-op the deconfliction backstop existed
+ *                  to avoid).
+ */
+export type LeaseRefreshOutcome = "held" | "lost" | "displaced"
+
+/**
  * Serialised form of the lease state, used as the local persistence cache.
  * Never trusted on its own — callers re-validate `self` against the lock
  * SOC before acting on it.
@@ -594,12 +617,14 @@ export class PartitionLease {
 
   /**
    * Re-run the lock protocol on the currently-held partition to bump
-   * `leasedUntil`. Returns `false` when we don't hold a lease (legacy mode)
-   * or the lock protocol returned `blocked` / `lost-race` / `aborted` — the
-   * caller should treat that as "lease lost".
+   * `leasedUntil`. Returns `"lost"` when we don't hold a lease (legacy mode)
+   * or the lock protocol returned `blocked` / `lost-race` / `aborted`,
+   * `"displaced"` when a foreign presence beacon proves a peer holds the
+   * partition (the deconfliction backstop), else `"held"`. See
+   * `LeaseRefreshOutcome` for how the coordinator must react to each.
    */
-  async refresh(): Promise<boolean> {
-    if (!this.self) return false
+  async refresh(): Promise<LeaseRefreshOutcome> {
+    if (!this.self) return "lost"
     const partition = this.self.partition
     const { stamper } = this.requireWriteContext()
     const lockResult = await acquirePartitionLock({
@@ -619,12 +644,12 @@ export class PartitionLease {
     })
     // `release()` can complete during the guard window above and null
     // `this.self` — re-check before dereferencing it.
-    if (!this.self) return false
+    if (!this.self) return "lost"
     if (lockResult.outcome !== "acquired" || !lockResult.payload) {
       console.warn(
         `[PartitionLease] Refresh on partition ${partition} returned ${lockResult.outcome}.`,
       )
-      return false
+      return "lost"
     }
     const payload = lockResult.payload
     this.self = {
@@ -646,13 +671,18 @@ export class PartitionLease {
     // poll-guard (propagation outran the window), two devices can briefly hold
     // the same partition. Once both beacons have propagated, the one with the
     // LATER generation yields here so the pair resolves to a single holder.
+    // This is a CONFIRMED displacement (read via the fresh per-epoch beacon
+    // address, which stays readable on a disjoint gateway) — reported as
+    // `"displaced"` so the coordinator demotes WITHOUT re-checking the static
+    // lock SOC, which we just rewrote with our own claim above and which is the
+    // frozen read the beacon channel exists to bypass.
     if (await this.foreignBeaconBeatsUs(partition, payload.generation)) {
       console.warn(
         `[PartitionLease] Refresh on partition ${partition}: an earlier-generation peer holds it; yielding.`,
       )
-      return false
+      return "displaced"
     }
-    return true
+    return "held"
   }
 
   /**

--- a/lib/src/sync/partition-lease.ts
+++ b/lib/src/sync/partition-lease.ts
@@ -35,6 +35,7 @@ import {
 } from "../utils/batch-utilization"
 import {
   acquirePartitionLock,
+  compareGenerations,
   deviceHomePartition,
   makeDeviceTiebreaker,
   NO_HOLDER_DEVICE_ID,
@@ -43,7 +44,14 @@ import {
   type PartitionLockGeneration,
   type PartitionLockPayload,
 } from "./partition-lock"
-import { resolveIntentRound } from "./partition-intent"
+import {
+  INTENT_GUARD_POLL_MS,
+  INTENT_GUARD_WINDOW_MS,
+  intentEpochBucket,
+  readPartitionIntent,
+  resolveIntentRound,
+  writePartitionIntent,
+} from "./partition-intent"
 import { readPartitionState, writePartitionState } from "./partition-state"
 
 /** Default guard time δ for the lock protocol (iteration-2 doc § δ tuning). */
@@ -144,6 +152,13 @@ export class PartitionLease {
       knownDeviceIds?: () => string[]
       /** Override for tests; per-rival intent-read timeout. */
       intentReadTimeoutMs?: number
+      /**
+       * Fresh-claim intent-round poll window / interval (gateway-propagation
+       * tunable). Default to the `INTENT_GUARD_*` constants; tests pass 0 for a
+       * single immediate read.
+       */
+      intentGuardWindowMs?: number
+      intentGuardPollMs?: number
     },
   ) {}
 
@@ -164,6 +179,8 @@ export class PartitionLease {
     guardMs?: number
     knownDeviceIds?: () => string[]
     intentReadTimeoutMs?: number
+    intentGuardWindowMs?: number
+    intentGuardPollMs?: number
   }): Promise<PartitionLease> {
     const swarmEncryptionKeyHex = uint8ArrayToHex(opts.swarmEncryptionKey)
     const backupKeyHex = await deriveSecret(swarmEncryptionKeyHex, "backup-key")
@@ -186,19 +203,108 @@ export class PartitionLease {
         swarmEncryptionKey: this.opts.swarmEncryptionKey,
         partition: p,
       })
-      if (
-        !lock ||
-        lock.holderDeviceId === NO_HOLDER_DEVICE_ID ||
-        lock.leasedUntil <= now
-      ) {
+      // Per-partition outcome — this is the line that reveals whether a joining
+      // device can actually SEE the current holder's lock SOC (the suspected
+      // cross-device dual-acquire cause). "no readable lock" here for a
+      // partition a peer holds = the lock SOC is invisible to us.
+      if (!lock) {
+        console.log(`[PartitionLease] refresh p=${p}: no readable lock`)
         continue
       }
+      if (lock.holderDeviceId === NO_HOLDER_DEVICE_ID) {
+        console.log(`[PartitionLease] refresh p=${p}: released sentinel`)
+        continue
+      }
+      const self = lock.holderDeviceId === this.opts.deviceId ? " (self)" : ""
+      if (lock.leasedUntil <= now) {
+        console.log(
+          `[PartitionLease] refresh p=${p}: EXPIRED holder ${lock.holderDeviceId}${self} (until ${lock.leasedUntil} <= now ${now})`,
+        )
+        continue
+      }
+      console.log(
+        `[PartitionLease] refresh p=${p}: held by ${lock.holderDeviceId}${self} until ${lock.leasedUntil}`,
+      )
       this.holders.set(p, {
         deviceId: lock.holderDeviceId,
         generation: lock.generation,
         acquiredAt: lock.acquiredAt,
         leasedUntil: lock.leasedUntil,
       })
+    }
+    const summary = Array.from(this.holders.entries())
+      .map(([p, h]) => `${p}->${h.deviceId}`)
+      .join(",")
+    console.log(
+      `[PartitionLease] refresh: live holders={${summary}} self=${this.opts.deviceId}`,
+    )
+  }
+
+  /**
+   * Merge live holders detected from per-device PRESENCE BEACONS (the intent
+   * SOCs holders re-publish each refresh) into `holders`. Unlike the static
+   * lock SOC, these live at fresh per-epoch addresses, so reading them forces a
+   * network retrieval that works on a gateway that 404s the static address —
+   * this is what lets a joiner detect an existing holder. Call AFTER
+   * `refreshFromSwarm` (union, not replace): either channel showing a live
+   * foreign holder marks the partition held. No-op without known rivals.
+   */
+  async refreshHoldersFromPresence(partitionCount: number): Promise<void> {
+    const now = this.now()
+    const rivals = (this.opts.knownDeviceIds?.() ?? []).filter(
+      (id) => id !== this.opts.deviceId,
+    )
+    if (rivals.length === 0) return
+
+    const currentBucket = intentEpochBucket(now)
+    const buckets = [currentBucket, currentBucket - 1]
+
+    const results = await Promise.all(
+      Array.from({ length: partitionCount }).flatMap((_unused, p) =>
+        rivals.flatMap((deviceId) =>
+          buckets.map(async (bucket) => ({
+            partition: p,
+            deviceId,
+            bucket,
+            intent: await readPartitionIntent({
+              bee: this.opts.bee,
+              backupSigner: this.opts.backupSigner,
+              swarmEncryptionKey: this.opts.swarmEncryptionKey,
+              partition: p,
+              deviceId,
+              epochBucket: bucket,
+              timeoutMs: this.opts.intentReadTimeoutMs,
+            }),
+          })),
+        ),
+      ),
+    )
+
+    for (const { partition, deviceId, bucket, intent } of results) {
+      if (!intent) continue
+      // A holder beacon carries `leasedUntil`; a pre-claim intent (the
+      // symmetric-race announce) does NOT. Only a beacon means "this partition
+      // is HELD" — a bare intent is a contender, left for the intent round to
+      // resolve, so it must NOT mark the partition held here.
+      if (intent.leasedUntil === undefined || intent.leasedUntil <= now)
+        continue
+      const leasedUntil = intent.leasedUntil
+
+      const existing = this.holders.get(partition)
+      // Keep a self-claim (from the lock SOC) — we hold it; don't let a foreign
+      // beacon shadow it. Otherwise record/refresh the foreign holder.
+      if (existing && existing.deviceId === this.opts.deviceId) continue
+      if (!existing || leasedUntil > existing.leasedUntil) {
+        this.holders.set(partition, {
+          deviceId,
+          generation: intent.generation,
+          acquiredAt: existing?.acquiredAt ?? 0,
+          leasedUntil,
+        })
+        console.log(
+          `[PartitionLease] presence p=${partition}: live holder ${deviceId} (bucket ${bucket}, leasedUntil ${leasedUntil})`,
+        )
+      }
     }
   }
 
@@ -275,12 +381,22 @@ export class PartitionLease {
     }
 
     await this.refreshFromSwarm(partitionCount)
+    // Union in holders detected via presence beacons (fresh per-epoch reads
+    // that work on the gateway where the static lock SOC is unreadable). This
+    // is what lets us detect a peer that ALREADY holds a partition.
+    await this.refreshHoldersFromPresence(partitionCount)
 
     // Prefer the partition we already hold; otherwise the first free/expired.
     // A re-acquire of our own partition is not a contended claim — skip the
     // intent round (which only guards taking a free/expired slot).
     const held = this.heldPartition()
     const chosenPartition = held ?? this.pickFreeOrExpired(partitionCount)
+    // Why this partition was chosen — `home` is our deterministic scan start,
+    // `liveHolders` the count refreshFromSwarm saw. If we pick a partition a
+    // peer actually holds, that means we couldn't read its lock SOC above.
+    console.log(
+      `[PartitionLease] acquire: chosen=${chosenPartition} via=${held !== undefined ? "held(re-acquire)" : "pickFreeOrExpired"} home=${deviceHomePartition(this.opts.deviceId, partitionCount)} liveHolders=${this.holders.size} partitionCount=${partitionCount}`,
+    )
 
     if (chosenPartition === undefined) {
       // Every partition is live + foreign-held.
@@ -385,6 +501,8 @@ export class PartitionLease {
         knownDeviceIds,
         now: this.now(),
         timeoutMs: this.opts.intentReadTimeoutMs,
+        guardWindowMs: this.opts.intentGuardWindowMs ?? INTENT_GUARD_WINDOW_MS,
+        guardPollMs: this.opts.intentGuardPollMs ?? INTENT_GUARD_POLL_MS,
       })
       if (outcome === "lose") {
         console.warn(
@@ -457,6 +575,14 @@ export class PartitionLease {
       leasedUntil: payload.leasedUntil,
     })
 
+    // Publish presence immediately so a joiner appearing before our first
+    // refresh tick still detects us (don't wait ~10s for the first heartbeat).
+    await this.publishPresenceBeacon(
+      partition,
+      payload.generation,
+      payload.leasedUntil,
+    )
+
     return {
       partition,
       partitionCount,
@@ -507,7 +633,102 @@ export class PartitionLease {
       acquiredAt: payload.acquiredAt,
       leasedUntil: payload.leasedUntil,
     }
+    // Re-publish our presence beacon so a joining device can detect us on the
+    // gateway, where the static lock SOC isn't reliably retrievable. Best-effort
+    // (a failed beacon self-heals next tick).
+    await this.publishPresenceBeacon(
+      partition,
+      payload.generation,
+      payload.leasedUntil,
+    )
+
+    // Deconfliction backstop: if a concurrent claim slipped past the acquire-time
+    // poll-guard (propagation outran the window), two devices can briefly hold
+    // the same partition. Once both beacons have propagated, the one with the
+    // LATER generation yields here so the pair resolves to a single holder.
+    if (await this.foreignBeaconBeatsUs(partition, payload.generation)) {
+      console.warn(
+        `[PartitionLease] Refresh on partition ${partition}: an earlier-generation peer holds it; yielding.`,
+      )
+      return false
+    }
     return true
+  }
+
+  /**
+   * True if some OTHER device has a live presence beacon on `partition` whose
+   * generation orders strictly before `ourGeneration` (i.e. it claimed first).
+   * Reads the current+previous epoch bucket for each known rival (fresh
+   * addresses → gateway-retrievable). No rivals known → false.
+   */
+  private async foreignBeaconBeatsUs(
+    partition: number,
+    ourGeneration: PartitionLockGeneration,
+  ): Promise<boolean> {
+    const now = this.now()
+    const rivals = (this.opts.knownDeviceIds?.() ?? []).filter(
+      (id) => id !== this.opts.deviceId,
+    )
+    if (rivals.length === 0) return false
+    const currentBucket = intentEpochBucket(now)
+    const results = await Promise.all(
+      rivals.flatMap((deviceId) =>
+        [currentBucket, currentBucket - 1].map((bucket) =>
+          readPartitionIntent({
+            bee: this.opts.bee,
+            backupSigner: this.opts.backupSigner,
+            swarmEncryptionKey: this.opts.swarmEncryptionKey,
+            partition,
+            deviceId,
+            epochBucket: bucket,
+            timeoutMs: this.opts.intentReadTimeoutMs,
+          }),
+        ),
+      ),
+    )
+    return results.some(
+      (intent) =>
+        intent?.leasedUntil !== undefined &&
+        intent.leasedUntil > now &&
+        compareGenerations(intent.generation, ourGeneration) < 0,
+    )
+  }
+
+  /**
+   * Re-publish this device's holder presence beacon for `partition` at the
+   * CURRENT epoch (the intent SOC, with `leasedUntil` set). A joiner's
+   * `refreshHoldersFromPresence` reads this at a fresh per-epoch address (forced
+   * network retrieval), which works on a gateway that 404s the static lock SOC.
+   * Gated on a known rival (no one to inform otherwise) and best-effort — never
+   * fails the refresh; the ~10s refresh cadence < INTENT_EPOCH_MS (30s) keeps
+   * the current bucket continuously populated for a live holder.
+   */
+  private async publishPresenceBeacon(
+    partition: number,
+    generation: PartitionLockGeneration,
+    leasedUntil: number,
+  ): Promise<void> {
+    const knownDeviceIds = this.opts.knownDeviceIds?.() ?? []
+    if (!knownDeviceIds.some((id) => id !== this.opts.deviceId)) return
+    const { stamper } = this.requireWriteContext()
+    try {
+      await writePartitionIntent({
+        bee: this.opts.bee,
+        stamper,
+        backupSigner: this.opts.backupSigner,
+        swarmEncryptionKey: this.opts.swarmEncryptionKey,
+        partition,
+        deviceId: this.opts.deviceId,
+        epochBucket: intentEpochBucket(this.now()),
+        generation,
+        leasedUntil,
+      })
+    } catch (error) {
+      console.warn(
+        `[PartitionLease] presence beacon publish failed for p=${partition} (self-heals next tick):`,
+        error,
+      )
+    }
   }
 
   /**

--- a/lib/src/sync/partition-lease.ts
+++ b/lib/src/sync/partition-lease.ts
@@ -35,6 +35,7 @@ import {
 } from "../utils/batch-utilization"
 import {
   acquirePartitionLock,
+  deviceHomePartition,
   NO_HOLDER_DEVICE_ID,
   readPartitionLock,
   releasePartitionLock,
@@ -216,11 +217,18 @@ export class PartitionLease {
   }
 
   /**
-   * Lowest partition in `[0, partitionCount)` with no live holder that
-   * isn't us, else `undefined`. Drives candidate selection in `acquire`.
+   * First partition with no live holder that isn't us, else `undefined`,
+   * scanning from this device's deterministic home offset
+   * (`deviceHomePartition`) and wrapping. Starting from a per-device offset
+   * spreads devices across slots even when none can read peers' locks (the
+   * disjoint-gateway frozen-cache case); the wrap keeps full coverage so a
+   * genuinely free slot is never missed. Drives candidate selection in
+   * `acquire`.
    */
   private pickFreeOrExpired(partitionCount: number): number | undefined {
-    for (let p = 0; p < partitionCount; p++) {
+    const start = deviceHomePartition(this.opts.deviceId, partitionCount)
+    for (let i = 0; i < partitionCount; i++) {
+      const p = (start + i) % partitionCount
       const holder = this.holders.get(p)
       if (!holder || holder.deviceId === this.opts.deviceId) return p
     }

--- a/lib/src/sync/partition-lock.test.ts
+++ b/lib/src/sync/partition-lock.test.ts
@@ -15,6 +15,7 @@ import { Binary } from "cafe-utility"
 import {
   acquirePartitionLock,
   compareGenerations,
+  deviceHomePartition,
   lockSocAddress,
   lockSocBucket,
   makeDeviceTiebreaker,
@@ -168,6 +169,38 @@ describe("makeDeviceTiebreaker", () => {
 
   it("is 16-hex (8 bytes)", () => {
     expect(makeDeviceTiebreaker(DEVICE_A)).toMatch(/^[0-9a-f]{16}$/)
+  })
+})
+
+describe("deviceHomePartition", () => {
+  it("is stable for the same deviceId", () => {
+    expect(deviceHomePartition(DEVICE_A, 8)).toBe(
+      deviceHomePartition(DEVICE_A, 8),
+    )
+  })
+
+  it("is always within [0, partitionCount)", () => {
+    for (const device of [DEVICE_A, DEVICE_B, DEVICE_C]) {
+      for (const count of [2, 3, 8, 100]) {
+        const p = deviceHomePartition(device, count)
+        expect(p).toBeGreaterThanOrEqual(0)
+        expect(p).toBeLessThan(count)
+        expect(Number.isInteger(p)).toBe(true)
+      }
+    }
+  })
+
+  it("spreads devices across slots instead of all landing on 0", () => {
+    // The bug: every device picked partition 0 when none could see peers'
+    // locks. Per-device home offsets break that systematic collision — the
+    // home partitions span more than one slot (not a uniqueness guarantee;
+    // birthday collisions remain, which is why this is a mitigation, not a
+    // fix — see deviceHomePartition).
+    const PARTITION_COUNT = 3
+    const homes = [DEVICE_A, DEVICE_B, DEVICE_C].map((d) =>
+      deviceHomePartition(d, PARTITION_COUNT),
+    )
+    expect(new Set(homes).size).toBeGreaterThan(1)
   })
 })
 

--- a/lib/src/sync/partition-lock.ts
+++ b/lib/src/sync/partition-lock.ts
@@ -218,6 +218,12 @@ export async function acquirePartitionLock(opts: {
   now?: () => number
   wait?: (ms: number) => Promise<void>
   /**
+   * Pre-built generation to claim with. Pass the SAME generation already
+   * advertised in a Phase-2 intent round so the winner's lock claim and its
+   * intent order identically. Defaults to a fresh `(now, tiebreaker)`.
+   */
+  generation?: PartitionLockGeneration
+  /**
    * Checked immediately before the claim write. When it returns true the
    * acquire aborts WITHOUT writing — used by `PartitionLease` to stop a
    * refresh that overlaps a `release()` from minting a ghost claim the
@@ -250,7 +256,7 @@ export async function acquirePartitionLock(opts: {
 
   // Lock is empty, expired, released, or already ours. Write our claim
   // and verify after the guard window.
-  const ourGeneration: PartitionLockGeneration = {
+  const ourGeneration: PartitionLockGeneration = opts.generation ?? {
     timestampMs: t,
     tiebreaker: makeDeviceTiebreaker(opts.deviceId),
   }

--- a/lib/src/sync/partition-lock.ts
+++ b/lib/src/sync/partition-lock.ts
@@ -166,11 +166,21 @@ export async function readPartitionLock(opts: {
     )
     // A payload that doesn't match the schema (foreign/corrupt/old format)
     // is treated the same as a missing lock — see the catch below.
-    return parsed.success ? parsed.data : undefined
-  } catch {
+    if (!parsed.success) {
+      console.warn(
+        `[partition-lock] read p=${partition}: SOC present but payload failed schema validation — treating as no lock`,
+      )
+      return undefined
+    }
+    return parsed.data
+  } catch (error) {
     // Missing chunk, decryption failure, or malformed JSON — treat all
     // as "lock unobserved". Callers (acquirePartitionLock) treat undefined
-    // as "first acquire".
+    // as "first acquire". Log the reason: a gateway read failure (404/timeout)
+    // for a lock another device DID write is the suspected cross-device
+    // dual-acquire cause, and must be distinguishable from a genuine "no lock".
+    const reason = error instanceof Error ? error.message : String(error)
+    console.warn(`[partition-lock] read p=${partition}: unreadable — ${reason}`)
     return undefined
   }
 }
@@ -193,6 +203,10 @@ export async function writePartitionLock(opts: {
   const identifier = makePartitionLockIdentifier(partition)
   const data = new TextEncoder().encode(JSON.stringify(payload))
   const target: UploadTarget = { mode: "stamper", bee, stamper }
+  // No `deferred` flag: Bee's /soc handler hardcodes Deferred:false and ignores
+  // the Swarm-Deferred-Upload header (bee 2.8.0 pkg/api/soc.go), so SOC writes
+  // are always synchronous / receipt-backed regardless. (Replication still
+  // depends on node reachability — see .claude/rules/bee-cluster.md.)
   await uploadSOC(target, backupSigner, identifier, data, {
     encryptionKey: swarmEncryptionKey,
   })

--- a/lib/src/sync/partition-lock.ts
+++ b/lib/src/sync/partition-lock.ts
@@ -103,6 +103,28 @@ export function makeDeviceTiebreaker(deviceId: string): string {
 }
 
 /**
+ * Deterministic per-device starting partition: `keccak256(deviceId) mod
+ * partitionCount`. Distinct devices map to distinct home partitions with high
+ * probability, so they spread across slots even when none can read peers' lock
+ * SOCs (the disjoint-gateway frozen-cache case — see
+ * docs/Partition-Lock-Hardening-Plan.md). Only changes the selection scan
+ * ORDER; visibly-held slots are still skipped, so behaviour under working
+ * reads is unchanged.
+ *
+ * ponytail: probabilistic spread, not mutual exclusion — colliding home
+ * partitions still race. The complete cross-gateway fix is the Phase 2
+ * intent-SOC protocol in the hardening plan.
+ */
+export function deviceHomePartition(
+  deviceId: string,
+  partitionCount: number,
+): number {
+  const hash = Binary.keccak256(new TextEncoder().encode(deviceId))
+  const n = ((hash[0] << 24) | (hash[1] << 16) | (hash[2] << 8) | hash[3]) >>> 0
+  return n % partitionCount
+}
+
+/**
  * Lexicographic comparison of two generations: timestamp first, then
  * tiebreaker. Returns -1 / 0 / 1.
  */

--- a/lib/src/sync/sync-account.ts
+++ b/lib/src/sync/sync-account.ts
@@ -366,6 +366,13 @@ export function createSyncAccount(
       stamper,
       deviceId: getOrCreateDeviceId(),
       accountId,
+      // Read fresh so the presence/intent rounds see the current device
+      // registry — without this the background-sync acquire has no rivals to
+      // check and can collide with a live holder on another device.
+      knownDeviceIds: () =>
+        accountsStore
+          .getAccount(new EthAddress(accountId))
+          ?.devices.map((d) => d.deviceId) ?? [],
       backupSigner: accountKey,
       swarmEncryptionKey: hexToUint8Array(encryptionKey),
       partitionCount,

--- a/lib/src/utils/batch-utilization.test.ts
+++ b/lib/src/utils/batch-utilization.test.ts
@@ -716,6 +716,88 @@ describe("UtilizationAwareStamper partition awareness", () => {
     expect(env2.slot).toBe(dataSlot(1, 0, PARTITION_COUNT))
   })
 
+  it("intent SOC routes to the contended partition's reserved slot, never a data lane, without consuming data budget", async () => {
+    // Phase-2 intent SOCs (partition-intent.ts) are stamped BEFORE the partition
+    // is bound. They must overstamp the contended partition's reserved slot
+    // (< DATA_COUNTER_START), so they can never collide with user data.
+    const stamper = await UtilizationAwareStamper.create(
+      TEST_SIGNER_KEY,
+      TEST_BATCH_ID,
+      TEST_DEPTH,
+      makeEmptyCache(),
+      TEST_OWNER,
+      TEST_ENC_KEY,
+    )
+    // Bind to partition 0 to prove the intent slot comes from the EXPLICIT
+    // reservation (the contended partition, here 1), not `this.partition`.
+    stamper.bindPartition({
+      partition: 0,
+      partitionCount: PARTITION_COUNT,
+      localCounter: new Uint32Array(NUM_BUCKETS),
+    })
+
+    const BUCKET = 0x2222
+    const CONTENDED = 1
+    const intentChunk = makeChunkInBucket(BUCKET, 1)
+    stamper.reserveIntentSocSlot(intentChunk.hash(), CONTENDED)
+    const intentEnv = decodeIndex(stamper.stamp(intentChunk).index)
+    stamper.clearIntentSocSlot()
+
+    expect(intentEnv.bucket).toBe(BUCKET)
+    // Routed to the contended partition's reserved slot — below every data lane.
+    expect(intentEnv.slot).toBe(CONTENDED)
+    expect(intentEnv.slot).toBeLessThan(DATA_COUNTER_START)
+    // Did not consume the data lane: counter untouched, so the next data chunk
+    // in this bucket still lands at j=0.
+    expect(stamper.getLocalCounter()![BUCKET]).toBe(0)
+    const dataEnv = decodeIndex(
+      stamper.stamp(makeChunkInBucket(BUCKET, 2)).index,
+    )
+    expect(dataEnv.slot).toBe(dataSlot(0, 0, PARTITION_COUNT))
+    expect(dataEnv.slot).toBeGreaterThanOrEqual(DATA_COUNTER_START)
+  })
+
+  it("intent stamps never share a (bucket, slot) with data stamps", async () => {
+    // Regression guard for the class of bug where intents fell into a data
+    // lane (overstamping user data). Interleave data + intent stamps in one
+    // bucket and assert the two occupy disjoint slot ranges: data lives at
+    // >= DATA_COUNTER_START, intents at the contended partition's reserved
+    // slot (< DATA_COUNTER_START). (Intents overstamping each OTHER at the
+    // same reserved slot is the documented, accepted residual — not asserted.)
+    const stamper = await UtilizationAwareStamper.create(
+      TEST_SIGNER_KEY,
+      TEST_BATCH_ID,
+      TEST_DEPTH,
+      makeEmptyCache(),
+      TEST_OWNER,
+      TEST_ENC_KEY,
+    )
+    stamper.bindPartition({
+      partition: 0,
+      partitionCount: PARTITION_COUNT,
+      localCounter: new Uint32Array(NUM_BUCKETS),
+    })
+
+    const BUCKET = 0x3333
+    const dataSlots = new Set<number>()
+    for (let i = 0; i < 10; i++) {
+      const dataEnv = decodeIndex(
+        stamper.stamp(makeChunkInBucket(BUCKET, 100 + i)).index,
+      )
+      expect(dataEnv.slot).toBeGreaterThanOrEqual(DATA_COUNTER_START)
+      expect(dataSlots.has(dataEnv.slot)).toBe(false) // data slots never reused
+      dataSlots.add(dataEnv.slot)
+
+      const intentChunk = makeChunkInBucket(BUCKET, 200 + i)
+      stamper.reserveIntentSocSlot(intentChunk.hash(), 0)
+      const intentEnv = decodeIndex(stamper.stamp(intentChunk).index)
+      stamper.clearIntentSocSlot()
+      // Intent slot is below the data range, so it can never equal a data slot.
+      expect(intentEnv.slot).toBeLessThan(DATA_COUNTER_START)
+      expect(dataSlots.has(intentEnv.slot)).toBe(false)
+    }
+  })
+
   it("auto-bind uses the BACKUP-signer address (derived from encryptionKey), not the `owner` arg", async () => {
     // Regression: `writePartitionLock` writes the lock SOC to
     // `keccak256(identifier || backupSigner.publicKey().address())`, where

--- a/lib/src/utils/batch-utilization.ts
+++ b/lib/src/utils/batch-utilization.ts
@@ -1213,6 +1213,19 @@ export class UtilizationAwareStamper implements Stamper {
   private reservedUtilizationChunks: Map<string, number> | undefined = undefined
 
   /**
+   * The per-partition intent SOC for an in-flight intent round (Phase 2 —
+   * `partition-intent.ts`), mapped to the reserved SLOT it must overstamp (the
+   * contended partition index). Routed like the lock SOC / utilisation chunks:
+   * `stamp()` places it in the partition's reserved slot, so it NEVER lands in
+   * a data lane (`>= DATA_COUNTER_START`) and cannot overstamp user data.
+   * Single-entry and self-clearing (set immediately before the upload, cleared
+   * in a `finally`), so it stays isolated from the `reservedUtilizationChunks`
+   * save lifecycle and never grows. See `reserveIntentSocSlot`.
+   */
+  private intentSoc: { addressHex: string; slot: number } | undefined =
+    undefined
+
+  /**
    * Circuit breaker for in-flight uploads. Flipped to `true` when the proxy
    * detects displacement on a refresh tick (or upload-start lease check);
    * subsequent partition-bound `stamp()` calls throw `PartitionLeaseLostError`
@@ -1395,6 +1408,23 @@ export class UtilizationAwareStamper implements Stamper {
   }
 
   /**
+   * Register the per-partition intent SOC so `stamp()` routes it to `slot`
+   * (the contended partition's reserved index) instead of a data slot — never
+   * consuming data budget or bumping the counter. `slot` is passed explicitly
+   * because the intent round runs BEFORE `bindPartition`, so `this.partition`
+   * is not yet set. Call immediately before the upload; pair with
+   * `clearIntentSocSlot` in a `finally`.
+   */
+  reserveIntentSocSlot(address: Uint8Array, slot: number): void {
+    this.intentSoc = { addressHex: uint8ArrayToHex(address), slot }
+  }
+
+  /** Clear the registered intent SOC after its upload. */
+  clearIntentSocSlot(): void {
+    this.intentSoc = undefined
+  }
+
+  /**
    * Inverse of `bindPartition` — clears partition slot state on demote.
    * Leaves `lockSocs` intact (still valid for the account; refresh/yield
    * writes may need them) and clears the lease-stale flag.
@@ -1564,6 +1594,20 @@ export class UtilizationAwareStamper implements Stamper {
     if (reservedSlot !== undefined) {
       const bucket = toBucket(chunkAddress)
       this.stamper.buckets[bucket] = reservedSlot
+      return this.stamper.stamp(chunk)
+    }
+
+    // Intent-SOC short-circuit: a partition-intent chunk (Phase 2) overstamps
+    // the contended partition's reserved slot — like the lock SOC, below the
+    // data lanes — so it can never collide with user data. Doesn't bump the
+    // counter. Not gated by `leaseStale`: the intent round runs before binding,
+    // while no lease is held.
+    if (
+      this.intentSoc !== undefined &&
+      this.intentSoc.addressHex === uint8ArrayToHex(chunkAddress)
+    ) {
+      const bucket = toBucket(chunkAddress)
+      this.stamper.buckets[bucket] = this.intentSoc.slot
       return this.stamper.stamp(chunk)
     }
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "clean": "pnpm -r clean && rm -rf swarm-id-build demo/build",
     "install:all": "pnpm install",
     "check:all": "pnpm --filter @snaha/swarm-id check:all && pnpm --filter swarm-identity check:all && pnpm --filter @swarm-id/ui check:all && pnpm --filter @swarm-id/demo check:all",
-    "format:all": "pnpm --filter @snaha/swarm-id format && pnpm --filter swarm-identity format && pnpm --filter @swarm-id/ui format && pnpm --filter @swarm-id/demo format && pnpm --filter @swarm-id/docs format",
+    "format:all": "pnpm --filter @snaha/swarm-id format && pnpm --filter swarm-identity format && pnpm --filter @swarm-id/ui format && pnpm --filter @swarm-id/demo format && pnpm --filter @swarm-id/docs format && prettier --write .",
     "format:lib": "pnpm --filter @snaha/swarm-id format"
   },
   "devDependencies": {

--- a/swarm-ui/src/routes/(app)/dev/+page.svelte
+++ b/swarm-ui/src/routes/(app)/dev/+page.svelte
@@ -14,6 +14,7 @@
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { identitiesStore } from '$lib/stores/identities.svelte'
   import { postageStampsStore } from '$lib/stores/postage-stamps.svelte'
+  import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
   import { connectedAppsStore } from '$lib/stores/connected-apps.svelte'
   import { syncStore } from '$lib/stores/sync.svelte'
   import { devSettingsStore, type MockStampResult } from '$lib/stores/dev-settings.svelte'
@@ -23,12 +24,16 @@
   import DeviceList from './device-list.svelte'
   import Divider from '$lib/components/ui/divider.svelte'
   import routes from '$lib/routes'
-  import { BatchId, EthAddress, PrivateKey, Utils } from '@ethersphere/bee-js'
+  import { BatchId, Bee, EthAddress, Identifier, PrivateKey, Utils } from '@ethersphere/bee-js'
   import {
     calculateStampAmountForDays,
     derivePostageSignerKey,
+    downloadEncryptedSOC,
     fetchChainState,
     formatTTL,
+    rejectAfter,
+    uint8ArrayToHex,
+    uploadSOC,
   } from '@snaha/swarm-id'
   import { MS_PER_SECOND } from '$lib/constants'
   import { SvelteMap } from 'svelte/reactivity'
@@ -133,6 +138,216 @@
   let beeStampsError = $state('')
   let lastBeeUrl = $state('')
 
+  // Retrievability self-check: does the configured Bee node serve back a SOC we
+  // just wrote? (If not, no cross-device coordination — lock/intent/presence
+  // SOCs — can work there, and normal sync/download is unreliable too.)
+  let selfCheckStampId = $state<string | undefined>(undefined)
+  let selfCheckRunning = $state(false)
+  let selfCheckLog = $state<string[]>([])
+  // The address of the just-written test SOC — copy it to another device's
+  // "Read by address" to test cross-device retrievability.
+  let selfCheckSocAddress = $state('')
+
+  // Cross-device check: read a chunk BY ADDRESS that another device wrote
+  // (paste the SOC address printed by that device's self-check). On a
+  // load-balanced gateway the writer can read its own write back from its own
+  // backend, but a different device may hit a backend that can't retrieve it —
+  // this is the read that actually mirrors cross-device coordination.
+  let readAddr = $state('')
+  let readChecking = $state(false)
+  let readLog = $state<string[]>([])
+
+  // Partition-coordination timing overrides (gateway propagation tuning). Read
+  // by the proxy from this localStorage key on connect; blank fields fall back
+  // to the lib defaults. Must match PARTITION_TUNING_KEY in swarm-id-proxy.ts.
+  const PARTITION_TUNING_KEY = 'swarm-id-partition-tuning'
+  function loadTuning(): {
+    guardWindowMs?: number
+    guardPollMs?: number
+    readTimeoutMs?: number
+  } {
+    if (typeof localStorage === 'undefined') return {}
+    try {
+      return JSON.parse(localStorage.getItem(PARTITION_TUNING_KEY) ?? '{}') ?? {}
+    } catch {
+      return {}
+    }
+  }
+  const initialTuning = loadTuning()
+  let tuningWindow = $state(initialTuning.guardWindowMs?.toString() ?? '')
+  let tuningPoll = $state(initialTuning.guardPollMs?.toString() ?? '')
+  let tuningTimeout = $state(initialTuning.readTimeoutMs?.toString() ?? '')
+  let tuningSaved = $state('')
+
+  function saveTuning() {
+    const obj: Record<string, number> = {}
+    const add = (key: string, raw: string) => {
+      const n = Number(raw)
+      if (raw.trim() !== '' && Number.isFinite(n) && n >= 0) obj[key] = n
+    }
+    add('guardWindowMs', tuningWindow)
+    add('guardPollMs', tuningPoll)
+    add('readTimeoutMs', tuningTimeout)
+    localStorage.setItem(PARTITION_TUNING_KEY, JSON.stringify(obj))
+    tuningSaved = `Saved ${JSON.stringify(obj)} — reload the app/proxy to apply.`
+  }
+  function resetTuning() {
+    localStorage.removeItem(PARTITION_TUNING_KEY)
+    tuningWindow = ''
+    tuningPoll = ''
+    tuningTimeout = ''
+    tuningSaved = 'Cleared — reload to use defaults (window 12000 / poll 2500 / read 2500 ms).'
+  }
+
+  // Per-read timeout and the elapsed-since-upload checkpoints to poll at.
+  const SELF_CHECK_READ_TIMEOUT_MS = 3000
+  const SELF_CHECK_POLL_MS = [0, 2000, 5000, 10000, 20000]
+  const RANDOM_BYTES = 32
+
+  function randomBytes(): Uint8Array {
+    return crypto.getRandomValues(new Uint8Array(RANDOM_BYTES))
+  }
+
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+  async function runRetrievabilityCheck() {
+    selfCheckRunning = true
+    const log: string[] = []
+    selfCheckLog = log
+    const push = (line: string) => {
+      log.push(line)
+      selfCheckLog = [...log]
+    }
+    try {
+      const stamp = postageStampsStore.stamps.find((s) => s.batchID.toHex() === selfCheckStampId)
+      if (!stamp) {
+        push('❌ Select a stored stamp to pay for the test chunk.')
+        return
+      }
+      // Test the node the proxy/app actually uses (network settings), not the
+      // dev-page stamp-buying URL which defaults to localhost.
+      const nodeUrl = networkSettingsStore.beeNodeUrl
+      const bee = new Bee(nodeUrl)
+      // Throwaway, fresh-per-run SOC: random owner key + identifier + encryption
+      // key + payload. Postage is paid by the stamp's signerKey; the SOC is
+      // owned by the throwaway signer — the same split a real presence beacon
+      // uses. A fresh address guarantees the read isn't served from a stale
+      // local cache.
+      const signer = new PrivateKey(randomBytes())
+      const encryptionKey = randomBytes()
+      const identifier = new Identifier(randomBytes())
+      const owner = signer.publicKey().address()
+
+      const stamper = await postageStampsStore.getStamper(stamp.batchID, {
+        owner,
+        encryptionKey,
+      })
+      if (!stamper) {
+        push('❌ Could not build a stamper for that batch.')
+        return
+      }
+
+      push(`Node: ${nodeUrl}`)
+      push(`Batch: ${stamp.batchID.toHex().slice(0, 12)}… (depth ${stamp.depth})`)
+      const t0 = Date.now()
+      const { socAddress } = await uploadSOC(
+        { mode: 'stamper', bee, stamper },
+        signer,
+        identifier,
+        randomBytes(),
+        { encryptionKey },
+      )
+      const addrHex = uint8ArrayToHex(socAddress)
+      selfCheckSocAddress = addrHex
+      push(`✅ Upload OK in ${Date.now() - t0}ms — SOC address ${addrHex}`)
+
+      let retrievedMs: number | undefined
+      let prev = 0
+      for (const checkpoint of SELF_CHECK_POLL_MS) {
+        await sleep(Math.max(0, checkpoint - prev))
+        prev = checkpoint
+        try {
+          await Promise.race([
+            downloadEncryptedSOC(bee, owner, identifier, encryptionKey),
+            rejectAfter(SELF_CHECK_READ_TIMEOUT_MS, 'read timed out'),
+          ])
+          retrievedMs = Date.now() - t0
+          break
+        } catch (error) {
+          push(
+            `  read @ ${checkpoint}ms: not yet (${error instanceof Error ? error.message : String(error)})`,
+          )
+        }
+      }
+
+      if (retrievedMs !== undefined) {
+        push(
+          `✅ Retrievable after ${retrievedMs}ms → this node serves back writes; multi-device coordination can work here.`,
+        )
+      } else {
+        push(
+          `❌ NOT retrievable within ~${SELF_CHECK_POLL_MS[SELF_CHECK_POLL_MS.length - 1] / 1000}s → this node does not serve back recently-written chunks. Cross-device coordination (lock/intent/presence SOCs) cannot work here, and normal sync/download will be unreliable too.`,
+        )
+      }
+    } catch (error) {
+      push(`❌ Error: ${error instanceof Error ? error.message : String(error)}`)
+    } finally {
+      selfCheckRunning = false
+    }
+  }
+
+  async function runReadByAddress() {
+    readChecking = true
+    const log: string[] = []
+    readLog = log
+    const push = (line: string) => {
+      log.push(line)
+      readLog = [...log]
+    }
+    try {
+      const addr = readAddr.trim().replace(/^0x/, '')
+      if (!/^[0-9a-fA-F]{64}$/.test(addr)) {
+        push('❌ Enter a 64-char hex chunk address (the SOC address from another device).')
+        return
+      }
+      const nodeUrl = networkSettingsStore.beeNodeUrl
+      const bee = new Bee(nodeUrl)
+      push(`Node: ${nodeUrl}`)
+      const t0 = Date.now()
+      let foundMs: number | undefined
+      let prev = 0
+      for (const checkpoint of SELF_CHECK_POLL_MS) {
+        await sleep(Math.max(0, checkpoint - prev))
+        prev = checkpoint
+        try {
+          await Promise.race([
+            bee.downloadChunk(addr),
+            rejectAfter(SELF_CHECK_READ_TIMEOUT_MS, 'read timed out'),
+          ])
+          foundMs = Date.now() - t0
+          break
+        } catch (error) {
+          push(
+            `  read @ ${checkpoint}ms: not yet (${error instanceof Error ? error.message : String(error)})`,
+          )
+        }
+      }
+      if (foundMs !== undefined) {
+        push(
+          `✅ Retrievable after ${foundMs}ms → this device CAN read the chunk the other device wrote; cross-device coordination can work.`,
+        )
+      } else {
+        push(
+          `❌ NOT retrievable within ~${SELF_CHECK_POLL_MS[SELF_CHECK_POLL_MS.length - 1] / 1000}s → this device cannot read the other device's chunk. The gateway isn't serving writes across nodes/sessions, so cross-device coordination cannot work here.`,
+        )
+      }
+    } catch (error) {
+      push(`❌ Error: ${error instanceof Error ? error.message : String(error)}`)
+    } finally {
+      readChecking = false
+    }
+  }
+
   // Known dev signers (pre-funded with ETH + BZZ in the local Bee cluster)
   const KNOWN_SIGNERS = [
     {
@@ -190,6 +405,18 @@
       label: `${stamp.batchID.slice(0, 10)}… (depth ${stamp.depth})`,
     })),
   )
+  // Stored stamps (with signerKey) usable to pay for the retrievability check.
+  const storedStampOptions = $derived(
+    postageStampsStore.stamps.map((stamp) => ({
+      value: stamp.batchID.toHex(),
+      label: `${stamp.batchID.toHex().slice(0, 10)}… (depth ${stamp.depth})`,
+    })),
+  )
+  $effect(() => {
+    if (storedStampOptions.length && !selfCheckStampId) {
+      selfCheckStampId = storedStampOptions[0].value
+    }
+  })
   const accountOptions = $derived(
     accountsStore.accounts.map((account) => ({
       value: account.id.toHex(),
@@ -373,11 +600,27 @@ Check console logs for details:
     }
   }
 
-  function clearAllData() {
+  // Clear just this browser's account stores (identities, apps, stamps).
+  function clearAccount() {
     accountsStore.clear()
     identitiesStore.clear()
     connectedAppsStore.clear()
     postageStampsStore.clear()
+  }
+
+  // Full reset: every swarm* localStorage key + the IndexedDB utilization DB,
+  // then reload so all in-memory stores re-init from empty storage. onblocked
+  // resolves too — an open DB connection is closed by the reload, letting the
+  // pending delete finish.
+  async function clearAll() {
+    for (const key of Object.keys(localStorage)) {
+      if (key.startsWith('swarm')) localStorage.removeItem(key)
+    }
+    await new Promise<void>((resolve) => {
+      const req = indexedDB.deleteDatabase('swarm-utilization-store')
+      req.onsuccess = req.onerror = req.onblocked = () => resolve()
+    })
+    location.reload()
   }
 
   async function loadBeeStamps() {
@@ -684,7 +927,10 @@ Check console logs for details:
           {accountCount} accounts, {identityCount} identities, {connectionCount} connections, {stampCount}
           stamps
         </Typography>
-        <Button variant="secondary" danger onclick={clearAllData}>Clear All Data</Button>
+        <Horizontal --horizontal-gap="var(--half-padding)">
+          <Button variant="secondary" danger onclick={clearAccount}>Clear account</Button>
+          <Button variant="secondary" danger onclick={clearAll}>Clear all</Button>
+        </Horizontal>
       </Vertical>
     </Vertical>
   {/if}
@@ -826,6 +1072,199 @@ Check console logs for details:
           <Typography font="mono" style="color: var(--colors-error);">❌ {stampError}</Typography>
         </Vertical>
       {/if}
+
+      <Divider --margin="var(--padding) 0" />
+
+      <Typography variant="h3">Stored Stamps (local)</Typography>
+      <Typography variant="small" style="color: var(--colors-medium);">
+        The postage batches saved in this browser. Copy these fields before clearing storage — paste
+        them into the "Use existing one" screen to re-adopt the same batch on a fresh identity (the
+        owner is derived from the signer key).
+      </Typography>
+      {#if postageStampsStore.stamps.length === 0}
+        <Typography variant="small" style="color: var(--colors-medium);">
+          No stamps stored locally.
+        </Typography>
+      {:else}
+        <Vertical --vertical-gap="var(--half-padding)">
+          {#each postageStampsStore.stamps as stamp (stamp.batchID.toHex())}
+            {@const assignment = stampAssignments.get(stamp.batchID.toHex())}
+            <Vertical
+              --vertical-gap="var(--half-padding)"
+              style="background: var(--colors-card-bg); padding: var(--padding); border: 1px solid var(--colors-low);"
+            >
+              <Vertical --vertical-gap="var(--half-padding)">
+                <Typography variant="small" style="color: var(--colors-medium);"
+                  >Batch ID</Typography
+                >
+                <Horizontal
+                  --horizontal-gap="var(--half-padding)"
+                  --horizontal-align-items="center"
+                >
+                  <Typography font="mono" variant="small" style="word-break: break-all;"
+                    >{stamp.batchID.toHex()}</Typography
+                  >
+                  <CopyButton text={stamp.batchID.toHex()} />
+                </Horizontal>
+              </Vertical>
+
+              <Vertical --vertical-gap="var(--half-padding)">
+                <Typography variant="small" style="color: var(--colors-medium);"
+                  >Signer Key</Typography
+                >
+                <Horizontal
+                  --horizontal-gap="var(--half-padding)"
+                  --horizontal-align-items="center"
+                >
+                  <Typography font="mono" variant="small" style="word-break: break-all;"
+                    >{stamp.signerKey.toHex()}</Typography
+                  >
+                  <CopyButton text={stamp.signerKey.toHex()} />
+                </Horizontal>
+              </Vertical>
+
+              <Horizontal --horizontal-gap="var(--double-padding)">
+                <Vertical --vertical-gap="var(--half-padding)">
+                  <Typography variant="small" style="color: var(--colors-medium);"
+                    >Amount</Typography
+                  >
+                  <Horizontal
+                    --horizontal-gap="var(--half-padding)"
+                    --horizontal-align-items="center"
+                  >
+                    <Typography font="mono" variant="small">{stamp.amount.toString()}</Typography>
+                    <CopyButton text={stamp.amount.toString()} />
+                  </Horizontal>
+                </Vertical>
+                <Vertical --vertical-gap="var(--half-padding)">
+                  <Typography variant="small" style="color: var(--colors-medium);">Depth</Typography
+                  >
+                  <Horizontal
+                    --horizontal-gap="var(--half-padding)"
+                    --horizontal-align-items="center"
+                  >
+                    <Typography font="mono" variant="small">{stamp.depth}</Typography>
+                    <CopyButton text={String(stamp.depth)} />
+                  </Horizontal>
+                </Vertical>
+                <Vertical --vertical-gap="var(--half-padding)">
+                  <Typography variant="small" style="color: var(--colors-medium);"
+                    >Block number</Typography
+                  >
+                  <Horizontal
+                    --horizontal-gap="var(--half-padding)"
+                    --horizontal-align-items="center"
+                  >
+                    <Typography font="mono" variant="small">{stamp.blockNumber}</Typography>
+                    <CopyButton text={String(stamp.blockNumber)} />
+                  </Horizontal>
+                </Vertical>
+              </Horizontal>
+
+              <Typography variant="small" style="color: var(--colors-medium);">
+                Account: {assignment?.account ?? '—'} · Identity: {assignment?.identity ?? '—'}
+              </Typography>
+            </Vertical>
+          {/each}
+        </Vertical>
+      {/if}
+
+      <Divider --margin="var(--padding) 0" />
+
+      <Typography variant="h3">Retrievability self-check</Typography>
+      <Typography variant="small" style="color: var(--colors-medium);">
+        Writes a throwaway single-owner chunk to the Bee node from network settings ({networkSettingsStore.beeNodeUrl})
+        and reads it back, to confirm the node actually serves back what you write. Multi-device
+        coordination (and reliable sync/download) only works when this succeeds.
+      </Typography>
+      <Vertical --vertical-gap="var(--half-padding)">
+        <Select
+          label="Pay with stored stamp"
+          items={storedStampOptions}
+          bind:value={selfCheckStampId}
+        />
+        <Button
+          onclick={runRetrievabilityCheck}
+          busy={selfCheckRunning}
+          disabled={selfCheckRunning || !selfCheckStampId}
+        >
+          {selfCheckRunning ? 'Checking…' : 'Run self-check'}
+        </Button>
+      </Vertical>
+      {#if selfCheckLog.length}
+        <Vertical
+          --vertical-gap="var(--half-padding)"
+          style="background: var(--colors-card-bg); padding: var(--padding); border: 1px solid var(--colors-low);"
+        >
+          {#each selfCheckLog as line, i (i)}
+            <Typography font="mono" variant="small" style="word-break: break-all;"
+              >{line}</Typography
+            >
+          {/each}
+          {#if selfCheckSocAddress}
+            <Horizontal --horizontal-gap="var(--half-padding)" --horizontal-align-items="center">
+              <Typography variant="small" style="color: var(--colors-medium);">
+                SOC address (copy to another device):
+              </Typography>
+              <CopyButton text={selfCheckSocAddress} />
+            </Horizontal>
+          {/if}
+        </Vertical>
+      {/if}
+
+      <Typography
+        variant="small"
+        style="color: var(--colors-medium); margin-top: var(--half-padding);"
+      >
+        Cross-device check: run the self-check on another device, copy its SOC address, paste it
+        here, and read it back. The writer reading its own chunk can succeed on a load-balanced
+        gateway even when a different device cannot — this is the read that mirrors coordination.
+      </Typography>
+      <Vertical --vertical-gap="var(--half-padding)">
+        <Input label="Chunk address from another device" bind:value={readAddr} />
+        <Button
+          variant="secondary"
+          onclick={runReadByAddress}
+          busy={readChecking}
+          disabled={readChecking || !readAddr}
+        >
+          {readChecking ? 'Reading…' : 'Read by address'}
+        </Button>
+      </Vertical>
+      {#if readLog.length}
+        <Vertical
+          --vertical-gap="var(--half-padding)"
+          style="background: var(--colors-card-bg); padding: var(--padding); border: 1px solid var(--colors-low);"
+        >
+          {#each readLog as line, i (i)}
+            <Typography font="mono" variant="small" style="word-break: break-all;"
+              >{line}</Typography
+            >
+          {/each}
+        </Vertical>
+      {/if}
+
+      <Divider --margin="var(--padding) 0" />
+
+      <Typography variant="h3">Partition tuning</Typography>
+      <Typography variant="small" style="color: var(--colors-medium);">
+        Tune the multi-device intent-round timing for this gateway's propagation delay. Blank =
+        library default (window 12000 / poll 2500 / read 2500 ms). Reload the app after saving so
+        the proxy picks it up.
+      </Typography>
+      <Vertical --vertical-gap="var(--half-padding)">
+        <Input label="Guard window (ms)" bind:value={tuningWindow} />
+        <Input label="Poll interval (ms)" bind:value={tuningPoll} />
+        <Input label="Read timeout (ms)" bind:value={tuningTimeout} />
+        <Horizontal --horizontal-gap="var(--half-padding)" --horizontal-align-items="center">
+          <Button onclick={saveTuning}>Save tuning</Button>
+          <Button variant="secondary" onclick={resetTuning}>Reset to defaults</Button>
+        </Horizontal>
+        {#if tuningSaved}
+          <Typography variant="small" style="color: var(--colors-medium);">{tuningSaved}</Typography
+          >
+        {/if}
+      </Vertical>
 
       <Divider --margin="var(--padding) 0" />
 


### PR DESCRIPTION
## Problem

The per-partition lock SOC lives at a single static address. Across disjoint
gateways a node serves that address from a frozen cache (no TTL, no
invalidation), so two devices contending for a *free* partition never see each
other's lock and both bind it — two devices end up holding the same partition
(reproduced with 3 browsers on the public gateway). Tuning guard/TTL timeouts
can't help: the failure is non-visibility, not latency.

## Solution

Phase 2 of the partition-lock hardening (builds on #356's release-fencing,
already in main):

- **Intent SOCs** (`lib/src/sync/partition-intent.ts`): per-`(partition,
  deviceId, epoch)` address. Each contender writes only its own and reads every
  known peer's. The address rotates per epoch, so a read forces a real network
  retrieval that bypasses the frozen lock-SOC cache — contenders see each other,
  order by `generation`, and only the unique global-minimum binds the lock.
- **Deterministic home partition** (`keccak256(deviceId) mod K`): spreads
  devices across partitions so they rarely contend, and acts as the safety net
  when peers' locks are unreadable.
- **Reserved-slot routing**: an intent stamps into the contended partition's
  reserved slot (`< DATA_COUNTER_START`), so it can never overstamp user data.
- **Push-sync + diagnostics**: intent SOCs are receipt-backed; added
  `knownDevices` / `intentRound` claim diagnostics.

Plus dev tooling: split the dev-page reset into **Clear account** (account
stores only) and **Clear all** (every `swarm*` localStorage key + the
`swarm-utilization-store` IndexedDB DB, then reload).

## Residuals (documented in docs/Partition-Lock-Hardening-Plan.md)

- Absence is unprovable on Swarm: a timed-out intent read is treated as "no
  intent" to preserve liveness, so the guarantee is "when the network works,
  rivals are seen"; genuine network partition falls back to guard + TTL + refresh.
- The intent round is gated on the local (eventually-consistent) device
  registry, so a device not yet synced into a peer's registry can still be
  missed on a fresh claim (`freshClaim + no rival seen`). Flagged for follow-up.

## Test plan

- `pnpm --filter @snaha/swarm-id check:all` green — **753** unit + integration
  tests, incl. new `partition-intent.test.ts` and the expanded
  `partition-lease.integration.test.ts` (intent round, presence beacons,
  epoch-boundary, deconfliction backstop).
- Manual 3-device test (Firefox/Chrome/Brave, public gateway): no collisions
  once all three run current code.

## Notes

- Each package's `check:all` passes individually; the monolithic `pnpm
  check:all` wrapper flakes locally (vitest drops test files under full-suite
  load) — environmental, not a code issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
