### PR TITLE
feat(ui): add developer tools page to the new UI

### DIFF
--- a/ui/src/lib/components/home-account.svelte
+++ b/ui/src/lib/components/home-account.svelte
@@ -142,7 +142,7 @@
   function onNameChange() {
     const trimmed = name.trim()
     if (trimmed.length > 0 && trimmed !== account.name) {
-      accountsStore.rename(account.id, trimmed)
+      account.rename(trimmed)
     }
   }
 
@@ -268,7 +268,7 @@
       if (myAttempt !== attempt) {
         return
       }
-      accountsStore.setAccess(account.id, access, await encryptSeed(entropy, key))
+      account.setAccess(access, await encryptSeed(entropy, key))
       dialog = undefined
       newPassword = ''
       verifyNewPassword = ''

--- a/ui/src/lib/components/home-account.svelte
+++ b/ui/src/lib/components/home-account.svelte
@@ -104,7 +104,7 @@
   let toastMessage = $state<string | undefined>(undefined)
   let toastTimer: ReturnType<typeof setTimeout> | undefined
 
-  const isLocal = $derived(account.stamps.length === 0)
+  const isLocal = $derived(account.drives.length === 0)
   const accessLabel = $derived(methodLabel(account.access.type))
   const AccessIcon: Component = $derived(
     account.access.type === 'passkey'
@@ -372,12 +372,12 @@
 
 <div class="flex w-full flex-col gap-6">
   {#if isLocal}
-    <!-- Local account banner: no stamps yet, so the account is view-only. -->
+    <!-- Local account banner: no drives yet, so the account is view-only. -->
     <div class="bg-muted flex w-full flex-col gap-2 rounded-lg px-4 py-2">
       <div class="flex w-full items-center gap-2">
         <Info class="size-4 shrink-0" />
         <p class="flex-1 text-sm">Local account (view-only)</p>
-        <!-- Stamp purchase flow is still TBD in the design. -->
+        <!-- Drive purchase flow is still TBD in the design. -->
         <Button size="xs" onclick={notImplemented}>Upgrade</Button>
         <Button size="xs" variant="ghost" onclick={() => (bannerInfoShown = !bannerInfoShown)}>
           Info
@@ -385,8 +385,8 @@
       </div>
       {#if bannerInfoShown}
         <p class="text-muted-foreground pl-6 text-sm">
-          This is a local account, view-only and not synced. Upgrade by adding a postage stamp to
-          upload data and use your Swarm ID across all your devices.
+          This is a local account, view-only and not synced. Upgrade by adding a drive to upload
+          data and use your Swarm ID across all your devices.
         </p>
       {/if}
     </div>

--- a/ui/src/lib/components/home-apps.svelte
+++ b/ui/src/lib/components/home-apps.svelte
@@ -12,7 +12,6 @@
   import { Button } from '$lib/components/ui/button'
   import { Select } from '$lib/components/ui/select'
   import { disconnectSharedConnection, removeSharedConnection } from '$lib/connect-handshake'
-  import { accountsStore } from '$lib/stores/accounts.svelte'
   import type { Account } from '$lib/types'
 
   const DEFAULT_CONNECTION_DAYS = 30
@@ -48,13 +47,13 @@
     // Revoke the shared record too — it holds the app secret the dApp's proxy
     // iframe authenticates from; the UI-local store is just the display copy.
     disconnectSharedConnection(account, appUrl)
-    accountsStore.disconnectApp(account.id, appUrl)
+    account.disconnectApp(appUrl)
     openMenuFor = undefined
   }
 
   function remove(appUrl: string) {
     removeSharedConnection(account, appUrl)
-    accountsStore.removeApp(account.id, appUrl)
+    account.removeApp(appUrl)
     openMenuFor = undefined
   }
 </script>
@@ -68,7 +67,7 @@
       options={DURATION_OPTIONS}
       bind:value={connectionDays}
       class="w-70"
-      onchange={(value) => accountsStore.setAppConnectionDays(account.id, Number(value))}
+      onchange={(value) => account.setAppConnectionDays(Number(value))}
     />
   </div>
 

--- a/ui/src/lib/connect-handshake.ts
+++ b/ui/src/lib/connect-handshake.ts
@@ -280,3 +280,11 @@ export function removeSharedAccountRecords(account: Account): void {
   const manager = createAccountsStorageManager()
   manager.save(manager.load().filter((shared) => !shared.id.equals(accountId)))
 }
+
+/**
+ * Erase every shared-storage account record (developer reset). De-authenticates
+ * all dApp proxy iframes on this origin via the resulting storage event.
+ */
+export function removeAllSharedAccountRecords(): void {
+  createAccountsStorageManager().clear()
+}

--- a/ui/src/lib/connect-handshake.ts
+++ b/ui/src/lib/connect-handshake.ts
@@ -43,27 +43,27 @@ function connectionDuration(account: Account): number {
     : DEFAULT_SESSION_DURATION
 }
 
-/** The stamp the proxy should upload with: the account default or its first stamp. */
+/** The drive the proxy should upload with: the account default or its first drive. */
 function defaultBatchId(account: Account): BatchId | undefined {
-  const batchId = account.defaultStampBatchId ?? account.stamps[0]?.batchId
+  const batchId = account.defaultDriveBatchId ?? account.drives[0]?.batchId
   return batchId === undefined ? undefined : new BatchId(batchId)
 }
 
-/** The account's stamps in the shared (@snaha/swarm-id) PostageStamp shape. */
+/** The account's drives in the shared (@snaha/swarm-id) PostageStamp shape. */
 function sharedStamps(account: Account): SharedPostageStamp[] {
-  return account.stamps.map((stamp) => ({
-    batchID: new BatchId(stamp.batchId),
-    signerKey: new PrivateKey(stamp.signerKey),
-    utilization: stamp.utilization,
-    usable: stamp.usable,
-    depth: stamp.depth,
-    amount: BigInt(stamp.amount),
-    bucketDepth: stamp.bucketDepth,
-    blockNumber: stamp.blockNumber,
-    immutableFlag: stamp.immutableFlag,
-    exists: stamp.exists,
-    batchTTL: stamp.batchTTL,
-    createdAt: stamp.createdAt,
+  return account.drives.map((drive) => ({
+    batchID: new BatchId(drive.batchId),
+    signerKey: new PrivateKey(drive.signerKey),
+    utilization: drive.utilization,
+    usable: drive.usable,
+    depth: drive.depth,
+    amount: BigInt(drive.amount),
+    bucketDepth: drive.bucketDepth,
+    blockNumber: drive.blockNumber,
+    immutableFlag: drive.immutableFlag,
+    exists: drive.exists,
+    batchTTL: drive.batchTTL,
+    createdAt: drive.createdAt,
   }))
 }
 
@@ -80,12 +80,12 @@ function updateSharedAccount(
 
 /**
  * Upsert the shared nested account record the proxy resolves a connection (and
- * its upload stamp) against. The account is its own single identity, owning its
- * connected apps and postage stamps inline.
+ * its upload drive) against. The account is its own single identity, owning its
+ * connected apps and drives inline.
  */
 async function saveSharedRecords(account: Account, masterKey: string): Promise<void> {
   const accountId = new EthAddress(account.id)
-  const stampBatchId = defaultBatchId(account)
+  const driveBatchId = defaultBatchId(account)
   const publicKey = bareHex(account.publicKey)
 
   const manager = createAccountsStorageManager()
@@ -100,7 +100,7 @@ async function saveSharedRecords(account: Account, masterKey: string): Promise<v
               ...shared,
               name: account.name,
               publicKey,
-              defaultPostageStampBatchID: stampBatchId ?? shared.defaultPostageStampBatchID,
+              defaultPostageStampBatchID: driveBatchId ?? shared.defaultPostageStampBatchID,
               postageStamps: sharedStamps(account),
             }
           : shared,
@@ -116,7 +116,7 @@ async function saveSharedRecords(account: Account, masterKey: string): Promise<v
         createdAt: account.createdAt,
         derivationKey: await deriveAccountDerivationKey(masterKey),
         publicKey,
-        defaultPostageStampBatchID: stampBatchId,
+        defaultPostageStampBatchID: driveBatchId,
         devices: [],
         connectedApps: [],
         postageStamps: sharedStamps(account),
@@ -271,7 +271,7 @@ export function removeSharedConnection(account: Account, appUrl: string): void {
 
 /**
  * Erase the account's shared-storage footprint: removing the nested account
- * record drops its connected apps and stamps with it, and the storage event
+ * record drops its connected apps and drives with it, and the storage event
  * de-authenticates any dApp proxy iframes.
  */
 export function removeSharedAccountRecords(account: Account): void {

--- a/ui/src/lib/connect-handshake.ts
+++ b/ui/src/lib/connect-handshake.ts
@@ -27,7 +27,6 @@ import {
 } from '@snaha/swarm-id'
 
 import { privateKeyFromEntropy } from '$lib/crypto/mnemonic'
-import { accountsStore } from '$lib/stores/accounts.svelte'
 import type { ConnectRequest } from '$lib/stores/connect.svelte'
 import type { Account } from '$lib/types'
 
@@ -156,7 +155,7 @@ function saveConnection(account: Account, request: ConnectRequest, appSecret: st
     return { ...shared, connectedApps }
   })
 
-  accountsStore.connectApp(account.id, {
+  account.connectApp({
     appUrl: request.appOrigin,
     appName: request.appName,
     appIcon: request.appIcon,

--- a/ui/src/lib/crypto/backup.test.ts
+++ b/ui/src/lib/crypto/backup.test.ts
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 import { describe, expect, it } from 'vitest'
 
-import type { Account } from '../types'
+import type { AccountRecord } from '../types'
 import { backupFilename, createBackup, restoreBackup } from './backup'
 import { walletFromPhrase } from './mnemonic'
 
 const PHRASE = 'test test test test test test test test test test test junk'
 const OTHER_PHRASE = 'legal winner thank year wave sausage worth useful legal winner thank yellow'
 
-function accountFor(phrase: string): Account {
+function accountFor(phrase: string): AccountRecord {
   const wallet = walletFromPhrase(phrase)
   return {
     id: wallet.address,

--- a/ui/src/lib/crypto/backup.test.ts
+++ b/ui/src/lib/crypto/backup.test.ts
@@ -19,7 +19,7 @@ function accountFor(phrase: string): AccountRecord {
     access: { type: 'password', kdfSalt: '00', kdfIterations: 1 },
     encryptedSeed: '00',
     appConnectionDays: 30,
-    stamps: [],
+    drives: [],
     connectedApps: [
       { appUrl: 'https://coucou.mail', appName: 'Coucou', lastConnectedAt: 1765000000000 },
     ],

--- a/ui/src/lib/crypto/backup.ts
+++ b/ui/src/lib/crypto/backup.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 The Swarm Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 /**
- * .swarmid backup files. The portable account data (name, stamps, connected
+ * .swarmid backup files. The portable account data (name, drives, connected
  * apps — never the access method or encrypted seed) is AES-GCM encrypted with
  * a key derived from the recovery-phrase entropy, so the file is useless
  * without the phrase and restoring needs exactly: file + phrase.
@@ -51,8 +51,8 @@ export async function createBackup(account: AccountData, entropy: Uint8Array): P
     publicKey: account.publicKey,
     createdAt: account.createdAt,
     appConnectionDays: account.appConnectionDays,
-    defaultStampBatchId: account.defaultStampBatchId,
-    stamps: account.stamps,
+    defaultDriveBatchId: account.defaultDriveBatchId,
+    drives: account.drives,
     connectedApps: account.connectedApps,
   }
 

--- a/ui/src/lib/crypto/backup.ts
+++ b/ui/src/lib/crypto/backup.ts
@@ -9,7 +9,7 @@
 import { decryptSeed, deriveKeyFromSecret, encryptSeed } from '$lib/crypto/encryption'
 import { bytesToHex, hexToBytes } from '$lib/crypto/hex'
 import { walletFromPhrase } from '$lib/crypto/mnemonic'
-import type { Account, AccountData } from '$lib/types'
+import type { AccountData } from '$lib/types'
 
 const BACKUP_VERSION = 1
 const BACKUP_KEY_INFO = 'swarm-id-backup-v1'
@@ -44,7 +44,7 @@ function parseEnvelope(fileContents: string): BackupEnvelope | undefined {
 }
 
 /** Serialize and encrypt an account into .swarmid file contents. */
-export async function createBackup(account: Account, entropy: Uint8Array): Promise<string> {
+export async function createBackup(account: AccountData, entropy: Uint8Array): Promise<string> {
   const data: AccountData = {
     id: account.id,
     name: account.name,

--- a/ui/src/lib/routes.ts
+++ b/ui/src/lib/routes.ts
@@ -14,6 +14,7 @@ const routes = {
   ACCOUNT_READY: '/account/ready' as const,
   ACCOUNT_IMPORT: '/account/import' as const,
   ACCOUNT_RESTORE: '/account/restore' as const,
+  DEV: '/dev' as const,
 }
 
 export default routes

--- a/ui/src/lib/stores/accounts.svelte.ts
+++ b/ui/src/lib/stores/accounts.svelte.ts
@@ -1,6 +1,6 @@
 // Copyright 2026 The Swarm Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-import type { Account, ConnectedApp } from '$lib/types'
+import type { Account, ConnectedApp, PostageStamp } from '$lib/types'
 
 const STORAGE_KEY = 'swarm-id-accounts-v2'
 
@@ -89,6 +89,36 @@ function createAccountsStore() {
         ...account,
         connectedApps: account.connectedApps.filter((app) => app.appUrl !== appUrl),
       }))
+    },
+    /**
+     * Add or replace a postage stamp on the account (deduped by batch id). The
+     * first stamp added becomes the account default so uploads have something
+     * to spend against without a separate assignment step.
+     */
+    addStamp(id: string, stamp: PostageStamp) {
+      update(id, (account) => ({
+        ...account,
+        stamps: [...account.stamps.filter((existing) => existing.batchId !== stamp.batchId), stamp],
+        defaultStampBatchId: account.defaultStampBatchId ?? stamp.batchId,
+      }))
+    },
+    removeStamp(id: string, batchId: string) {
+      update(id, (account) => {
+        const stamps = account.stamps.filter((stamp) => stamp.batchId !== batchId)
+        // Drop the default when it points at the removed stamp; fall back to
+        // whatever remains so the account never references a missing batch.
+        const defaultStampBatchId =
+          account.defaultStampBatchId === batchId ? stamps[0]?.batchId : account.defaultStampBatchId
+        return { ...account, stamps, defaultStampBatchId }
+      })
+    },
+    setDefaultStamp(id: string, batchId: string | undefined) {
+      update(id, (account) => ({ ...account, defaultStampBatchId: batchId }))
+    },
+    /** Wipe every account from this device (developer reset). */
+    clear() {
+      accounts = []
+      persist()
     },
   }
 }

--- a/ui/src/lib/stores/accounts.svelte.ts
+++ b/ui/src/lib/stores/accounts.svelte.ts
@@ -1,6 +1,6 @@
 // Copyright 2026 The Swarm Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-import type { AccessMethod, AccountRecord, ConnectedApp, PostageStamp } from '$lib/types'
+import type { AccessMethod, AccountRecord, ConnectedApp, Drive } from '$lib/types'
 
 const STORAGE_KEY = 'swarm-id-accounts-v2'
 
@@ -8,8 +8,8 @@ const STORAGE_KEY = 'swarm-id-accounts-v2'
  * The account aggregate root. Fields are reactive (`$state`) so component reads
  * update on mutation, and every mutator is a method on the object that persists
  * the whole collection through the injected `onChange` — callers mutate the
- * account they already hold (`account.addStamp(…)`), never a store method that
- * takes an id and looks the account up. The account owns its postage stamps and
+ * account they already hold (`account.addDrive(…)`), never a store method that
+ * takes an id and looks the account up. The account owns its drives and
  * connected apps inline (nested model). `toJSON()` is the plain serialized form.
  */
 export class Account {
@@ -22,8 +22,8 @@ export class Account {
   access = $state<AccessMethod>({ type: 'password', kdfSalt: '', kdfIterations: 0 })
   encryptedSeed = $state('')
   appConnectionDays = $state<number | undefined>(undefined)
-  defaultStampBatchId = $state<string | undefined>(undefined)
-  stamps = $state<PostageStamp[]>([])
+  defaultDriveBatchId = $state<string | undefined>(undefined)
+  drives = $state<Drive[]>([])
   connectedApps = $state<ConnectedApp[]>([])
   readonly #onChange: () => void
 
@@ -35,8 +35,8 @@ export class Account {
     this.access = record.access
     this.encryptedSeed = record.encryptedSeed
     this.appConnectionDays = record.appConnectionDays
-    this.defaultStampBatchId = record.defaultStampBatchId
-    this.stamps = record.stamps
+    this.defaultDriveBatchId = record.defaultDriveBatchId
+    this.drives = record.drives
     this.connectedApps = record.connectedApps
     this.#onChange = onChange
   }
@@ -77,27 +77,27 @@ export class Account {
   }
 
   /**
-   * Add or replace a postage stamp (deduped by batch id). The first stamp added
-   * becomes the account default so uploads have something to spend against.
+   * Add or replace a drive (deduped by batch id). The first drive added becomes
+   * the account default so uploads have something to spend against.
    */
-  addStamp(stamp: PostageStamp) {
-    this.stamps = [...this.stamps.filter((existing) => existing.batchId !== stamp.batchId), stamp]
-    this.defaultStampBatchId ??= stamp.batchId
+  addDrive(drive: Drive) {
+    this.drives = [...this.drives.filter((existing) => existing.batchId !== drive.batchId), drive]
+    this.defaultDriveBatchId ??= drive.batchId
     this.#onChange()
   }
 
-  removeStamp(batchId: string) {
-    this.stamps = this.stamps.filter((stamp) => stamp.batchId !== batchId)
-    // Drop the default when it points at the removed stamp; fall back to
+  removeDrive(batchId: string) {
+    this.drives = this.drives.filter((drive) => drive.batchId !== batchId)
+    // Drop the default when it points at the removed drive; fall back to
     // whatever remains so the account never references a missing batch.
-    if (this.defaultStampBatchId === batchId) {
-      this.defaultStampBatchId = this.stamps[0]?.batchId
+    if (this.defaultDriveBatchId === batchId) {
+      this.defaultDriveBatchId = this.drives[0]?.batchId
     }
     this.#onChange()
   }
 
-  setDefaultStamp(batchId: string | undefined) {
-    this.defaultStampBatchId = batchId
+  setDefaultDrive(batchId: string | undefined) {
+    this.defaultDriveBatchId = batchId
     this.#onChange()
   }
 
@@ -111,8 +111,8 @@ export class Account {
       access: this.access,
       encryptedSeed: this.encryptedSeed,
       appConnectionDays: this.appConnectionDays,
-      defaultStampBatchId: this.defaultStampBatchId,
-      stamps: this.stamps,
+      defaultDriveBatchId: this.defaultDriveBatchId,
+      drives: this.drives,
       connectedApps: this.connectedApps,
     }
   }
@@ -131,6 +131,22 @@ function hydrate(record: AccountRecord): Account {
   return new Account(record, persist)
 }
 
+// Records persisted before the stamp→drive rename used `stamps` /
+// `defaultStampBatchId`. Accept either spelling on load and rewrite in the
+// current shape on the next persist.
+type StoredRecord = AccountRecord & {
+  stamps?: Drive[]
+  defaultStampBatchId?: string
+}
+
+function normalize(record: StoredRecord): AccountRecord {
+  return {
+    ...record,
+    drives: record.drives ?? record.stamps ?? [],
+    defaultDriveBatchId: record.defaultDriveBatchId ?? record.defaultStampBatchId,
+  }
+}
+
 function load(): Account[] {
   if (typeof localStorage === 'undefined') {
     return []
@@ -140,7 +156,7 @@ function load(): Account[] {
     return []
   }
   try {
-    return (JSON.parse(raw) as AccountRecord[]).map(hydrate)
+    return (JSON.parse(raw) as StoredRecord[]).map((record) => hydrate(normalize(record)))
   } catch {
     return []
   }

--- a/ui/src/lib/stores/accounts.svelte.ts
+++ b/ui/src/lib/stores/accounts.svelte.ts
@@ -1,8 +1,135 @@
 // Copyright 2026 The Swarm Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-import type { Account, ConnectedApp, PostageStamp } from '$lib/types'
+import type { AccessMethod, AccountRecord, ConnectedApp, PostageStamp } from '$lib/types'
 
 const STORAGE_KEY = 'swarm-id-accounts-v2'
+
+/**
+ * The account aggregate root. Fields are reactive (`$state`) so component reads
+ * update on mutation, and every mutator is a method on the object that persists
+ * the whole collection through the injected `onChange` — callers mutate the
+ * account they already hold (`account.addStamp(…)`), never a store method that
+ * takes an id and looks the account up. The account owns its postage stamps and
+ * connected apps inline (nested model). `toJSON()` is the plain serialized form.
+ */
+export class Account {
+  readonly id: string
+  readonly publicKey: string
+  readonly createdAt: number
+  // Initialized here so the runes compiler tracks them; real values come from
+  // the record in the constructor.
+  name = $state('')
+  access = $state<AccessMethod>({ type: 'password', kdfSalt: '', kdfIterations: 0 })
+  encryptedSeed = $state('')
+  appConnectionDays = $state<number | undefined>(undefined)
+  defaultStampBatchId = $state<string | undefined>(undefined)
+  stamps = $state<PostageStamp[]>([])
+  connectedApps = $state<ConnectedApp[]>([])
+  readonly #onChange: () => void
+
+  constructor(record: AccountRecord, onChange: () => void) {
+    this.id = record.id
+    this.publicKey = record.publicKey
+    this.createdAt = record.createdAt
+    this.name = record.name
+    this.access = record.access
+    this.encryptedSeed = record.encryptedSeed
+    this.appConnectionDays = record.appConnectionDays
+    this.defaultStampBatchId = record.defaultStampBatchId
+    this.stamps = record.stamps
+    this.connectedApps = record.connectedApps
+    this.#onChange = onChange
+  }
+
+  rename(name: string) {
+    this.name = name
+    this.#onChange()
+  }
+
+  /** Swap the unlock method: new access metadata + seed re-encrypted for it. */
+  setAccess(access: AccessMethod, encryptedSeed: string) {
+    this.access = access
+    this.encryptedSeed = encryptedSeed
+    this.#onChange()
+  }
+
+  setAppConnectionDays(days: number) {
+    this.appConnectionDays = days
+    this.#onChange()
+  }
+
+  /** Record a (re)connection — replaces any previous entry for the same app. */
+  connectApp(app: ConnectedApp) {
+    this.connectedApps = [...this.connectedApps.filter((a) => a.appUrl !== app.appUrl), app]
+    this.#onChange()
+  }
+
+  disconnectApp(appUrl: string) {
+    this.connectedApps = this.connectedApps.map((app) =>
+      app.appUrl === appUrl ? { ...app, connectedUntil: undefined } : app,
+    )
+    this.#onChange()
+  }
+
+  removeApp(appUrl: string) {
+    this.connectedApps = this.connectedApps.filter((app) => app.appUrl !== appUrl)
+    this.#onChange()
+  }
+
+  /**
+   * Add or replace a postage stamp (deduped by batch id). The first stamp added
+   * becomes the account default so uploads have something to spend against.
+   */
+  addStamp(stamp: PostageStamp) {
+    this.stamps = [...this.stamps.filter((existing) => existing.batchId !== stamp.batchId), stamp]
+    this.defaultStampBatchId ??= stamp.batchId
+    this.#onChange()
+  }
+
+  removeStamp(batchId: string) {
+    this.stamps = this.stamps.filter((stamp) => stamp.batchId !== batchId)
+    // Drop the default when it points at the removed stamp; fall back to
+    // whatever remains so the account never references a missing batch.
+    if (this.defaultStampBatchId === batchId) {
+      this.defaultStampBatchId = this.stamps[0]?.batchId
+    }
+    this.#onChange()
+  }
+
+  setDefaultStamp(batchId: string | undefined) {
+    this.defaultStampBatchId = batchId
+    this.#onChange()
+  }
+
+  /** Plain serializable record — used by `JSON.stringify` when persisting. */
+  toJSON(): AccountRecord {
+    return {
+      id: this.id,
+      name: this.name,
+      publicKey: this.publicKey,
+      createdAt: this.createdAt,
+      access: this.access,
+      encryptedSeed: this.encryptedSeed,
+      appConnectionDays: this.appConnectionDays,
+      defaultStampBatchId: this.defaultStampBatchId,
+      stamps: this.stamps,
+      connectedApps: this.connectedApps,
+    }
+  }
+}
+
+let accounts = $state<Account[]>([])
+
+function persist() {
+  if (typeof localStorage === 'undefined') {
+    return
+  }
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(accounts))
+}
+
+function hydrate(record: AccountRecord): Account {
+  return new Account(record, persist)
+}
 
 function load(): Account[] {
   if (typeof localStorage === 'undefined') {
@@ -13,114 +140,46 @@ function load(): Account[] {
     return []
   }
   try {
-    return JSON.parse(raw) as Account[]
+    return (JSON.parse(raw) as AccountRecord[]).map(hydrate)
   } catch {
     return []
   }
 }
 
-function createAccountsStore() {
-  let accounts = $state<Account[]>(load())
+accounts = load()
 
-  function persist() {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(accounts))
-  }
-
-  // Keep tabs in sync: another tab writing accounts updates this one.
-  if (typeof window !== 'undefined') {
-    window.addEventListener('storage', (event) => {
-      if (event.key === STORAGE_KEY) {
-        accounts = load()
-      }
-    })
-  }
-
-  function update(id: string, change: (account: Account) => Account) {
-    accounts = accounts.map((account) => (account.id === id ? change(account) : account))
-    persist()
-  }
-
-  return {
-    get accounts() {
-      return accounts
-    },
-    get(id: string): Account | undefined {
-      return accounts.find((account) => account.id === id)
-    },
-    add(account: Account) {
-      // Replace any previous record for the same address (sign-in / restore).
-      accounts = [...accounts.filter((existing) => existing.id !== account.id), account]
-      persist()
-    },
-    rename(id: string, name: string) {
-      update(id, (account) => ({ ...account, name }))
-    },
-    remove(id: string) {
-      accounts = accounts.filter((account) => account.id !== id)
-      persist()
-    },
-    /** Swap the unlock method: new access metadata + seed re-encrypted for it. */
-    setAccess(id: string, access: Account['access'], encryptedSeed: string) {
-      update(id, (account) => ({ ...account, access, encryptedSeed }))
-    },
-    setAppConnectionDays(id: string, days: number) {
-      update(id, (account) => ({ ...account, appConnectionDays: days }))
-    },
-    /** Record a (re)connection — replaces any previous entry for the app. */
-    connectApp(id: string, app: ConnectedApp) {
-      update(id, (account) => ({
-        ...account,
-        connectedApps: [
-          ...account.connectedApps.filter((existing) => existing.appUrl !== app.appUrl),
-          app,
-        ],
-      }))
-    },
-    disconnectApp(id: string, appUrl: string) {
-      update(id, (account) => ({
-        ...account,
-        connectedApps: account.connectedApps.map((app) =>
-          app.appUrl === appUrl ? { ...app, connectedUntil: undefined } : app,
-        ),
-      }))
-    },
-    removeApp(id: string, appUrl: string) {
-      update(id, (account) => ({
-        ...account,
-        connectedApps: account.connectedApps.filter((app) => app.appUrl !== appUrl),
-      }))
-    },
-    /**
-     * Add or replace a postage stamp on the account (deduped by batch id). The
-     * first stamp added becomes the account default so uploads have something
-     * to spend against without a separate assignment step.
-     */
-    addStamp(id: string, stamp: PostageStamp) {
-      update(id, (account) => ({
-        ...account,
-        stamps: [...account.stamps.filter((existing) => existing.batchId !== stamp.batchId), stamp],
-        defaultStampBatchId: account.defaultStampBatchId ?? stamp.batchId,
-      }))
-    },
-    removeStamp(id: string, batchId: string) {
-      update(id, (account) => {
-        const stamps = account.stamps.filter((stamp) => stamp.batchId !== batchId)
-        // Drop the default when it points at the removed stamp; fall back to
-        // whatever remains so the account never references a missing batch.
-        const defaultStampBatchId =
-          account.defaultStampBatchId === batchId ? stamps[0]?.batchId : account.defaultStampBatchId
-        return { ...account, stamps, defaultStampBatchId }
-      })
-    },
-    setDefaultStamp(id: string, batchId: string | undefined) {
-      update(id, (account) => ({ ...account, defaultStampBatchId: batchId }))
-    },
-    /** Wipe every account from this device (developer reset). */
-    clear() {
-      accounts = []
-      persist()
-    },
-  }
+// Keep tabs in sync: another tab writing accounts updates this one.
+if (typeof window !== 'undefined') {
+  window.addEventListener('storage', (event) => {
+    if (event.key === STORAGE_KEY) {
+      accounts = load()
+    }
+  })
 }
 
-export const accountsStore = createAccountsStore()
+/** The account collection: create / look up / remove whole accounts. Per-account
+ * state changes live on the {@link Account} object itself. */
+export const accountsStore = {
+  get accounts() {
+    return accounts
+  },
+  get(id: string): Account | undefined {
+    return accounts.find((account) => account.id === id)
+  },
+  /** Create — or replace, for sign-in / restore — an account; returns the live object. */
+  add(record: AccountRecord): Account {
+    const account = hydrate(record)
+    accounts = [...accounts.filter((existing) => existing.id !== record.id), account]
+    persist()
+    return account
+  },
+  remove(id: string) {
+    accounts = accounts.filter((account) => account.id !== id)
+    persist()
+  },
+  /** Wipe every account from this device (developer reset). */
+  clear() {
+    accounts = []
+    persist()
+  },
+}

--- a/ui/src/lib/stores/session.svelte.ts
+++ b/ui/src/lib/stores/session.svelte.ts
@@ -9,7 +9,7 @@ interface SetupDraft {
   flow: 'create' | 'sign-in' | 'restore'
   name: string
   phrase?: string
-  /** Account data carried over by a restore (stamps, apps, original name). */
+  /** Account data carried over by a restore (drives, apps, original name). */
   restored?: AccountData
 }
 

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -37,16 +37,17 @@ export interface ConnectedApp {
   connectedUntil?: number
 }
 
-export interface Account {
+/**
+ * The portable part of an account — carried by sign-in sync and backup files.
+ * Holds no device unlock secrets (access method / encrypted seed).
+ */
+export interface AccountData {
   /** 0x-prefixed Ethereum address derived from the recovery phrase. */
   id: string
   name: string
   /** Compressed secp256k1 public key (0x-prefixed hex). */
   publicKey: string
   createdAt: number
-  access: AccessMethod
-  /** BIP-39 entropy encrypted with the access-method key (hex: IV || ciphertext). */
-  encryptedSeed: string
   /** How long app connections stay valid, in days. */
   appConnectionDays?: number
   defaultStampBatchId?: string
@@ -54,5 +55,18 @@ export interface Account {
   connectedApps: ConnectedApp[]
 }
 
-/** The portable part of an account carried by sign-in sync and backup files. */
-export type AccountData = Omit<Account, 'access' | 'encryptedSeed'>
+/** A full persisted account record: portable data plus this device's unlock secrets. */
+export interface AccountRecord extends AccountData {
+  access: AccessMethod
+  /** BIP-39 entropy encrypted with the access-method key (hex: IV || ciphertext). */
+  encryptedSeed: string
+}
+
+/**
+ * The live account object the app works with: {@link AccountRecord} fields as
+ * reactive state plus the mutation methods that own them. Defined with the
+ * collection store and re-exported here so `$lib/types` stays the one type entry
+ * point. Account-state changes are methods on the object (`account.addStamp(…)`),
+ * never store calls that take an id and look the account up.
+ */
+export type { Account } from './stores/accounts.svelte'

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * The account is the aggregate root: it owns its postage stamps and connected
- * apps directly (nested), rather than referencing them across flat collections.
+ * The account is the aggregate root: it owns its drives and connected apps
+ * directly (nested), rather than referencing them across flat collections.
  * All values are plain JSON so the whole account serializes as-is.
  */
 
@@ -13,7 +13,11 @@ export type AccessMethod =
   | { type: 'eth-wallet'; walletAddress: string; encryptionSalt: string }
   | { type: 'password'; kdfSalt: string; kdfIterations: number }
 
-export interface PostageStamp {
+/**
+ * A drive: an account's unit of owned Swarm storage, backed by a postage stamp
+ * batch on the Bee node. Batch-level fields mirror the node's stamp object.
+ */
+export interface Drive {
   batchId: string
   signerKey: string
   depth: number
@@ -50,8 +54,8 @@ export interface AccountData {
   createdAt: number
   /** How long app connections stay valid, in days. */
   appConnectionDays?: number
-  defaultStampBatchId?: string
-  stamps: PostageStamp[]
+  defaultDriveBatchId?: string
+  drives: Drive[]
   connectedApps: ConnectedApp[]
 }
 
@@ -66,7 +70,7 @@ export interface AccountRecord extends AccountData {
  * The live account object the app works with: {@link AccountRecord} fields as
  * reactive state plus the mutation methods that own them. Defined with the
  * collection store and re-exported here so `$lib/types` stays the one type entry
- * point. Account-state changes are methods on the object (`account.addStamp(…)`),
+ * point. Account-state changes are methods on the object (`account.addDrive(…)`),
  * never store calls that take an id and look the account up.
  */
 export type { Account } from './stores/accounts.svelte'

--- a/ui/src/routes/account/new/access/+page.svelte
+++ b/ui/src/routes/account/new/access/+page.svelte
@@ -85,7 +85,7 @@
     // Carry over data from a restore, or from an existing record for the same
     // address — re-importing a phrase must not wipe stamps or connected apps.
     const carried = draft.restored ?? accountsStore.get(wallet.address)
-    const account = {
+    const account = accountsStore.add({
       id: wallet.address,
       name: draft.name,
       publicKey: wallet.publicKey,
@@ -96,8 +96,7 @@
       defaultStampBatchId: carried?.defaultStampBatchId,
       stamps: carried?.stamps ?? [],
       connectedApps: carried?.connectedApps ?? [],
-    }
-    accountsStore.add(account)
+    })
     sessionStore.setCurrentAccount(wallet.address)
     const flow = draft.flow
 

--- a/ui/src/routes/account/new/access/+page.svelte
+++ b/ui/src/routes/account/new/access/+page.svelte
@@ -83,7 +83,7 @@
     }
     const wallet = walletFromPhrase(draft.phrase)
     // Carry over data from a restore, or from an existing record for the same
-    // address — re-importing a phrase must not wipe stamps or connected apps.
+    // address — re-importing a phrase must not wipe drives or connected apps.
     const carried = draft.restored ?? accountsStore.get(wallet.address)
     const account = accountsStore.add({
       id: wallet.address,
@@ -93,8 +93,8 @@
       access,
       encryptedSeed: await encryptSeed(wallet.entropy, key),
       appConnectionDays: carried?.appConnectionDays,
-      defaultStampBatchId: carried?.defaultStampBatchId,
-      stamps: carried?.stamps ?? [],
+      defaultDriveBatchId: carried?.defaultDriveBatchId,
+      drives: carried?.drives ?? [],
       connectedApps: carried?.connectedApps ?? [],
     })
     sessionStore.setCurrentAccount(wallet.address)

--- a/ui/src/routes/account/new/done/+page.svelte
+++ b/ui/src/routes/account/new/done/+page.svelte
@@ -59,16 +59,14 @@
 
           <div class="bg-muted flex w-full flex-col items-center rounded-lg p-2 text-center">
             <p class="text-sm font-bold">Want the full experience?</p>
-            <p class="text-sm">
-              Upload data and sync your Swarm ID across devices with a postage stamp.
-            </p>
+            <p class="text-sm">Upload data and sync your Swarm ID across devices with a drive.</p>
           </div>
         </div>
 
         <div class="flex w-full flex-col items-center gap-4">
           <div class="flex w-full flex-col items-center gap-2">
-            <!-- Stamp purchase flow is still TBD in the design. -->
-            <Button class="w-full" onclick={notImplemented}>Add a postage stamp</Button>
+            <!-- Drive purchase flow is still TBD in the design. -->
+            <Button class="w-full" onclick={notImplemented}>Add a drive</Button>
             <Button variant="outline" class="w-full" href={resolve(routes.HOME)}>
               Stay local for now
             </Button>

--- a/ui/src/routes/dev/+page.svelte
+++ b/ui/src/routes/dev/+page.svelte
@@ -21,7 +21,7 @@
   import routes from '$lib/routes'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
-  import type { PostageStamp } from '$lib/types'
+  import type { Drive } from '$lib/types'
   import { truncateAddress } from '$lib/utils'
 
   import { type BeeStamp, type EndpointProbe, beeDev } from './bee'
@@ -115,8 +115,8 @@
 
   // ── Overview counts ──────────────────────────────────────────────────────────
   const accountCount = $derived(accountsStore.accounts.length)
-  const stampCount = $derived(
-    accountsStore.accounts.reduce((total, account) => total + account.stamps.length, 0),
+  const driveCount = $derived(
+    accountsStore.accounts.reduce((total, account) => total + account.drives.length, 0),
   )
   const connectionCount = $derived(
     accountsStore.accounts.reduce((total, account) => total + account.connectedApps.length, 0),
@@ -139,13 +139,13 @@
     selectedAccountId ? accountsStore.get(selectedAccountId) : undefined,
   )
 
-  // batchId → which account holds it (and whether it is that account's default).
-  const stampAssignments = $derived.by(() => {
+  // batchId → which account holds it as a drive (and whether it is that account's default).
+  const driveAssignments = $derived.by(() => {
     const map = new SvelteMap<string, string>()
     for (const account of accountsStore.accounts) {
-      for (const stamp of account.stamps) {
-        const isDefault = account.defaultStampBatchId === stamp.batchId
-        map.set(stamp.batchId, isDefault ? `${account.name} (default)` : account.name)
+      for (const drive of account.drives) {
+        const isDefault = account.defaultDriveBatchId === drive.batchId
+        map.set(drive.batchId, isDefault ? `${account.name} (default)` : account.name)
       }
     }
     return map
@@ -223,7 +223,7 @@
     }
   }
 
-  function assignStamp() {
+  function assignDrive() {
     assignError = ''
     assignMessage = ''
     const account = selectedAccount
@@ -243,7 +243,7 @@
     }
 
     const signerKey = useCustomSigner ? customSignerKey.toLowerCase() : selectedSigner
-    const stamp: PostageStamp = {
+    const drive: Drive = {
       batchId: beeStamp.batchID,
       signerKey,
       depth: beeStamp.depth,
@@ -257,12 +257,12 @@
       batchTTL: beeStamp.batchTTL,
       createdAt: Date.now(),
     }
-    account.addStamp(stamp)
-    account.setDefaultStamp(beeStamp.batchID)
-    assignMessage = `Assigned stamp to ${truncateAddress(account.id)} and set as default.`
+    account.addDrive(drive)
+    account.setDefaultDrive(beeStamp.batchID)
+    assignMessage = `Assigned drive to ${truncateAddress(account.id)} and set as default.`
   }
 
-  function removeStamp() {
+  function removeDrive() {
     assignError = ''
     assignMessage = ''
     const account = selectedAccount
@@ -270,12 +270,12 @@
       assignError = 'Select a stamp and an account first.'
       return
     }
-    account.removeStamp(selectedStampId)
-    assignMessage = `Removed stamp from ${truncateAddress(account.id)}.`
+    account.removeDrive(selectedStampId)
+    assignMessage = `Removed drive from ${truncateAddress(account.id)}.`
   }
 
   function clearAllData() {
-    if (!confirm('Delete all accounts, stamps and connections on this device?')) {
+    if (!confirm('Delete all accounts, drives and connections on this device?')) {
       return
     }
     accountsStore.clear()
@@ -340,7 +340,7 @@
         <section class="flex flex-col items-start gap-3">
           <h2 class="text-sm font-bold">Local data</h2>
           <p class="text-sm">
-            {accountCount} accounts · {stampCount} stamps · {connectionCount} connections
+            {accountCount} accounts · {driveCount} drives · {connectionCount} connections
           </p>
           <Button variant="destructive" onclick={clearAllData}>Clear all data</Button>
         </section>
@@ -440,7 +440,7 @@
                   <div class="text-muted-foreground flex flex-wrap gap-x-4 text-xs">
                     <span>Depth: {stamp.depth}</span>
                     <span>Usable: {stamp.usable ? 'yes' : 'no'}</span>
-                    <span>Assigned: {stampAssignments.get(stamp.batchID) ?? '—'}</span>
+                    <span>Assigned: {driveAssignments.get(stamp.batchID) ?? '—'}</span>
                   </div>
                 </div>
               {/each}
@@ -451,10 +451,10 @@
         <div class="bg-border h-px w-full"></div>
 
         <section class="flex flex-col gap-3">
-          <h2 class="text-sm font-bold">Assign stamp to account</h2>
+          <h2 class="text-sm font-bold">Assign drive to account</h2>
 
           {#if accountOptions.length === 0}
-            <p class="text-muted-foreground text-sm">Create an account first to assign a stamp.</p>
+            <p class="text-muted-foreground text-sm">Create an account first to assign a drive.</p>
           {:else if stampOptions.length === 0}
             <p class="text-muted-foreground text-sm">No stamps on the node to assign yet.</p>
           {:else}
@@ -482,13 +482,13 @@
             {/if}
 
             <div class="flex gap-2">
-              <Button disabled={useCustomSigner && !!customSignerError} onclick={assignStamp}>
+              <Button disabled={useCustomSigner && !!customSignerError} onclick={assignDrive}>
                 Assign and set default
               </Button>
               <Button
                 variant="destructive"
-                disabled={!selectedAccount?.stamps.some((s) => s.batchId === selectedStampId)}
-                onclick={removeStamp}
+                disabled={!selectedAccount?.drives.some((d) => d.batchId === selectedStampId)}
+                onclick={removeDrive}
               >
                 Remove from account
               </Button>

--- a/ui/src/routes/dev/+page.svelte
+++ b/ui/src/routes/dev/+page.svelte
@@ -1,0 +1,506 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<script lang="ts">
+  import { SvelteMap } from 'svelte/reactivity'
+
+  import { Utils } from '@ethersphere/bee-js'
+  import LoaderCircle from '@lucide/svelte/icons/loader-circle'
+  import { calculateStampAmountForDays, fetchChainState } from '@snaha/swarm-id'
+
+  import { resolve } from '$app/paths'
+
+  import AppHeader from '$lib/components/app-header.svelte'
+  import { Button } from '$lib/components/ui/button'
+  import { Input } from '$lib/components/ui/input'
+  import { Select } from '$lib/components/ui/select'
+  import { Tabs } from '$lib/components/ui/tabs'
+  import { removeAllSharedAccountRecords } from '$lib/connect-handshake'
+  import routes from '$lib/routes'
+  import { accountsStore } from '$lib/stores/accounts.svelte'
+  import { sessionStore } from '$lib/stores/session.svelte'
+  import type { PostageStamp } from '$lib/types'
+  import { truncateAddress } from '$lib/utils'
+
+  import { type BeeStamp, type EndpointProbe, beeDev } from './bee'
+  import CopyButton from './copy-button.svelte'
+  import StatusDot from './status-dot.svelte'
+
+  // Local bee-compose cluster endpoints (see .claude/rules/bee-cluster.md).
+  const QUEEN_API = 'http://localhost:1633'
+  const WORKER_API = 'http://localhost:16331'
+  const BLOCKCHAIN_RPC = 'http://localhost:9545'
+  // Demo dApp origin under `pnpm dev:new` (see root package.json dev:demo:new).
+  const DEMO_ORIGIN = 'http://localhost:3500'
+
+  const ENDPOINTS: { label: string; url: string; probe: EndpointProbe }[] = [
+    { label: 'Queen API', url: QUEEN_API, probe: 'head' },
+    { label: 'Worker API', url: WORKER_API, probe: 'head' },
+    { label: 'Blockchain RPC', url: BLOCKCHAIN_RPC, probe: 'json-rpc' },
+  ]
+
+  // Default validity to fund when auto-filling the amount from chain price. Bee
+  // enforces a 24h minimum; 7 days gives headroom for dev testing.
+  const DEFAULT_STAMP_DAYS = 7
+  const BATCH_ID_PREVIEW = 10
+  const SIGNER_KEY_LENGTH = 64
+
+  // Known dev signers (pre-funded with ETH + BZZ in the local Bee cluster).
+  const KNOWN_SIGNERS = [
+    {
+      value: '566058308ad5fa3888173c741a1fb902c9f1f19559b11fc2738dfc53637ce4e9',
+      label: 'Queen (node owner)',
+    },
+    {
+      value: '4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d',
+      label: 'Wallet 0 (pre-funded)',
+    },
+    {
+      value: '6cbed15c793ce57650b9877cf6fa156fbef513c4e6134f022a85b1ffdd59b2a1',
+      label: 'Wallet 1 (pre-funded)',
+    },
+  ]
+
+  const TABS = [
+    { value: 'overview', label: 'Overview' },
+    { value: 'stamps', label: 'Stamps' },
+  ]
+  let activeTab = $state('overview')
+
+  // ── Buy-stamp state ────────────────────────────────────────────────────────
+  let beeUrl = $state(QUEEN_API)
+  // Amount starts empty — autofilled from chain price on first load. Hardcoding
+  // a default is fragile across chain configs (each has its own price floor).
+  let stampAmount = $state('')
+  let stampDepth = $state('20')
+  let buying = $state(false)
+  let stampResult = $state<{ batchID: string; txHash: string } | undefined>(undefined)
+  let stampError = $state('')
+  let currentPrice = $state<bigint | undefined>(undefined)
+  let chainStateError = $state('')
+  let selectedSigner = $state(KNOWN_SIGNERS[0].value)
+
+  // ── Bee-node stamp listing ──────────────────────────────────────────────────
+  let beeStamps = $state<BeeStamp[]>([])
+  let beeStampsLoading = $state(false)
+  let beeStampsError = $state('')
+  let lastBeeUrl = $state('')
+
+  // ── Assign-to-account state ─────────────────────────────────────────────────
+  // Empty string = no selection (matches the Select component's string value).
+  let selectedStampId = $state('')
+  let selectedAccountId = $state('')
+  let useCustomSigner = $state(false)
+  let customSignerKey = $state('')
+  let assignMessage = $state('')
+  let assignError = $state('')
+
+  const customSignerError = $derived.by(() => {
+    if (!useCustomSigner) {
+      return undefined
+    }
+    if (customSignerKey.length === 0) {
+      return 'Custom signer key is required'
+    }
+    if (!/^[0-9a-fA-F]+$/.test(customSignerKey)) {
+      return 'Signer key must be a valid hex string'
+    }
+    if (customSignerKey.length !== SIGNER_KEY_LENGTH) {
+      return `Signer key must be exactly ${SIGNER_KEY_LENGTH} hex characters`
+    }
+    return undefined
+  })
+
+  // ── Overview counts ──────────────────────────────────────────────────────────
+  const accountCount = $derived(accountsStore.accounts.length)
+  const stampCount = $derived(
+    accountsStore.accounts.reduce((total, account) => total + account.stamps.length, 0),
+  )
+  const connectionCount = $derived(
+    accountsStore.accounts.reduce((total, account) => total + account.connectedApps.length, 0),
+  )
+
+  // ── Derived options ──────────────────────────────────────────────────────────
+  const stampOptions = $derived(
+    beeStamps.map((stamp) => ({
+      value: stamp.batchID,
+      label: `${stamp.batchID.slice(0, BATCH_ID_PREVIEW)}… (depth ${stamp.depth})`,
+    })),
+  )
+  const accountOptions = $derived(
+    accountsStore.accounts.map((account) => ({
+      value: account.id,
+      label: `${account.name} (${truncateAddress(account.id)})`,
+    })),
+  )
+  const selectedAccount = $derived(
+    selectedAccountId ? accountsStore.get(selectedAccountId) : undefined,
+  )
+
+  // batchId → which account holds it (and whether it is that account's default).
+  const stampAssignments = $derived.by(() => {
+    const map = new SvelteMap<string, string>()
+    for (const account of accountsStore.accounts) {
+      for (const stamp of account.stamps) {
+        const isDefault = account.defaultStampBatchId === stamp.batchId
+        map.set(stamp.batchId, isDefault ? `${account.name} (default)` : account.name)
+      }
+    }
+    return map
+  })
+
+  // Keep the selected stamp/account valid as the underlying lists change.
+  $effect(() => {
+    if (stampOptions.length && !stampOptions.some((option) => option.value === selectedStampId)) {
+      selectedStampId = stampOptions[0].value
+    } else if (stampOptions.length === 0) {
+      selectedStampId = ''
+    }
+  })
+  $effect(() => {
+    if (
+      accountOptions.length &&
+      !accountOptions.some((option) => option.value === selectedAccountId)
+    ) {
+      selectedAccountId = accountOptions[0].value
+    } else if (accountOptions.length === 0) {
+      selectedAccountId = ''
+    }
+  })
+
+  // Load node stamps + chain price the first time the Stamps tab opens (and
+  // whenever the bee URL changes).
+  $effect(() => {
+    if (activeTab === 'stamps' && beeUrl && beeUrl !== lastBeeUrl && !beeStampsLoading) {
+      loadBeeStamps()
+      loadChainState()
+    }
+  })
+
+  async function loadBeeStamps() {
+    beeStampsLoading = true
+    beeStampsError = ''
+    try {
+      beeStamps = await beeDev.fetchStamps(beeUrl)
+      lastBeeUrl = beeUrl
+    } catch (error) {
+      beeStampsError = error instanceof Error ? error.message : String(error)
+      beeStamps = []
+    } finally {
+      beeStampsLoading = false
+    }
+  }
+
+  async function loadChainState() {
+    chainStateError = ''
+    try {
+      const state = await fetchChainState(beeUrl)
+      currentPrice = state.currentPrice
+      // Only autofill while the field is untouched; after that the user owns it.
+      if (stampAmount === '') {
+        stampAmount = calculateStampAmountForDays(state.currentPrice, DEFAULT_STAMP_DAYS).toString()
+      }
+    } catch (error) {
+      chainStateError = error instanceof Error ? error.message : String(error)
+      currentPrice = undefined
+    }
+  }
+
+  async function buyStamp() {
+    buying = true
+    stampError = ''
+    stampResult = undefined
+    try {
+      stampResult = await beeDev.buyStamp(beeUrl, stampAmount, stampDepth)
+      // Reflect the freshly bought batch in the list without a manual refresh.
+      await loadBeeStamps()
+    } catch (error) {
+      stampError = error instanceof Error ? error.message : String(error)
+    } finally {
+      buying = false
+    }
+  }
+
+  function assignStamp() {
+    assignError = ''
+    assignMessage = ''
+    if (!selectedStampId || !selectedAccountId) {
+      assignError = 'Select a stamp and an account first.'
+      return
+    }
+    if (useCustomSigner && customSignerError) {
+      assignError = customSignerError
+      return
+    }
+
+    const beeStamp = beeStamps.find((stamp) => stamp.batchID === selectedStampId)
+    if (!beeStamp) {
+      assignError = 'Stamp data not found. Reload stamps first.'
+      return
+    }
+
+    const signerKey = useCustomSigner ? customSignerKey.toLowerCase() : selectedSigner
+    const stamp: PostageStamp = {
+      batchId: beeStamp.batchID,
+      signerKey,
+      depth: beeStamp.depth,
+      amount: beeStamp.amount,
+      bucketDepth: beeStamp.bucketDepth,
+      blockNumber: beeStamp.blockNumber,
+      immutableFlag: beeStamp.immutableFlag,
+      utilization: Utils.getStampUsage(beeStamp.utilization, beeStamp.depth, beeStamp.bucketDepth),
+      usable: beeStamp.usable,
+      exists: beeStamp.exists,
+      batchTTL: beeStamp.batchTTL,
+      createdAt: Date.now(),
+    }
+    accountsStore.addStamp(selectedAccountId, stamp)
+    accountsStore.setDefaultStamp(selectedAccountId, beeStamp.batchID)
+    assignMessage = `Assigned stamp to ${truncateAddress(selectedAccountId)} and set as default.`
+  }
+
+  function removeStamp() {
+    assignError = ''
+    assignMessage = ''
+    if (!selectedStampId || !selectedAccountId) {
+      assignError = 'Select a stamp and an account first.'
+      return
+    }
+    accountsStore.removeStamp(selectedAccountId, selectedStampId)
+    assignMessage = `Removed stamp from ${truncateAddress(selectedAccountId)}.`
+  }
+
+  function clearAllData() {
+    if (!confirm('Delete all accounts, stamps and connections on this device?')) {
+      return
+    }
+    accountsStore.clear()
+    removeAllSharedAccountRecords()
+    sessionStore.clearCurrentAccount()
+  }
+
+  const connectUrl = $derived(
+    `${resolve(routes.CONNECT)}#origin=${encodeURIComponent(DEMO_ORIGIN)}&appName=Demo`,
+  )
+</script>
+
+<!--
+  All <a> links on this dev page are intentionally non-router targets: external
+  Bee/RPC endpoints (open in a new tab) and the connect popup's hash-encoded
+  request. Internal navigation uses <Button href={resolve(...)}> instead.
+-->
+<!-- eslint-disable svelte/no-navigation-without-resolve -->
+<div class="flex min-h-svh flex-col">
+  <AppHeader />
+
+  <main class="flex w-full flex-1 flex-col items-center px-8 pb-16">
+    <div class="flex w-full max-w-2xl flex-col gap-6">
+      <h1 class="text-lg font-bold">Developer Tools</h1>
+
+      <Tabs tabs={TABS} bind:value={activeTab} />
+
+      {#if activeTab === 'overview'}
+        <section class="flex flex-col gap-3">
+          <h2 class="text-sm font-bold">Local Bee endpoints</h2>
+          {#each ENDPOINTS as endpoint (endpoint.url)}
+            <div class="flex items-center gap-2 text-sm">
+              <StatusDot endpoint={endpoint.url} probe={endpoint.probe} />
+              <span class="text-muted-foreground w-28 shrink-0">{endpoint.label}</span>
+              <a
+                href={endpoint.url}
+                target="_blank"
+                rel="noopener"
+                class="text-primary font-mono underline-offset-4 hover:underline"
+              >
+                {endpoint.url}
+              </a>
+              <CopyButton text={endpoint.url} />
+            </div>
+          {/each}
+        </section>
+
+        <section class="flex flex-col gap-3">
+          <h2 class="text-sm font-bold">Test connect flow</h2>
+          <p class="text-muted-foreground text-sm">
+            Open the connect popup for the local demo app.
+          </p>
+          <div class="flex items-center gap-2 text-sm">
+            <StatusDot endpoint={DEMO_ORIGIN} />
+            <a href={connectUrl} class="text-primary font-mono underline-offset-4 hover:underline">
+              {DEMO_ORIGIN} (demo)
+            </a>
+            <CopyButton text={connectUrl} />
+          </div>
+        </section>
+
+        <section class="flex flex-col items-start gap-3">
+          <h2 class="text-sm font-bold">Local data</h2>
+          <p class="text-sm">
+            {accountCount} accounts · {stampCount} stamps · {connectionCount} connections
+          </p>
+          <Button variant="destructive" onclick={clearAllData}>Clear all data</Button>
+        </section>
+      {:else if activeTab === 'stamps'}
+        <section class="flex flex-col gap-3">
+          <h2 class="text-sm font-bold">Buy postage stamp</h2>
+          <p class="text-muted-foreground text-sm">
+            Buy a stamp on the local chain for testing uploads.
+          </p>
+
+          <label class="flex flex-col gap-1.5 text-sm">
+            <span class="text-muted-foreground">Bee node URL</span>
+            <Input bind:value={beeUrl} />
+          </label>
+
+          <div class="flex gap-3">
+            <label class="flex flex-1 flex-col gap-1.5 text-sm">
+              <span class="text-muted-foreground">Amount</span>
+              <Input bind:value={stampAmount} />
+            </label>
+            <label class="flex w-28 flex-col gap-1.5 text-sm">
+              <span class="text-muted-foreground">Depth (17–40)</span>
+              <Input bind:value={stampDepth} />
+            </label>
+          </div>
+
+          {#if currentPrice !== undefined}
+            {@const minAmount = calculateStampAmountForDays(currentPrice, 1)}
+            <p class="text-muted-foreground text-xs">
+              Chain price: {currentPrice.toLocaleString()} PLUR/chunk/block · 24h min: {minAmount.toLocaleString()}
+              PLUR · default fills {DEFAULT_STAMP_DAYS}d
+            </p>
+          {:else if chainStateError}
+            <p class="text-destructive text-xs">Could not fetch chainstate: {chainStateError}</p>
+          {/if}
+
+          <label class="flex flex-col gap-1.5 text-sm">
+            <span class="text-muted-foreground">Signer key</span>
+            <Select options={KNOWN_SIGNERS} bind:value={selectedSigner} />
+          </label>
+
+          <Button class="self-start" disabled={buying || !stampAmount} onclick={buyStamp}>
+            {#if buying}
+              <LoaderCircle class="animate-spin" />
+            {/if}
+            {buying ? 'Buying…' : 'Buy stamp'}
+          </Button>
+
+          {#if stampResult}
+            <div class="bg-card flex flex-col gap-3 rounded-lg border p-4">
+              <p class="text-success text-sm font-medium">Stamp purchased</p>
+              {#each [{ label: 'Batch ID', value: stampResult.batchID }, { label: 'Amount', value: stampAmount }, { label: 'Depth', value: stampDepth }, { label: 'Signer key', value: selectedSigner }, { label: 'Tx hash', value: stampResult.txHash }] as field (field.label)}
+                <div class="flex flex-col gap-1">
+                  <span class="text-muted-foreground text-xs">{field.label}</span>
+                  <div class="flex items-center gap-1.5">
+                    <span class="font-mono text-xs break-all">{field.value}</span>
+                    <CopyButton text={field.value} />
+                  </div>
+                </div>
+              {/each}
+              <p class="text-muted-foreground text-xs">Wait ~30s for the stamp to become usable.</p>
+            </div>
+          {/if}
+
+          {#if stampError}
+            <p class="text-destructive text-sm">{stampError}</p>
+          {/if}
+        </section>
+
+        <div class="bg-border h-px w-full"></div>
+
+        <section class="flex flex-col gap-3">
+          <div class="flex items-center justify-between">
+            <h2 class="text-sm font-bold">Stamps on the Bee node</h2>
+            <Button variant="outline" disabled={beeStampsLoading} onclick={loadBeeStamps}>
+              {#if beeStampsLoading}
+                <LoaderCircle class="animate-spin" />
+              {/if}
+              Refresh
+            </Button>
+          </div>
+
+          {#if beeStampsError}
+            <p class="text-destructive text-sm">{beeStampsError}</p>
+          {/if}
+
+          {#if beeStamps.length === 0}
+            <p class="text-muted-foreground text-sm">No stamps found on the Bee node.</p>
+          {:else}
+            <div class="flex flex-col gap-2">
+              {#each beeStamps as stamp (stamp.batchID)}
+                <div class="bg-card flex flex-col gap-1 rounded-lg border p-3">
+                  <div class="flex items-center gap-1.5">
+                    <span class="font-mono text-xs break-all">{stamp.batchID}</span>
+                    <CopyButton text={stamp.batchID} />
+                  </div>
+                  <div class="text-muted-foreground flex flex-wrap gap-x-4 text-xs">
+                    <span>Depth: {stamp.depth}</span>
+                    <span>Usable: {stamp.usable ? 'yes' : 'no'}</span>
+                    <span>Assigned: {stampAssignments.get(stamp.batchID) ?? '—'}</span>
+                  </div>
+                </div>
+              {/each}
+            </div>
+          {/if}
+        </section>
+
+        <div class="bg-border h-px w-full"></div>
+
+        <section class="flex flex-col gap-3">
+          <h2 class="text-sm font-bold">Assign stamp to account</h2>
+
+          {#if accountOptions.length === 0}
+            <p class="text-muted-foreground text-sm">Create an account first to assign a stamp.</p>
+          {:else if stampOptions.length === 0}
+            <p class="text-muted-foreground text-sm">No stamps on the node to assign yet.</p>
+          {:else}
+            <label class="flex flex-col gap-1.5 text-sm">
+              <span class="text-muted-foreground">Stamp</span>
+              <Select options={stampOptions} bind:value={selectedStampId} />
+            </label>
+            <label class="flex flex-col gap-1.5 text-sm">
+              <span class="text-muted-foreground">Account</span>
+              <Select options={accountOptions} bind:value={selectedAccountId} />
+            </label>
+
+            <label class="flex items-center gap-2 text-sm">
+              <input type="checkbox" bind:checked={useCustomSigner} />
+              Use custom signer key
+            </label>
+            {#if useCustomSigner}
+              <label class="flex flex-col gap-1.5 text-sm">
+                <span class="text-muted-foreground">Custom signer key</span>
+                <Input bind:value={customSignerKey} aria-invalid={!!customSignerError} />
+                {#if customSignerError}
+                  <span class="text-destructive text-xs">{customSignerError}</span>
+                {/if}
+              </label>
+            {/if}
+
+            <div class="flex gap-2">
+              <Button disabled={useCustomSigner && !!customSignerError} onclick={assignStamp}>
+                Assign and set default
+              </Button>
+              <Button
+                variant="destructive"
+                disabled={!selectedAccount?.stamps.some((s) => s.batchId === selectedStampId)}
+                onclick={removeStamp}
+              >
+                Remove from account
+              </Button>
+            </div>
+
+            {#if assignMessage}
+              <p class="text-success text-sm">{assignMessage}</p>
+            {/if}
+            {#if assignError}
+              <p class="text-destructive text-sm">{assignError}</p>
+            {/if}
+          {/if}
+        </section>
+      {/if}
+    </div>
+  </main>
+</div>

--- a/ui/src/routes/dev/+page.svelte
+++ b/ui/src/routes/dev/+page.svelte
@@ -226,7 +226,8 @@
   function assignStamp() {
     assignError = ''
     assignMessage = ''
-    if (!selectedStampId || !selectedAccountId) {
+    const account = selectedAccount
+    if (!selectedStampId || !account) {
       assignError = 'Select a stamp and an account first.'
       return
     }
@@ -256,20 +257,21 @@
       batchTTL: beeStamp.batchTTL,
       createdAt: Date.now(),
     }
-    accountsStore.addStamp(selectedAccountId, stamp)
-    accountsStore.setDefaultStamp(selectedAccountId, beeStamp.batchID)
-    assignMessage = `Assigned stamp to ${truncateAddress(selectedAccountId)} and set as default.`
+    account.addStamp(stamp)
+    account.setDefaultStamp(beeStamp.batchID)
+    assignMessage = `Assigned stamp to ${truncateAddress(account.id)} and set as default.`
   }
 
   function removeStamp() {
     assignError = ''
     assignMessage = ''
-    if (!selectedStampId || !selectedAccountId) {
+    const account = selectedAccount
+    if (!selectedStampId || !account) {
       assignError = 'Select a stamp and an account first.'
       return
     }
-    accountsStore.removeStamp(selectedAccountId, selectedStampId)
-    assignMessage = `Removed stamp from ${truncateAddress(selectedAccountId)}.`
+    account.removeStamp(selectedStampId)
+    assignMessage = `Removed stamp from ${truncateAddress(account.id)}.`
   }
 
   function clearAllData() {

--- a/ui/src/routes/dev/bee.ts
+++ b/ui/src/routes/dev/bee.ts
@@ -1,0 +1,89 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Raw Bee-node operations used only by the developer tools (`/dev`). These talk
+ * to a local Bee node directly rather than through the proxy, so they live
+ * outside the account store — they read and mutate node state, not account
+ * state. The page records the resulting stamps on the account via
+ * `accountsStore`.
+ */
+
+/** A postage batch as returned by Bee's `GET /stamps`. */
+export interface BeeStamp {
+  batchID: string
+  utilization: number
+  usable: boolean
+  label: string
+  depth: number
+  amount: string
+  bucketDepth: number
+  blockNumber: number
+  immutableFlag: boolean
+  exists: boolean
+  batchTTL: number
+}
+
+export interface BoughtStamp {
+  batchID: string
+  txHash: string
+}
+
+/** How a `checkEndpoint` probe is performed for a given service. */
+export type EndpointProbe = 'head' | 'json-rpc'
+
+async function readError(response: Response): Promise<string> {
+  const text = await response.text()
+  return text || `HTTP ${response.status}`
+}
+
+export const beeDev = {
+  /**
+   * Liveness probe for a local service. HTTP services answer a no-cors HEAD
+   * (opaque but resolves when reachable); the JSON-RPC node answers an
+   * `eth_blockNumber` call. Returns whether the endpoint responded.
+   */
+  async checkEndpoint(endpoint: string, probe: EndpointProbe = 'head'): Promise<boolean> {
+    try {
+      if (probe === 'json-rpc') {
+        const response = await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ jsonrpc: '2.0', method: 'eth_blockNumber', params: [], id: 1 }),
+        })
+        return response.ok
+      }
+      await fetch(endpoint, { method: 'HEAD', mode: 'no-cors' })
+      return true
+    } catch {
+      return false
+    }
+  },
+
+  /** List the postage batches the Bee node knows about. */
+  async fetchStamps(beeUrl: string): Promise<BeeStamp[]> {
+    const response = await fetch(`${beeUrl}/stamps`)
+    if (!response.ok) {
+      throw new Error(await readError(response))
+    }
+    const data = (await response.json()) as { stamps?: BeeStamp[] }
+    return data.stamps ?? []
+  },
+
+  /**
+   * Buy a MUTABLE postage batch on the local chain. Bee defaults to immutable,
+   * but the multi-device partition scheme rewrites the partition-lock SOC on
+   * every lease refresh, which an immutable batch forbids — so request mutable
+   * explicitly. Returns immediately (no wait-for-usable); the batch needs ~30s
+   * before it can stamp uploads.
+   */
+  async buyStamp(beeUrl: string, amount: string, depth: string): Promise<BoughtStamp> {
+    const response = await fetch(`${beeUrl}/stamps/${amount}/${depth}`, {
+      method: 'POST',
+      headers: { immutable: 'false' },
+    })
+    if (!response.ok) {
+      throw new Error(await readError(response))
+    }
+    return (await response.json()) as BoughtStamp
+  },
+}

--- a/ui/src/routes/dev/copy-button.svelte
+++ b/ui/src/routes/dev/copy-button.svelte
@@ -1,0 +1,42 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<script lang="ts">
+  import Check from '@lucide/svelte/icons/check'
+  import Copy from '@lucide/svelte/icons/copy'
+
+  import { Button } from '$lib/components/ui/button'
+  import { copyToClipboard } from '$lib/utils'
+
+  const COPIED_RESET_MS = 1500
+
+  let { text }: { text: string } = $props()
+
+  let copied = $state(false)
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  async function copy() {
+    if (!(await copyToClipboard(text))) {
+      return
+    }
+    copied = true
+    clearTimeout(timer)
+    timer = setTimeout(() => (copied = false), COPIED_RESET_MS)
+  }
+</script>
+
+<Button
+  variant="ghost"
+  size="icon"
+  class="size-6 [&_svg]:size-3.5"
+  aria-label="Copy"
+  onclick={copy}
+>
+  {#if copied}
+    <Check class="text-success" />
+  {:else}
+    <Copy />
+  {/if}
+</Button>

--- a/ui/src/routes/dev/status-dot.svelte
+++ b/ui/src/routes/dev/status-dot.svelte
@@ -1,0 +1,38 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<script lang="ts">
+  import { onMount } from 'svelte'
+
+  import { cn } from '$lib/utils'
+
+  import { type EndpointProbe, beeDev } from './bee'
+
+  const CHECK_INTERVAL_MS = 10_000
+
+  type Status = 'online' | 'offline' | 'checking'
+
+  let { endpoint, probe = 'head' }: { endpoint: string; probe?: EndpointProbe } = $props()
+
+  let status = $state<Status>('checking')
+
+  const COLORS: Record<Status, string> = {
+    online: 'bg-success',
+    offline: 'bg-destructive',
+    checking: 'bg-muted-foreground animate-pulse',
+  }
+
+  async function check() {
+    status = (await beeDev.checkEndpoint(endpoint, probe)) ? 'online' : 'offline'
+  }
+
+  onMount(() => {
+    check()
+    const interval = setInterval(check, CHECK_INTERVAL_MS)
+    return () => clearInterval(interval)
+  })
+</script>
+
+<span class={cn('inline-block size-2 shrink-0 rounded-full', COLORS[status])} title={status}></span>

--- a/ui/src/routes/home/+page.svelte
+++ b/ui/src/routes/home/+page.svelte
@@ -20,7 +20,7 @@
 
   const TABS = [
     { value: 'apps', label: 'Apps' },
-    { value: 'stamps', label: 'Stamps' },
+    { value: 'drives', label: 'Drives' },
     { value: 'account', label: 'Account' },
   ]
 
@@ -56,9 +56,9 @@
         {#key account.id}
           {#if tab === 'apps'}
             <HomeApps {account} />
-          {:else if tab === 'stamps'}
+          {:else if tab === 'drives'}
             <p class="text-muted-foreground py-8 text-center text-sm">
-              Postage stamp management is coming soon.
+              Drive management is coming soon.
             </p>
           {:else}
             <HomeAccount {account} />


### PR DESCRIPTION
Adds the developer tools page to the new `ui/` package, plus two supporting refactors it surfaced. Three commits, each self-contained.

## 1. Developer tools page (`/dev`)

Ports the legacy dev page into `ui/`, adapted to the new **nested single-level account model** (the `Account` aggregate owns its drives and connected apps inline — no separate identities/stamps/sync stores). Reachable at `http://localhost:5500/dev`. Two fully-working tabs, no mocks:

**Overview**
- Live status dots for the local Bee endpoints (Queen `:1633`, Worker `:16331`, Blockchain RPC `:9545`) + the demo origin.
- "Test connect flow" link to the demo (hash-encoded connect request, `:3500`).
- Local-data counts and a **Clear all data** action (also de-authenticates dApp proxy iframes via `removeAllSharedAccountRecords()`).

**Stamps**
- Buy a **mutable** postage stamp on the local chain (amount autofilled from chain price; mutable so the multi-device partition-lock SOC can be rewritten).
- List the node's stamps, showing which account holds each as a drive (and which is default).
- Assign a node stamp to an account as a **drive** (records the signer key, sets it default), with a custom-signer option and remove-from-account.

Dev-only code is colocated under `ui/src/routes/dev/` (`+page.svelte`, `bee.ts` Bee-node I/O helper, `copy-button.svelte`, `status-dot.svelte`).

_Intentionally omitted:_ the legacy **Sync** and **Devices** tabs — the new model has no identities or multi-device/sync subsystem wired in yet, so they'd be non-functional mock UI.

## 2. `Account` is a rich reactive object that owns its mutations

Per-account state changes are methods **on the account object** (`account.addDrive(drive)`, `account.rename(name)`, …) instead of store methods that take an id and look the account up.

- `Account` becomes a reactive class (`$state` fields) that persists itself via an injected `onChange`; `accountsStore` is now just the collection — `accounts`, `get(id)`, `add(record)` (returns the live instance), `remove(id)`, `clear()`.
- Types split in `$lib/types`: `AccountData` (portable, no secrets) and `AccountRecord` (data + access/encryptedSeed) are standalone interfaces; the `Account` class type is **type-only re-exported** so `$lib/types` stays the type entry point with no runtime cycle.
- The class carries a private `#onChange` (making it nominal), so `createBackup` — which only reads portable fields — takes `AccountData`.
- Call sites updated to the object form: `home-account`, `home-apps`, `connect-handshake`, account creation, dev page.

Reactivity confirmed: `$state` class fields re-render readers on mutation, independent of the `accounts` array.

## 3. Rename the account storage concept "stamp" → "drive"

"Drive" is the product term for an account's owned Swarm storage (backed by a postage stamp batch).

- **Domain → drive:** `PostageStamp`→`Drive`, `account.stamps`→`account.drives`, `defaultStampBatchId`→`defaultDriveBatchId`, `addStamp/removeStamp/setDefaultStamp`→`addDrive/removeDrive/setDefaultDrive`, plus UI copy (home "Drives" tab, "Add a drive", dev "Assign drive to account" / "N drives").
- **Kept as stamp (Bee-node layer / wire):** the dev page's buy-stamp & "Stamps on the Bee node" sections, `routes/dev/bee.ts` (`BeeStamp`/`fetchStamps`/`buyStamp`), the `/stamps` endpoint, bee-js `BatchId`, and the lib shared-record fields (`SharedPostageStamp`/`defaultPostageStampBatchID`/`postageStamps`).
- **Migration:** the persisted shape changed, so `accounts.svelte.ts` `load()` has a `normalize()` shim that accepts either spelling; existing local accounts survive and are rewritten in the new shape on the next persist.

## Verification

- `pnpm check:all` (full monorepo) passes — lint, `svelte-check` (0 errors/0 warnings for `@swarm-id/ui`), knip; 24 unit tests pass (incl. backup round-trip).
- End-to-end against a local `bee-compose` cluster: buy → list → assign → remove → clear; rich-object mutations persist and re-render; a **legacy-shaped** account migrates cleanly (loads as drives, rewrites in the new shape on mutation). No console errors.

> Note for reviewers: the new `ui` typechecks against `lib/dist`, so run `pnpm build:lib` after pulling if `svelte-check` reports phantom missing-export errors. The dev tab is still labeled "Stamps" since it's mostly Bee-stamp tooling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)