### PR TITLE
fix(sync): demote on beacon-confirmed displacement (refresh-tick backstop was a no-op)

### DIFF
--- a/lib/src/sync/batch-write-coordinator.test.ts
+++ b/lib/src/sync/batch-write-coordinator.test.ts
@@ -42,6 +42,7 @@ import {
   type BatchWriteCoordinatorDeps,
 } from "./batch-write-coordinator"
 import { NO_HOLDER_DEVICE_ID } from "./partition-lock"
+import type { LeaseRefreshOutcome } from "./partition-lease"
 import { LEASE_REFRESH_MS, LEASE_TTL_MS } from "../utils/batch-utilization"
 
 const SELF = "self-device"
@@ -75,7 +76,7 @@ function makeLease(
     }
     /** Make `acquire` reject — an operational failure, not contention. */
     acquireError?: Error
-    refreshResult?: boolean
+    refreshResult?: LeaseRefreshOutcome
   } = {},
 ) {
   let partition = opts.partition
@@ -94,7 +95,7 @@ function makeLease(
       if (r.partition !== undefined) partition = r.partition
       return r
     }),
-    refresh: vi.fn(async () => opts.refreshResult ?? true),
+    refresh: vi.fn(async () => opts.refreshResult ?? "held"),
     release: vi.fn(async () => {}),
     bumpLocalLease: vi.fn(),
     serialize: vi.fn(() => ({ v: 1 })),
@@ -312,7 +313,7 @@ describe("BatchWriteCoordinator — displacement-during-upload race fix", () => 
     // Seed a held lease on partition 0 that fails its refresh (so the tick
     // falls back to the displacement read), and make the lock SOC name a live
     // peer. Keep the lease "active" so the idle-yield branch is skipped.
-    const lease = makeLease({ partition: 0, refreshResult: false })
+    const lease = makeLease({ partition: 0, refreshResult: "lost" })
     internals.partitionLease = lease
     internals.lastLeaseActivityAt = Date.now()
     internals.activeUploadCount = 1
@@ -346,7 +347,7 @@ describe("BatchWriteCoordinator — displacement-during-upload race fix", () => 
       }),
     )
     const internals = coordinator as unknown as Internals
-    const lease = makeLease({ partition: 0, refreshResult: false })
+    const lease = makeLease({ partition: 0, refreshResult: "lost" })
     internals.partitionLease = lease
     internals.lastLeaseActivityAt = Date.now()
     internals.activeUploadCount = 1
@@ -361,6 +362,52 @@ describe("BatchWriteCoordinator — displacement-during-upload race fix", () => 
     expect(stamper.unbindPartition).not.toHaveBeenCalled()
     expect(coordinator.currentPartition).toBe(0)
     expect(lease.bumpLocalLease).toHaveBeenCalled()
+  })
+
+  it("demotes on a beacon-confirmed displacement, even though the static lock SOC still shows us live", async () => {
+    // The refresh-time deconfliction backstop: `PartitionLease.refresh()` reads
+    // a rival's presence beacon at a fresh per-epoch address — the channel that
+    // stays readable on a disjoint gateway where the static lock SOC is frozen —
+    // and, finding an earlier-generation foreign holder, reports `"displaced"`.
+    //
+    // Regression guard for the no-op the backstop existed to avoid: `refresh()`
+    // ALSO just rewrote our own claim to the static lock SOC, so re-gating the
+    // demote on `readPartitionLock` would read SELF (live) and never confirm —
+    // and the device would keep a partition a peer already holds (dual-hold →
+    // silent overstamp). The coordinator must trust the beacon verdict directly.
+    const calls: string[] = []
+    const stamper = makeStamper(calls)
+    const onLeaseChange = vi.fn()
+    const coordinator = new BatchWriteCoordinator(
+      makeDeps({
+        stamper: stamper as unknown as BatchWriteCoordinatorDeps["stamper"],
+        onLeaseChange,
+      }),
+    )
+    const internals = coordinator as unknown as Internals
+    const lease = makeLease({ partition: 0, refreshResult: "displaced" })
+    internals.partitionLease = lease
+    internals.lastLeaseActivityAt = Date.now()
+    internals.activeUploadCount = 1
+    // The frozen-gateway view: the static lock SOC shows OURSELVES as the live
+    // holder (we just rewrote it on this very refresh). Pre-fix, the coordinator
+    // re-gated on this read and so kept the lease — the bug.
+    lockController.payload = {
+      holderDeviceId: SELF,
+      leasedUntil: Date.now() + 10_000,
+    }
+
+    await internals.refreshTick(lease)
+
+    // Mirrors the displacement-race fix: invalidate the breaker, then unbind.
+    expect(calls).toEqual(["invalidate", "unbind"])
+    expect(coordinator.currentPartition).toBeUndefined()
+    expect(coordinator.isReadOnly).toBe(true)
+    expect(internals.pendingAcquire).toBe(true)
+    expect(onLeaseChange).toHaveBeenLastCalledWith({
+      currentPartition: undefined,
+      isReadOnly: true,
+    })
   })
 })
 
@@ -386,7 +433,7 @@ describe("BatchWriteCoordinator — sentinel re-assert at upload start", () => {
   }
 
   it("re-asserts the claim when a sentinel is visible while holding", async () => {
-    const lease = makeLease({ partition: 0, refreshResult: true })
+    const lease = makeLease({ partition: 0, refreshResult: "held" })
     const { internals, stamper, writeLeaseCache } = setup(lease)
 
     await internals.ensureLeaseStillValid()
@@ -398,7 +445,7 @@ describe("BatchWriteCoordinator — sentinel re-assert at upload start", () => {
   })
 
   it("demotes and throws when the re-assert loses to a peer", async () => {
-    const lease = makeLease({ partition: 0, refreshResult: false })
+    const lease = makeLease({ partition: 0, refreshResult: "lost" })
     const { coordinator, internals, stamper } = setup(lease)
 
     await expect(internals.ensureLeaseStillValid()).rejects.toThrow(/reclaimed/)
@@ -799,7 +846,7 @@ describe("BatchWriteCoordinator — stale refresh-tick guards", () => {
 
     // Lease A on partition 0: refresh fails, lock SOC names a live peer →
     // the tick confirms displacement and queues finalizeDemote on the lock.
-    const leaseA = makeLease({ partition: 0, refreshResult: false })
+    const leaseA = makeLease({ partition: 0, refreshResult: "lost" })
     internals.partitionLease = leaseA
     internals.lastLeaseActivityAt = Date.now()
     internals.activeUploadCount = 1 // skip the idle-yield branch

--- a/lib/src/sync/batch-write-coordinator.ts
+++ b/lib/src/sync/batch-write-coordinator.ts
@@ -46,7 +46,10 @@ import {
 } from "../utils/batch-utilization"
 import { withBatchWriteLock } from "../utils/batch-write-lock"
 import { PartitionLease } from "./partition-lease"
-import type { PartitionLeaseStateSnapshot } from "./partition-lease"
+import type {
+  LeaseRefreshOutcome,
+  PartitionLeaseStateSnapshot,
+} from "./partition-lease"
 import { readPartitionLock, NO_HOLDER_DEVICE_ID } from "./partition-lock"
 import type { UploadTarget } from "../proxy/upload"
 import type { StampWorkerPool } from "../proxy/stamp-worker-pool"
@@ -598,7 +601,7 @@ export class BatchWriteCoordinator {
       payload !== undefined &&
       payload.holderDeviceId === NO_HOLDER_DEVICE_ID
     ) {
-      let reasserted: boolean
+      let reasserted: LeaseRefreshOutcome
       try {
         reasserted = await this.partitionLease.refresh()
       } catch (err) {
@@ -610,9 +613,10 @@ export class BatchWriteCoordinator {
         )
         return
       }
-      if (!reasserted) {
-        // blocked / lost-race — a peer claimed after the sentinel. Mirror
-        // the displaced branch exactly (we are under the write lock).
+      if (reasserted !== "held") {
+        // blocked / lost-race (`"lost"`) or a beacon-confirmed peer
+        // (`"displaced"`) — a peer claimed after the sentinel. Mirror the
+        // displaced branch exactly (we are under the write lock).
         console.warn(
           `[BatchWriteCoordinator] Sentinel re-assert: partition ${partition} taken by a peer; demoting.`,
         )
@@ -724,8 +728,17 @@ export class BatchWriteCoordinator {
 
     let confirmedDisplaced = false
     try {
-      const ok = await lease.refresh()
-      if (!ok) {
+      const outcome = await lease.refresh()
+      if (outcome === "displaced") {
+        // The lease read a foreign presence beacon (earlier generation) at a
+        // fresh per-epoch address and confirmed a peer holds this partition.
+        // That beacon channel is exactly what the static lock SOC cannot show
+        // on a disjoint gateway, so trust the verdict directly. Re-reading the
+        // lock SOC here would be the no-op the backstop exists to avoid:
+        // refresh() just rewrote our own claim to that address, so the read
+        // would return SELF and never confirm the displacement.
+        confirmedDisplaced = true
+      } else if (outcome === "lost") {
         // Couldn't confirm via write+verify — check for ACTUAL displacement
         // with one read. A 500 here returns undefined → not displaced.
         const payload = await readPartitionLock({

--- a/lib/src/sync/partition-lease.integration.test.ts
+++ b/lib/src/sync/partition-lease.integration.test.ts
@@ -819,7 +819,7 @@ describe("PartitionLease.refresh", () => {
 
     nowValue = NOW1 + 10_000
     const ok = await lease.refresh()
-    expect(ok).toBe(true)
+    expect(ok).toBe("held")
 
     const observed = await readPartitionLock({
       bee: bee as unknown as Bee,
@@ -831,9 +831,9 @@ describe("PartitionLease.refresh", () => {
     expect(observed?.leasedUntil).toBe(nowValue + LEASE_TTL_MS)
   })
 
-  it("returns false when no lease is held", async () => {
+  it("returns 'lost' when no lease is held", async () => {
     const lease = makeLease({ deviceId: DEVICE_A, bee: bee as unknown as Bee })
-    expect(await lease.refresh()).toBe(false)
+    expect(await lease.refresh()).toBe("lost")
   })
 })
 
@@ -975,7 +975,7 @@ describe("PartitionLease.release — generation fencing (#349)", () => {
 
     // A refresh tick that slipped past teardown: must abort (no ghost claim
     // the fenced release would refuse to clear), not throw.
-    await expect(leaseA.refresh()).resolves.toBe(false)
+    await expect(leaseA.refresh()).resolves.toBe("lost")
 
     unblock()
     await releasing
@@ -1343,7 +1343,12 @@ describe("PartitionLease.acquire — holder presence beacons (gateway holder-exi
     })
 
     // On refresh, DEVICE_A (later generation) detects DEVICE_B and yields.
-    expect(await lease.refresh()).toBe(false)
+    // The verdict comes from the per-epoch beacon channel, so it is reported as
+    // a CONFIRMED `"displaced"` (not a plain `"lost"`): the coordinator must
+    // demote on this without re-reading the static lock SOC, which DEVICE_A
+    // just rewrote with its own claim. See the BatchWriteCoordinator test
+    // "demotes on a beacon-confirmed displacement …" for the end-to-end guard.
+    expect(await lease.refresh()).toBe("displaced")
   })
 
   it("refresh keeps the lease when only a LATER-generation peer is present", async () => {
@@ -1368,6 +1373,6 @@ describe("PartitionLease.acquire — holder presence beacons (gateway holder-exi
       genTimestamp: NOW + 1000,
     })
     // DEVICE_A is the earlier holder → keeps the lease.
-    expect(await lease.refresh()).toBe(true)
+    expect(await lease.refresh()).toBe("held")
   })
 })

--- a/lib/src/sync/partition-lease.ts
+++ b/lib/src/sync/partition-lease.ts
@@ -93,6 +93,29 @@ export interface AcquireResult {
 }
 
 /**
+ * Outcome of a `refresh()` tick. Distinguishes the two ways a refresh can fail
+ * to keep the lease, because the coordinator must react to them differently:
+ *
+ * - `"held"`     — the lease is still ours and was extended.
+ * - `"lost"`     — could not confirm via write+verify (no lease, or the lock
+ *                  protocol returned `blocked`/`lost-race`/`aborted`). The
+ *                  caller should re-check the static lock SOC before demoting
+ *                  (a transient read-your-writes hiccup must not demote — the
+ *                  Phase-1 optimism).
+ * - `"displaced"` — a foreign PRESENCE BEACON with an earlier generation proved
+ *                  a peer already holds this partition. The beacon is read at a
+ *                  fresh per-epoch address — the channel that stays readable on
+ *                  a disjoint gateway where the static lock SOC is frozen — so
+ *                  this is a CONFIRMED displacement. The caller MUST demote
+ *                  directly and must NOT re-gate on the static lock SOC: by the
+ *                  time `refresh()` returns, it has already rewritten our own
+ *                  claim to that address, so a re-read there would see SELF and
+ *                  never confirm (the no-op the deconfliction backstop existed
+ *                  to avoid).
+ */
+export type LeaseRefreshOutcome = "held" | "lost" | "displaced"
+
+/**
  * Serialised form of the lease state, used as the local persistence cache.
  * Never trusted on its own — callers re-validate `self` against the lock
  * SOC before acting on it.
@@ -594,12 +617,14 @@ export class PartitionLease {
 
   /**
    * Re-run the lock protocol on the currently-held partition to bump
-   * `leasedUntil`. Returns `false` when we don't hold a lease (legacy mode)
-   * or the lock protocol returned `blocked` / `lost-race` / `aborted` — the
-   * caller should treat that as "lease lost".
+   * `leasedUntil`. Returns `"lost"` when we don't hold a lease (legacy mode)
+   * or the lock protocol returned `blocked` / `lost-race` / `aborted`,
+   * `"displaced"` when a foreign presence beacon proves a peer holds the
+   * partition (the deconfliction backstop), else `"held"`. See
+   * `LeaseRefreshOutcome` for how the coordinator must react to each.
    */
-  async refresh(): Promise<boolean> {
-    if (!this.self) return false
+  async refresh(): Promise<LeaseRefreshOutcome> {
+    if (!this.self) return "lost"
     const partition = this.self.partition
     const { stamper } = this.requireWriteContext()
     const lockResult = await acquirePartitionLock({
@@ -619,12 +644,12 @@ export class PartitionLease {
     })
     // `release()` can complete during the guard window above and null
     // `this.self` — re-check before dereferencing it.
-    if (!this.self) return false
+    if (!this.self) return "lost"
     if (lockResult.outcome !== "acquired" || !lockResult.payload) {
       console.warn(
         `[PartitionLease] Refresh on partition ${partition} returned ${lockResult.outcome}.`,
       )
-      return false
+      return "lost"
     }
     const payload = lockResult.payload
     this.self = {
@@ -646,13 +671,18 @@ export class PartitionLease {
     // poll-guard (propagation outran the window), two devices can briefly hold
     // the same partition. Once both beacons have propagated, the one with the
     // LATER generation yields here so the pair resolves to a single holder.
+    // This is a CONFIRMED displacement (read via the fresh per-epoch beacon
+    // address, which stays readable on a disjoint gateway) — reported as
+    // `"displaced"` so the coordinator demotes WITHOUT re-checking the static
+    // lock SOC, which we just rewrote with our own claim above and which is the
+    // frozen read the beacon channel exists to bypass.
     if (await this.foreignBeaconBeatsUs(partition, payload.generation)) {
       console.warn(
         `[PartitionLease] Refresh on partition ${partition}: an earlier-generation peer holds it; yielding.`,
       )
-      return false
+      return "displaced"
     }
-    return true
+    return "held"
   }
 
   /**


### PR DESCRIPTION
## Context

Targets the branch of #359, not `main` — the code under review only exists there. Merge #359 first (or retarget to `main` if #359 is rebased/merged).

## The bug — the refresh-time deconfliction backstop is a no-op end to end

#359 adds a backstop: on a refresh tick, `PartitionLease.refresh()` reads each known rival's **presence beacon** at a fresh per-epoch address (the channel that stays readable on a disjoint gateway where the static lock SOC is frozen) and, on finding an earlier-generation foreign holder, yields by returning `false`. The intent: when a collision slips past the acquire-time guard, "the pair resolves to a single holder."

It doesn't, because `BatchWriteCoordinator.refreshTick` decides demote-vs-keep like this:

```ts
const ok = await lease.refresh()
if (!ok) {
  const payload = await readPartitionLock({ ...static lock SOC... })
  confirmedDisplaced = isDisplaced(payload, Date.now(), this.deps.deviceId)
}
// demote only if confirmedDisplaced; else bumpLocalLease() — keeps the lease
```

So a `false` from the beacon backstop is re-gated on `isDisplaced(readPartitionLock(...))` — a read of the **static lock SOC**, the exact read the beacon channel exists to bypass. Worse, `refresh()` *just rewrote our own claim* to that static address moments earlier, so on our own (frozen) gateway the read returns **SELF** and `isDisplaced` is effectively always `false`. Result: `confirmedDisplaced = false` → `bumpLocalLease()` → the lease is **kept**, the beacon "yield" is discarded, and the dual-hold persists (both devices keep refreshing, re-publishing live beacons, and stamping into the same partition's data lanes — the silent-overwrite harm #359 set out to prevent).

The coordinator has zero beacon awareness, and #359's test only asserts `lease.refresh()` returns `false` **in isolation** — it never drives the coordinator, so the end-to-end no-op slips through green.

## Demonstration

New test `BatchWriteCoordinator — … demotes on a beacon-confirmed displacement, even though the static lock SOC still shows us live`. With the coordinator left at #359's behavior (re-gate on the static SOC), it fails:

```
× demotes on a beacon-confirmed displacement, even though the static lock SOC still shows us live
  AssertionError: expected [] to deeply equal [ 'invalidate', 'unbind' ]
```

`[]` = the coordinator never demoted (no `invalidate`/`unbind`); it kept the lease. With the fix it passes.

## Fix

Give `refresh()` a discriminated return so the coordinator can tell the two distinct "didn't keep the lease" reasons apart:

```ts
export type LeaseRefreshOutcome = "held" | "lost" | "displaced"
```

- `"displaced"` — a foreign beacon (earlier generation) **confirmed** a peer holds it via the reliable per-epoch channel → the coordinator demotes **directly**, no static-SOC re-gate.
- `"lost"` — couldn't confirm via write+verify (no lease / `blocked` / `lost-race` / `aborted`) → keeps the existing static-SOC re-check (the Phase-1 read-your-writes optimism, unchanged: a transient hiccup must not demote).
- `"held"` — unchanged.

The sentinel-reassert path now treats anything but `"held"` as a demote (same behavior as the old `!reasserted`).

## Tests
- **New:** coordinator demotes on `"displaced"` despite a live self-held static lock SOC (the regression guard above).
- **Updated:** existing `refresh()` assertions migrated to the outcome type; the `partition-lease.integration.test.ts` deconfliction test now asserts `"displaced"`, which doubles as proof the real beacon path produces the new outcome.
- `pnpm --filter @snaha/swarm-id` `typecheck` + `lint` clean; full lib suite **786 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)