### PR TITLE
chore(ci): make DigitalOcean deploy manual-only

### DIFF
--- a/.github/workflows/deploy-do.yml
+++ b/.github/workflows/deploy-do.yml
@@ -1,9 +1,10 @@
 name: Deploy to Digital Ocean
 
+# Manual-only: the DigitalOcean id/demo apps are pinned to a hand-picked
+# deployment. Auto-deploy on push to main is intentionally disabled so the
+# canonical legacy domains aren't overwritten on every merge. Trigger this
+# workflow from the Actions tab (workflow_dispatch) to publish a new build.
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## What

Removes the `push: branches: [main]` trigger from `deploy-do.yml`, leaving only `workflow_dispatch`.

## Why

The DigitalOcean **id** (`swarm-id.snaha.net`) and **demo** (`swarm-demo.snaha.net`) apps are now pinned to a hand-picked deployment (rolled back manually on DO). The GitHub Action was auto-deploying the latest `main` on every merge, which would overwrite that rollback.

DigitalOcean's own `deploy_on_push` is already `false` in both `.do/*.yaml` specs, so this Action was the **sole** remaining auto-deploy path. After this change, the id/demo apps only deploy when the workflow is manually triggered from the Actions tab.

> ⚠️ This needs to merge before any other PR lands on `main` — until it does, the old push trigger is still live and the next merge would re-trigger an auto-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)