### PR TITLE
docs: add commit and PR conventions to AGENT.md

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -115,8 +115,10 @@ Authentication uses storage events: popup writes to localStorage → storage eve
 
 ## Version control conventions
 
-- Use conventional commits
-- Don't use the issue number in branch names
+- Use [conventional commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `chore:`)
+- Keep PR titles and descriptions concise
+- Omit the issue number from branch names and titles
+- When a PR resolves an issue, reference it with a closing keyword (e.g. `Closes #53`) so GitHub closes the issue automatically on merge
 
 ## Deployment
 


### PR DESCRIPTION
Adopts the commit/PR conventions from [snaha/kalkul-next#90](https://github.com/snaha/kalkul-next/pull/90) into this repo's agent-instructions file (`AGENT.md`, which `CLAUDE.md` symlinks to).

Expands the **Version control conventions** section:

- Use [conventional commits](https://www.conventionalcommits.org/) (e.g. `feat:`, `fix:`, `chore:`)
- Keep PR titles and descriptions concise
- Omit the issue number from branch names and titles
- When a PR resolves an issue, reference it with a closing keyword (e.g. `Closes #53`) so GitHub closes the issue automatically on merge

Single file, single logical change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)