### PR TITLE
fix(stamps): batch existence display + manual form validation

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -523,6 +523,8 @@ export {
   fetchOnChainBatchState,
   fetchBatchTTLFromContract,
   fetchAuthoritativeBatchTTL,
+  resolveBatchStatus,
+  resolvePostageStampContractAddress,
   calculateContractTTLSeconds,
   decodeBatches,
   decodeUint,
@@ -531,6 +533,8 @@ export {
 export type {
   OnChainPostageBatch,
   OnChainBatchState,
+  OnChainBatchResult,
+  BatchResolution,
 } from "./utils/postage-contract"
 
 // Postage stamp <-> account/identity association

--- a/lib/src/utils/postage-contract.test.ts
+++ b/lib/src/utils/postage-contract.test.ts
@@ -9,7 +9,10 @@ import {
   fetchAuthoritativeBatchTTL,
   fetchBatchTTLFromContract,
   fetchOnChainBatchState,
+  fetchOnChainBatchStateResult,
+  resolveBatchStatus,
   POSTAGE_STAMP_CONTRACT_ADDRESS,
+  resolvePostageStampContractAddress,
   type OnChainBatchState,
 } from "./postage-contract"
 
@@ -372,5 +375,154 @@ describe("fetchAuthoritativeBatchTTL", () => {
     const ttl = await fetchAuthoritativeBatchTTL(RPC, BEE, BATCH_ID)
 
     expect(ttl).toBeUndefined()
+  })
+})
+
+describe("resolvePostageStampContractAddress", () => {
+  const LOCAL = "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512"
+
+  it("honours the local override only for a local RPC", () => {
+    expect(
+      resolvePostageStampContractAddress("http://localhost:9545", LOCAL),
+    ).toBe(LOCAL)
+    expect(
+      resolvePostageStampContractAddress("http://127.0.0.1:9545", LOCAL),
+    ).toBe(LOCAL)
+  })
+
+  it("ignores the local override for a remote RPC (mainnet)", () => {
+    expect(
+      resolvePostageStampContractAddress(
+        "https://xdai.fairdatasociety.org/",
+        LOCAL,
+      ),
+    ).toBe(POSTAGE_STAMP_CONTRACT_ADDRESS)
+  })
+
+  it("falls back to mainnet when no override is given", () => {
+    expect(resolvePostageStampContractAddress("http://localhost:9545")).toBe(
+      POSTAGE_STAMP_CONTRACT_ADDRESS,
+    )
+  })
+})
+
+const ZERO_TUPLE = "0x" + "0".repeat(64 * 6)
+
+describe("fetchOnChainBatchStateResult", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch")
+  })
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it("reports found with the decoded state", async () => {
+    fetchSpy.mockResolvedValue(batchResponse(FULL_RESPONSE))
+    const result = await fetchOnChainBatchStateResult(
+      "https://rpc.example",
+      BATCH_ID,
+    )
+    expect(result.status).toBe("found")
+    if (result.status === "found") {
+      expect(result.state.lastPrice).toBe(LAST_PRICE)
+    }
+  })
+
+  it("reports not-found for a zero-owner tuple", async () => {
+    fetchSpy.mockResolvedValue(
+      batchResponse({
+        0: { result: ZERO_TUPLE },
+        1: { result: OUT_PAYMENT_RESULT },
+        2: { result: LAST_PRICE_RESULT },
+      }),
+    )
+    const result = await fetchOnChainBatchStateResult(
+      "https://rpc.example",
+      BATCH_ID,
+    )
+    expect(result.status).toBe("not-found")
+  })
+
+  it("reports error when the RPC fails", async () => {
+    fetchSpy.mockRejectedValue(new Error("rpc down"))
+    const result = await fetchOnChainBatchStateResult(
+      "https://rpc.example",
+      BATCH_ID,
+    )
+    expect(result.status).toBe("error")
+  })
+})
+
+describe("resolveBatchStatus", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>
+
+  const RPC = "https://rpc.example"
+  const BEE = "https://bee.example"
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch")
+  })
+  afterEach(() => {
+    fetchSpy.mockRestore()
+  })
+
+  it("found via contract, with the contract TTL", async () => {
+    fetchSpy.mockImplementation((url) =>
+      Promise.resolve(
+        url === RPC ? batchResponse(FULL_RESPONSE) : ({} as Response),
+      ),
+    )
+    const result = await resolveBatchStatus(RPC, BEE, BATCH_ID)
+    expect(result).toEqual({
+      status: "found",
+      ttlSeconds: EXPECTED_TTL_SECONDS,
+    })
+  })
+
+  it("not-found is authoritative and does not consult the Bee node", async () => {
+    fetchSpy.mockImplementation((url) => {
+      if (url === RPC) {
+        return Promise.resolve(
+          batchResponse({
+            0: { result: ZERO_TUPLE },
+            1: { result: OUT_PAYMENT_RESULT },
+            2: { result: LAST_PRICE_RESULT },
+          }),
+        )
+      }
+      throw new Error("Bee must not be consulted on contract not-found")
+    })
+    const result = await resolveBatchStatus(RPC, BEE, BATCH_ID)
+    expect(result).toEqual({ status: "not-found" })
+  })
+
+  it("falls back to the Bee node when the contract read errors", async () => {
+    fetchSpy.mockImplementation((url) =>
+      url === RPC
+        ? Promise.reject(new Error("rpc down"))
+        : Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ batchTTL: 4242 }),
+          } as Response),
+    )
+    const result = await resolveBatchStatus(RPC, BEE, BATCH_ID)
+    expect(result).toEqual({ status: "found", ttlSeconds: 4242 })
+  })
+
+  it("is unreachable when both the contract and the Bee node fail", async () => {
+    fetchSpy.mockImplementation((url) =>
+      url === RPC
+        ? Promise.reject(new Error("rpc down"))
+        : Promise.resolve({
+            ok: false,
+            status: 404,
+            json: () => Promise.resolve({}),
+          } as Response),
+    )
+    const result = await resolveBatchStatus(RPC, BEE, BATCH_ID)
+    expect(result).toEqual({ status: "unreachable" })
   })
 })

--- a/lib/src/utils/postage-contract.ts
+++ b/lib/src/utils/postage-contract.ts
@@ -30,6 +30,41 @@ export const POSTAGE_STAMP_CONTRACT_ADDRESS =
   "0x45a1502382541cd610cc9068e88727426b696293"
 
 /**
+ * True when an RPC URL targets a local dev chain (bee-compose anvil). A
+ * dev-deployed PostageStamp address is only valid against such a node.
+ */
+function isLocalRpcUrl(rpcUrl: string): boolean {
+  try {
+    const { hostname } = new URL(rpcUrl)
+    return (
+      hostname === "localhost" ||
+      hostname === "127.0.0.1" ||
+      hostname === "0.0.0.0"
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Picks the PostageStamp contract address that matches the chain `rpcUrl` points
+ * at. A dev-override address (bee-compose anvil) is only honoured against a local
+ * RPC; against any remote RPC (Gnosis mainnet) it would read a nonexistent
+ * contract — `eth_call` returns empty, the batch looks unknown, and callers
+ * silently fall back to a bogus price estimate. Tying the address to the RPC
+ * network stops the two from drifting apart, which is what produced wildly wrong
+ * estimated expiry dates when a dev build read a mainnet batch (#344).
+ */
+export function resolvePostageStampContractAddress(
+  rpcUrl: string,
+  localContractAddress?: string,
+): string {
+  return isLocalRpcUrl(rpcUrl) && localContractAddress
+    ? localContractAddress
+    : POSTAGE_STAMP_CONTRACT_ADDRESS
+}
+
+/**
  * 4-byte function selectors (first 4 bytes of keccak256 of the signature).
  * Hardcoded so the library needs no keccak/ABI dependency for these fixed,
  * argument-free (or single-bytes32) calls.
@@ -199,11 +234,29 @@ async function ethCallBatch(
  *          contract (zero owner) or the RPC request fails. Never throws — the
  *          UI falls back to other expiry sources on `undefined`.
  */
-export async function fetchOnChainBatchState(
+/**
+ * Outcome of an on-chain batch read, keeping the two failure modes distinct:
+ *   - `found` — the contract knows the batch (non-zero owner).
+ *   - `not-found` — the contract returned an all-zero tuple; the batch
+ *     authoritatively does not exist on this chain.
+ *   - `error` — the RPC request failed or returned an undecodable payload, so
+ *     existence is *unknown* (not the same as "does not exist").
+ */
+export type OnChainBatchResult =
+  | { status: "found"; state: OnChainBatchState }
+  | { status: "not-found" }
+  | { status: "error" }
+
+/**
+ * Reads a batch's on-chain state, distinguishing "definitively absent" from
+ * "couldn't check". {@link fetchOnChainBatchState} is the simpler wrapper that
+ * collapses both into `undefined`.
+ */
+export async function fetchOnChainBatchStateResult(
   rpcUrl: string,
   batchId: string,
   contractAddress: string = POSTAGE_STAMP_CONTRACT_ADDRESS,
-): Promise<OnChainBatchState | undefined> {
+): Promise<OnChainBatchResult> {
   try {
     const id = normalizeBatchId(batchId)
     const [batchesResult, outPaymentResult, lastPriceResult] =
@@ -223,20 +276,36 @@ export async function fetchOnChainBatchState(
       ])
 
     const batch = decodeBatches(batchesResult)
-    // A non-existent batch decodes to an all-zero tuple. Treat it as unknown so
-    // callers fall back rather than render a bogus "expired" date.
+    // A non-existent batch decodes to an all-zero tuple — a definitive "no such
+    // batch on this chain", distinct from an RPC error below.
     if (batch.owner === ZERO_ADDRESS) {
-      return undefined
+      return { status: "not-found" }
     }
 
     return {
-      batch,
-      currentTotalOutPayment: decodeUint(outPaymentResult),
-      lastPrice: decodeUint(lastPriceResult),
+      status: "found",
+      state: {
+        batch,
+        currentTotalOutPayment: decodeUint(outPaymentResult),
+        lastPrice: decodeUint(lastPriceResult),
+      },
     }
   } catch {
-    return undefined
+    return { status: "error" }
   }
+}
+
+export async function fetchOnChainBatchState(
+  rpcUrl: string,
+  batchId: string,
+  contractAddress: string = POSTAGE_STAMP_CONTRACT_ADDRESS,
+): Promise<OnChainBatchState | undefined> {
+  const result = await fetchOnChainBatchStateResult(
+    rpcUrl,
+    batchId,
+    contractAddress,
+  )
+  return result.status === "found" ? result.state : undefined
 }
 
 /**
@@ -301,18 +370,83 @@ export async function fetchBatchTTLFromContract(
  * @param gnosisRpcUrl - Gnosis Chain JSON-RPC URL (for the contract read)
  * @param beeUrl - Bee node URL (fallback)
  * @param batchId - 32-byte hex batch ID, with or without `0x` prefix
- * @param contractAddress - PostageStamp contract address for the contract read
- *          (defaults to mainnet; override for a local dev chain).
+ * @param localContractAddress - PostageStamp address for a local dev chain. Only
+ *          honoured when `gnosisRpcUrl` targets a local node; against any remote
+ *          RPC the Gnosis mainnet deployment is used regardless (see
+ *          {@link resolvePostageStampContractAddress}).
  * @returns Remaining TTL in seconds, or `undefined` if neither source can answer.
  */
 export async function fetchAuthoritativeBatchTTL(
   gnosisRpcUrl: string,
   beeUrl: string,
   batchId: string,
-  contractAddress: string = POSTAGE_STAMP_CONTRACT_ADDRESS,
+  localContractAddress?: string,
 ): Promise<number | undefined> {
+  const contractAddress = resolvePostageStampContractAddress(
+    gnosisRpcUrl,
+    localContractAddress,
+  )
   return (
     (await fetchBatchTTLFromContract(gnosisRpcUrl, batchId, contractAddress)) ??
     (await fetchBatchTTL(beeUrl, batchId))
   )
+}
+
+/**
+ * Existence + remaining TTL of a batch, for UI that must tell "this batch does
+ * not exist on the configured chain" apart from "we couldn't reach the chain".
+ *   - `found` — carries `ttlSeconds` (remaining TTL, or `undefined` when the
+ *     price is zero so there is no finite expiry).
+ *   - `not-found` — the PostageStamp contract authoritatively has no such batch.
+ *   - `unreachable` — neither the contract nor the Bee node could be reached, so
+ *     existence is unknown.
+ */
+export type BatchResolution =
+  | { status: "found"; ttlSeconds: number | undefined }
+  | { status: "not-found" }
+  | { status: "unreachable" }
+
+/**
+ * Resolves a batch's existence and remaining TTL, treating the on-chain contract
+ * as the source of truth. A contract `not-found` is authoritative — a Bee node
+ * that happens to track the batch cannot override the chain. The Bee node is
+ * consulted only when the contract read itself failed (RPC unreachable), as a
+ * best-effort second opinion.
+ *
+ * Unlike {@link fetchAuthoritativeBatchTTL} (best-effort TTL, falls back to Bee
+ * even on contract `not-found`), this is the stricter lookup for existence-aware
+ * UI.
+ *
+ * @param localContractAddress - PostageStamp address for a local dev chain; only
+ *          honoured against a local RPC (see {@link resolvePostageStampContractAddress}).
+ */
+export async function resolveBatchStatus(
+  gnosisRpcUrl: string,
+  beeUrl: string,
+  batchId: string,
+  localContractAddress?: string,
+): Promise<BatchResolution> {
+  const contractAddress = resolvePostageStampContractAddress(
+    gnosisRpcUrl,
+    localContractAddress,
+  )
+  const contract = await fetchOnChainBatchStateResult(
+    gnosisRpcUrl,
+    batchId,
+    contractAddress,
+  )
+  if (contract.status === "found") {
+    return {
+      status: "found",
+      ttlSeconds: calculateContractTTLSeconds(contract.state),
+    }
+  }
+  if (contract.status === "not-found") {
+    return { status: "not-found" }
+  }
+  // Contract read errored — fall back to the Bee node as a second opinion.
+  const beeTtl = await fetchBatchTTL(beeUrl, batchId)
+  return beeTtl !== undefined
+    ? { status: "found", ttlSeconds: beeTtl }
+    : { status: "unreachable" }
 }

--- a/swarm-ui/src/lib/components/postage-stamp-form.svelte
+++ b/swarm-ui/src/lib/components/postage-stamp-form.svelte
@@ -59,88 +59,116 @@
     return undefined
   })
 
+  // Validation errors are surfaced only when focus leaves a field, never while
+  // typing. These hold the error snapshot captured at blur (the derived *Error
+  // values above stay live and drive `disabled`). Mutated only in focus handlers,
+  // so typing in a field never changes its displayed error.
+  let batchIDErrorShown = $state<string | undefined>(undefined)
+  let numberErrorShown = $state<string | undefined>(undefined)
+  let signerKeyErrorShown = $state<string | undefined>(undefined)
+
+  // Snapshot the current error when focus leaves a field — but not when the whole
+  // window loses focus (e.g. alt-tabbing to an editor to copy a value).
+  function snapshotOnBlur(snapshot: () => void) {
+    if (document.hasFocus()) snapshot()
+  }
+
   $effect(() => {
-    disabled = !batchID || !depth || !!batchIDError || !!numberError || !!signerKeyError
+    disabled =
+      !batchID || !depth || !signerKey || !!batchIDError || !!numberError || !!signerKeyError
   })
 </script>
 
 <Vertical>
   <!-- Row 1 -->
-  <div class="input-wrapper">
+  <div
+    class="input-wrapper"
+    onfocusin={() => (batchIDErrorShown = undefined)}
+    onfocusout={() => snapshotOnBlur(() => (batchIDErrorShown = batchIDError))}
+  >
     <Input
       variant="outline"
       dimension="compact"
       name="batchID"
       bind:value={batchID}
-      error={batchIDError}
+      error={batchIDErrorShown}
       label="Stamp ID"
       helperText="Don't reuse stamps across accounts and identities"
     />
   </div>
-  {#if batchIDError}
+  {#if batchIDErrorShown}
     <div class="error-full-width">
-      <ErrorMessage>{batchIDError}</ErrorMessage>
+      <ErrorMessage>{batchIDErrorShown}</ErrorMessage>
     </div>
   {/if}
 
   <!-- Row 2 -->
   <Vertical>
-    <ResponsiveLayout --responsive-justify-content="stretch">
-      <FormattedNumberInput
-        variant="outline"
-        dimension="compact"
-        name="depth"
-        locale={undefined}
-        bind:value={depth}
-        label="Depth"
-        class="flex-grow"
-        min={0}
-        max={255}
-        step={1}
-      />
-      <FormattedBigintInput
-        variant="outline"
-        dimension="compact"
-        name="amount"
-        locale={undefined}
-        bind:value={amount}
-        label="Amount"
-        class="flex-grow"
-        min={0n}
-      />
-      <FormattedNumberInput
-        variant="outline"
-        dimension="compact"
-        name="blockNumber"
-        locale={undefined}
-        bind:value={blockNumber}
-        label="Block number"
-        class="flex-grow"
-        min={0}
-        step={1}
-      />
-    </ResponsiveLayout>
-    {#if numberError}
+    <div
+      onfocusin={() => (numberErrorShown = undefined)}
+      onfocusout={() => snapshotOnBlur(() => (numberErrorShown = numberError))}
+    >
+      <ResponsiveLayout --responsive-justify-content="stretch">
+        <FormattedNumberInput
+          variant="outline"
+          dimension="compact"
+          name="depth"
+          locale={undefined}
+          bind:value={depth}
+          label="Depth"
+          class="flex-grow"
+          min={0}
+          max={255}
+          step={1}
+        />
+        <FormattedBigintInput
+          variant="outline"
+          dimension="compact"
+          name="amount"
+          locale={undefined}
+          bind:value={amount}
+          label="Amount"
+          class="flex-grow"
+          min={0n}
+        />
+        <FormattedNumberInput
+          variant="outline"
+          dimension="compact"
+          name="blockNumber"
+          locale={undefined}
+          bind:value={blockNumber}
+          label="Block number"
+          class="flex-grow"
+          min={0}
+          step={1}
+        />
+      </ResponsiveLayout>
+    </div>
+    {#if numberErrorShown}
       <div class="error-full-width">
-        <ErrorMessage>{numberError}</ErrorMessage>
+        <ErrorMessage>{numberErrorShown}</ErrorMessage>
       </div>
     {/if}
   </Vertical>
 
   <!-- Row 3 -->
-  <div class="input-wrapper">
+  <div
+    class="input-wrapper"
+    onfocusin={() => (signerKeyErrorShown = undefined)}
+    onfocusout={() => snapshotOnBlur(() => (signerKeyErrorShown = signerKeyError))}
+  >
     <Input
       variant="outline"
       dimension="compact"
       name="signerKey"
       bind:value={signerKey}
-      error={signerKeyError}
+      error={signerKeyErrorShown}
       label="Signer key"
     />
   </div>
-  {#if signerKeyError}
+  {#if signerKeyErrorShown}
     <div class="error-full-width">
-      <ErrorMessage>{signerKeyError}</ErrorMessage>
+      <ErrorMessage>{signerKeyErrorShown}</ErrorMessage>
     </div>
   {/if}
 

--- a/swarm-ui/src/routes/(app)/identity/[id]/stamps/+page.svelte
+++ b/swarm-ui/src/routes/(app)/identity/[id]/stamps/+page.svelte
@@ -26,9 +26,10 @@
   import WarningAltFilled from 'carbon-icons-svelte/lib/WarningAltFilled.svelte'
   import {
     calculateTTLSeconds,
-    fetchAuthoritativeBatchTTL,
+    resolveBatchStatus,
     fetchSwarmPrice,
     getBlockTimestamp,
+    type BatchResolution,
   } from '@snaha/swarm-id'
   import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
   import { postageStampContractAddress, MS_PER_SECOND } from '$lib/constants'
@@ -39,6 +40,11 @@
   const BYTES_PER_MB = BYTES_PER_KB * BYTES_PER_KB
   const BYTES_PER_GB = BYTES_PER_MB * BYTES_PER_KB
   const SECONDS_PER_MONTH = 2592000
+  const MONTHS_PER_YEAR = 12
+  // A constant-price estimate beyond this is treated as nonsense (e.g. a stale
+  // price epoch or a mis-entered amount can yield year-40000 dates, #344). We'd
+  // rather show no expiry than an absurd one.
+  const MAX_PLAUSIBLE_STAMP_TTL_YEARS = 100
   const MAX_UTILIZATION_PERCENT = 100
   const EXPIRY_SOON_LIFETIME_FRACTION = 0.1
   const BEEPORT_TOPUP_URL = 'https://beeport.eth.limo/?topup='
@@ -67,6 +73,10 @@
   // for price changes since stamp creation that the Swarmscan-price
   // approximation cannot.
   const chainExpiryMs = new SvelteMap<string, number>()
+  // Per-batch on-chain existence status (no entry = still resolving). Drives the
+  // card: a batch absent from / unverifiable against the configured chain shows a
+  // notice instead of fabricated capacity/expiry details.
+  const batchStatus = new SvelteMap<string, BatchResolution['status']>()
 
   async function fetchBlockTimestamp(blockNumber: number): Promise<number | undefined> {
     if (blockTimestamps.has(blockNumber)) {
@@ -87,17 +97,18 @@
 
   async function fetchStampExpiry(stamp: PostageStamp): Promise<void> {
     const batchId = stamp.batchID.toHex()
-    // Resolve remaining TTL from the most authoritative source: the on-chain
-    // PostageStamp contract first (works for any batchId, even one the
-    // configured Bee node has never seen), then the Bee node's batchTTL.
-    const ttlSeconds = await fetchAuthoritativeBatchTTL(
+    // Resolve existence + remaining TTL from the PostageStamp contract (the
+    // source of truth, works for any batchId the Bee node never saw), falling
+    // back to the Bee node only when the contract read itself fails.
+    const resolution = await resolveBatchStatus(
       networkSettingsStore.gnosisRpcUrl,
       networkSettingsStore.beeNodeUrl,
       batchId,
       postageStampContractAddress,
     )
-    if (ttlSeconds !== undefined) {
-      chainExpiryMs.set(batchId, Date.now() + ttlSeconds * MS_PER_SECOND)
+    batchStatus.set(batchId, resolution.status)
+    if (resolution.status === 'found' && resolution.ttlSeconds !== undefined) {
+      chainExpiryMs.set(batchId, Date.now() + resolution.ttlSeconds * MS_PER_SECOND)
     }
   }
 
@@ -169,9 +180,23 @@
       return undefined
     }
     const durationSeconds = calculateTTLSeconds(stamp.amount, price)
+    const maxTtlSeconds = MAX_PLAUSIBLE_STAMP_TTL_YEARS * MONTHS_PER_YEAR * SECONDS_PER_MONTH
+    // An estimate of 0 (bad inputs) or an implausibly distant one is treated as
+    // "unknown" rather than rendered as a wrong date — the row is then hidden.
+    if (durationSeconds <= 0 || durationSeconds > maxTtlSeconds) {
+      return undefined
+    }
     const startTimeMs =
       blockTimestamp !== undefined ? blockTimestamp * MS_PER_SECOND : stamp.createdAt
-    return { expiryMs: startTimeMs + durationSeconds * MS_PER_SECOND, estimated: true }
+    const expiryMs = startTimeMs + durationSeconds * MS_PER_SECOND
+    // We only reach the estimate when neither chain source knew the batch (e.g.
+    // a batch not on the configured chain's contract). An estimate that lands in
+    // the past can't be trusted to mean "expired" — show "unknown" instead of a
+    // misleading expired date.
+    if (expiryMs <= Date.now()) {
+      return undefined
+    }
+    return { expiryMs, estimated: true }
   }
 
   function formatExpiryDate(expiryMs: number, estimated: boolean): string {
@@ -234,50 +259,73 @@
         {/snippet}
       </Input>
 
-      <Horizontal --horizontal-gap="var(--half-padding)" --horizontal-align-items="center">
-        <div class="capacity-label">
-          <Typography>{formatCapacity(stamp.utilization, stamp.depth)}</Typography>
-        </div>
-        <div class="progress-bar">
-          <div
-            class="progress-bar-fill"
-            style="width: {Math.min(
-              stamp.utilization * MAX_UTILIZATION_PERCENT,
-              MAX_UTILIZATION_PERCENT,
-            )}%"
-          ></div>
-        </div>
-      </Horizontal>
-
-      {@const stampBlockTimestamp = blockTimestamps.get(stamp.blockNumber)}
-      {@const stampChainExpiry = chainExpiryMs.get(stamp.batchID.toHex())}
-      {@const expiry = getExpiry(stamp, pricePerGBPerMonth, stampBlockTimestamp, stampChainExpiry)}
-      {#if expiry !== undefined}
-        {@const expired = isExpired(expiry.expiryMs)}
-        {@const expiringSoon =
-          !expired && isExpiringSoon(stamp, expiry.expiryMs, pricePerGBPerMonth)}
-        <Horizontal --horizontal-justify-content="space-between" --horizontal-align-items="center">
-          <Typography>Expiry date</Typography>
-          <Horizontal --horizontal-gap="var(--half-padding)" --horizontal-align-items="center">
-            <Typography
-              --typography-color={expired || expiringSoon ? 'var(--colors-red)' : undefined}
-            >
-              {formatExpiryDate(expiry.expiryMs, expiry.estimated)}
-            </Typography>
-            {#if expiry.estimated}
-              <Typography variant="small">(estimated)</Typography>
-            {/if}
-            {#if expired}
-              <Badge variant="error" dimension="small">
-                <WarningAltFilled size={16} />Expired
-              </Badge>
-            {:else if expiringSoon}
-              <Badge variant="error" dimension="small">
-                <WarningAltFilled size={16} />Expires soon
-              </Badge>
-            {/if}
-          </Horizontal>
+      {@const status = batchStatus.get(stamp.batchID.toHex())}
+      {#if status === 'not-found'}
+        <Horizontal --horizontal-gap="var(--half-padding)" --horizontal-align-items="center">
+          <WarningAltFilled size={16} />
+          <Typography variant="small">This batch does not exist on the current network.</Typography>
         </Horizontal>
+      {:else if status === 'unreachable'}
+        <Horizontal --horizontal-gap="var(--half-padding)" --horizontal-align-items="center">
+          <WarningAltFilled size={16} />
+          <Typography variant="small">
+            Network unreachable — couldn't verify this batch right now.
+          </Typography>
+        </Horizontal>
+      {:else}
+        <Horizontal --horizontal-gap="var(--half-padding)" --horizontal-align-items="center">
+          <div class="capacity-label">
+            <Typography>{formatCapacity(stamp.utilization, stamp.depth)}</Typography>
+          </div>
+          <div class="progress-bar">
+            <div
+              class="progress-bar-fill"
+              style="width: {Math.min(
+                stamp.utilization * MAX_UTILIZATION_PERCENT,
+                MAX_UTILIZATION_PERCENT,
+              )}%"
+            ></div>
+          </div>
+        </Horizontal>
+
+        {@const stampBlockTimestamp = blockTimestamps.get(stamp.blockNumber)}
+        {@const stampChainExpiry = chainExpiryMs.get(stamp.batchID.toHex())}
+        {@const expiry = getExpiry(
+          stamp,
+          pricePerGBPerMonth,
+          stampBlockTimestamp,
+          stampChainExpiry,
+        )}
+        {#if expiry !== undefined}
+          {@const expired = isExpired(expiry.expiryMs)}
+          {@const expiringSoon =
+            !expired && isExpiringSoon(stamp, expiry.expiryMs, pricePerGBPerMonth)}
+          <Horizontal
+            --horizontal-justify-content="space-between"
+            --horizontal-align-items="center"
+          >
+            <Typography>Expiry date</Typography>
+            <Horizontal --horizontal-gap="var(--half-padding)" --horizontal-align-items="center">
+              <Typography
+                --typography-color={expired || expiringSoon ? 'var(--colors-red)' : undefined}
+              >
+                {formatExpiryDate(expiry.expiryMs, expiry.estimated)}
+              </Typography>
+              {#if expiry.estimated}
+                <Typography variant="small">(estimated)</Typography>
+              {/if}
+              {#if expired}
+                <Badge variant="error" dimension="small">
+                  <WarningAltFilled size={16} />Expired
+                </Badge>
+              {:else if expiringSoon}
+                <Badge variant="error" dimension="small">
+                  <WarningAltFilled size={16} />Expires soon
+                </Badge>
+              {/if}
+            </Horizontal>
+          </Horizontal>
+        {/if}
       {/if}
     </Vertical>
   </Vertical>


### PR DESCRIPTION
Stacked on top of #345 so the diff is just the delta — easy to compare what changed beyond the base "compute stamp expiry from the PostageStamp contract" work.

## Changes

**Contract resolution, expiry hardening & batch existence** (`lib` + stamps page)
- Pick the PostageStamp contract address by the RPC's network (`resolvePostageStampContractAddress`): a local dev-chain override is honoured only against a local RPC, otherwise the Gnosis mainnet deployment is used. Fixes a dev build reading a mainnet batch against the local contract address (#344).
- Clamp the constant-price expiry estimate — implausibly far-future or already-past projections render as "unknown" instead of bogus dates (e.g. year 42227).
- `resolveBatchStatus` distinguishes **found / not-found / unreachable**, with the on-chain contract as source of truth (a Bee node can't override a zero-owner result). The stamp card now shows a notice — *"does not exist on the current network"* or *"network unreachable"* — instead of fabricated capacity/expiry.

**Manual stamp form validation** (`postage-stamp-form.svelte`)
- Errors surface only when focus leaves a field (snapshot on `focusout`), never while typing; a window-focus blur is ignored (`document.hasFocus`) so alt-tabbing to copy a value doesn't trigger validation. Snapshot clears on `focusin`.
- The submit button now requires a non-empty signer key.

## Notes
- Base is `fix/stamp-expiry-from-contract` (#345); GitHub will auto-retarget to `main` once #345 merges.
- `pnpm check:all` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)