### PR TITLE
feat(ui): developer tools page on a single Zod-validated account model

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -170,6 +170,7 @@ export {
   PasskeyBackupHeaderSchemaV1,
   EthereumBackupHeaderSchemaV1,
   AgentBackupHeaderSchemaV1,
+  LocalBackupHeaderSchemaV1,
   EncryptedSwarmIdExportSchemaV1,
 } from "./utils/backup-encryption"
 
@@ -177,6 +178,7 @@ export type {
   PasskeyBackupHeader,
   EthereumBackupHeader,
   AgentBackupHeader,
+  LocalBackupHeader,
   EncryptedSwarmIdExport,
   BackupHeaderWithoutCiphertext,
   ParseHeaderResult,
@@ -326,6 +328,8 @@ export type {
   PasskeyAccount,
   EthereumAccount,
   AgentAccount,
+  LocalAccount,
+  AccessMethod,
   ConnectedApp,
   PostageStamp,
   AccountMetadata,
@@ -338,6 +342,9 @@ export {
   DEFAULT_BEE_NODE_URL,
   DEFAULT_GNOSIS_RPC_URL,
   NetworkSettingsSchemaV1,
+  AccountSchemaV1,
+  LocalAccountSchemaV1,
+  AccessMethodSchemaV1,
 } from "./schemas"
 
 // Base validation schemas and types

--- a/lib/src/schemas.ts
+++ b/lib/src/schemas.ts
@@ -243,12 +243,50 @@ export const AgentAccountSchemaV1 = CommonAccountSchemaV1.extend({
 })
 
 /**
+ * Access Method Schema V1
+ *
+ * How a `local` account's encrypted seed is unlocked on this device. Mirrors
+ * the identity UI's access methods. Fields are device-local crypto material
+ * (plain hex / numbers) — never bee-js byte classes — so they round-trip as-is.
+ */
+export const AccessMethodSchemaV1 = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("passkey"), credentialId: z.string() }),
+  z.object({
+    type: z.literal("eth-wallet"),
+    walletAddress: z.string(),
+    encryptionSalt: z.string(),
+  }),
+  z.object({
+    type: z.literal("password"),
+    kdfSalt: z.string(),
+    kdfIterations: z.number(),
+  }),
+])
+
+/**
+ * Local Account Schema V1
+ *
+ * A device-local account whose BIP-39 entropy is encrypted at rest with a
+ * device-local access method (passkey / eth-wallet / password). This is the
+ * model the identity UI (`@swarm-id/ui`) creates and unlocks. Like every
+ * account it carries a `derivationKey` (computed from the master key at
+ * creation time); the seed itself is held only as `encryptedSeed`.
+ */
+export const LocalAccountSchemaV1 = CommonAccountSchemaV1.extend({
+  type: z.literal("local"),
+  access: AccessMethodSchemaV1,
+  // BIP-39 entropy encrypted with the access-method key (hex: IV || ciphertext).
+  encryptedSeed: z.string(),
+})
+
+/**
  * Account Schema V1 (discriminated union)
  */
 export const AccountSchemaV1 = z.discriminatedUnion("type", [
   PasskeyAccountSchemaV1,
   EthereumAccountSchemaV1,
   AgentAccountSchemaV1,
+  LocalAccountSchemaV1,
 ])
 
 // ============================================================================
@@ -308,6 +346,8 @@ export type Device = z.infer<typeof DeviceSchemaV1>
 export type PasskeyAccount = z.infer<typeof PasskeyAccountSchemaV1>
 export type EthereumAccount = z.infer<typeof EthereumAccountSchemaV1>
 export type AgentAccount = z.infer<typeof AgentAccountSchemaV1>
+export type LocalAccount = z.infer<typeof LocalAccountSchemaV1>
+export type AccessMethod = z.infer<typeof AccessMethodSchemaV1>
 export type Account = z.infer<typeof AccountSchemaV1>
 export type ConnectedApp = z.infer<typeof ConnectedAppSchemaV1>
 export type PostageStamp = z.infer<typeof PostageStampSchemaV1>

--- a/lib/src/test-fixtures.ts
+++ b/lib/src/test-fixtures.ts
@@ -10,6 +10,7 @@ import type {
   PasskeyAccount,
   EthereumAccount,
   AgentAccount,
+  LocalAccount,
   ConnectedApp,
   PostageStamp,
 } from "./schemas"
@@ -79,6 +80,24 @@ export function createAgentAccount(
     name: "Test Agent Account",
     createdAt: 1700000000000,
     type: "agent" as const,
+    derivationKey: TEST_DERIVATION_KEY_HEX,
+    devices: [],
+    connectedApps: [],
+    postageStamps: [],
+    ...overrides,
+  }
+}
+
+export function createLocalAccount(
+  overrides?: Partial<LocalAccount>,
+): LocalAccount {
+  return {
+    id: new EthAddress(TEST_ETH_ADDRESS_HEX),
+    name: "Test Local Account",
+    createdAt: 1700000000000,
+    type: "local" as const,
+    access: { type: "password", kdfSalt: "00", kdfIterations: 100000 },
+    encryptedSeed: "aabbccdd",
     derivationKey: TEST_DERIVATION_KEY_HEX,
     devices: [],
     connectedApps: [],

--- a/lib/src/utils/backup-encryption.test.ts
+++ b/lib/src/utils/backup-encryption.test.ts
@@ -21,6 +21,7 @@ import {
   createPasskeyAccount,
   createEthereumAccount,
   createAgentAccount,
+  createLocalAccount,
   createConnectedApp,
   createPostageStamp,
 } from "../test-fixtures"
@@ -105,6 +106,27 @@ describe("round-trip: encrypt → decrypt for each account type", () => {
     if (!result.success) return
 
     expect(result.data.metadata.accountName).toBe("Test Agent Account")
+  })
+
+  it("should round-trip a local account", async () => {
+    const account = createLocalAccount()
+
+    const encrypted = await createEncryptedExport(
+      account,
+      TEST_DERIVATION_KEY_HEX,
+    )
+
+    expect(encrypted.accountType).toBe("local")
+
+    const result = await decryptEncryptedExport(
+      encrypted,
+      TEST_DERIVATION_KEY_HEX,
+    )
+
+    expect(result.success).toBe(true)
+    if (!result.success) return
+
+    expect(result.data.metadata.accountName).toBe("Test Local Account")
   })
 
   it("should survive JSON serialization (file I/O simulation)", async () => {
@@ -263,6 +285,16 @@ describe("buildBackupHeader", () => {
     expect(header).not.toHaveProperty("ethereumAddress")
     expect(header).not.toHaveProperty("encryptedMasterKey")
     expect(header).not.toHaveProperty("encryptionSalt")
+  })
+
+  it("should carry no key material for local accounts", () => {
+    const header = buildBackupHeader(createLocalAccount())
+
+    expect(header.accountType).toBe("local")
+    // Device-local access material must never leave in the plaintext header.
+    expect(header).not.toHaveProperty("access")
+    expect(header).not.toHaveProperty("encryptedSeed")
+    expect(header).not.toHaveProperty("credentialId")
   })
 })
 

--- a/lib/src/utils/backup-encryption.ts
+++ b/lib/src/utils/backup-encryption.ts
@@ -65,12 +65,22 @@ export const AgentBackupHeaderSchemaV1 = BackupHeaderBaseSchemaV1.extend({
   accountType: z.literal("agent"),
 })
 
+/**
+ * Local account backup header. Like the agent header, it carries no key
+ * material: the seed is re-entered (or re-derived from the recovery phrase) on
+ * import, so only the account name + timestamp travel in plaintext.
+ */
+export const LocalBackupHeaderSchemaV1 = BackupHeaderBaseSchemaV1.extend({
+  accountType: z.literal("local"),
+})
+
 export const EncryptedSwarmIdExportSchemaV1 = z.discriminatedUnion(
   "accountType",
   [
     PasskeyBackupHeaderSchemaV1,
     EthereumBackupHeaderSchemaV1,
     AgentBackupHeaderSchemaV1,
+    LocalBackupHeaderSchemaV1,
   ],
 )
 
@@ -81,6 +91,7 @@ export const EncryptedSwarmIdExportSchemaV1 = z.discriminatedUnion(
 export type PasskeyBackupHeader = z.infer<typeof PasskeyBackupHeaderSchemaV1>
 export type EthereumBackupHeader = z.infer<typeof EthereumBackupHeaderSchemaV1>
 export type AgentBackupHeader = z.infer<typeof AgentBackupHeaderSchemaV1>
+export type LocalBackupHeader = z.infer<typeof LocalBackupHeaderSchemaV1>
 export type EncryptedSwarmIdExport = z.infer<
   typeof EncryptedSwarmIdExportSchemaV1
 >
@@ -178,6 +189,7 @@ export type BackupHeaderWithoutCiphertext =
   | Omit<PasskeyBackupHeader, "ciphertext">
   | Omit<EthereumBackupHeader, "ciphertext">
   | Omit<AgentBackupHeader, "ciphertext">
+  | Omit<LocalBackupHeader, "ciphertext">
 
 export function buildBackupHeader(
   account: Account,
@@ -202,6 +214,11 @@ export function buildBackupHeader(
       accountType: "ethereum" as const,
       ethereumAddress: account.ethereumAddress.toHex(),
     }
+  }
+
+  if (account.type === "local") {
+    // No key material — the seed is re-entered/derived on import (like agent).
+    return { ...base, accountType: "local" as const }
   }
 
   // agent — no extra fields

--- a/lib/src/utils/storage-managers.test.ts
+++ b/lib/src/utils/storage-managers.test.ts
@@ -1,0 +1,64 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest"
+import { BatchId, PrivateKey } from "@ethersphere/bee-js"
+import { serializeAccount } from "./storage-managers"
+import { AccountSchemaV1 } from "../schemas"
+import {
+  TEST_BATCH_ID_HEX,
+  TEST_PRIVATE_KEY_HEX,
+  createLocalAccount,
+  createPostageStamp,
+} from "../test-fixtures"
+
+describe("serializeAccount — local variant", () => {
+  it("round-trips a local account through serialize + Zod parse", () => {
+    const account = createLocalAccount({
+      access: { type: "passkey", credentialId: "cred-xyz" },
+      encryptedSeed: "0011223344",
+      defaultPostageStampBatchID: new BatchId(TEST_BATCH_ID_HEX),
+      postageStamps: [
+        createPostageStamp({
+          batchID: new BatchId(TEST_BATCH_ID_HEX),
+          signerKey: new PrivateKey(TEST_PRIVATE_KEY_HEX),
+        }),
+      ],
+    })
+
+    const serialized = serializeAccount(account)
+
+    // Survives a JSON file round-trip (no class instances leak into storage).
+    const reparsed = AccountSchemaV1.parse(
+      JSON.parse(JSON.stringify(serialized)),
+    )
+
+    expect(reparsed.type).toBe("local")
+    if (reparsed.type !== "local") return
+    expect(reparsed.access).toEqual({
+      type: "passkey",
+      credentialId: "cred-xyz",
+    })
+    expect(reparsed.encryptedSeed).toBe("0011223344")
+    expect(reparsed.id.equals(account.id)).toBe(true)
+    expect(reparsed.derivationKey).toBe(account.derivationKey)
+    expect(
+      reparsed.postageStamps[0].batchID.equals(new BatchId(TEST_BATCH_ID_HEX)),
+    ).toBe(true)
+  })
+
+  it("persists each access method shape", () => {
+    for (const access of [
+      { type: "passkey", credentialId: "c" },
+      { type: "eth-wallet", walletAddress: "0xabc", encryptionSalt: "ff" },
+      { type: "password", kdfSalt: "aa", kdfIterations: 200000 },
+    ] as const) {
+      const serialized = serializeAccount(createLocalAccount({ access }))
+      const reparsed = AccountSchemaV1.parse(
+        JSON.parse(JSON.stringify(serialized)),
+      )
+      if (reparsed.type !== "local") throw new Error("expected local")
+      expect(reparsed.access).toEqual(access)
+    }
+  })
+})

--- a/lib/src/utils/storage-managers.ts
+++ b/lib/src/utils/storage-managers.ts
@@ -87,6 +87,13 @@ export function serializeAccount(account: Account): Record<string, unknown> {
         account.encryptedSecretSeed.toUint8Array(),
       ),
     }
+  } else if (account.type === "local") {
+    // `access` is plain JSON (no byte classes); persist it and the seed as-is.
+    return {
+      ...common,
+      access: account.access,
+      encryptedSeed: account.encryptedSeed,
+    }
   } else {
     return common
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "format:lib": "pnpm --filter @snaha/swarm-id format"
   },
   "devDependencies": {
-    "@snaha/bee-compose": "^0.1.3",
+    "@snaha/bee-compose": "^0.1.5",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "concurrently": "^9.1.2",
     "prettier": "^3.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@snaha/bee-compose':
-        specifier: ^0.1.3
-        version: 0.1.3
+        specifier: ^0.1.5
+        version: 0.1.5
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^6.0.2
         version: 6.0.2(prettier-plugin-svelte@3.4.0(prettier@3.8.1)(svelte@5.48.2))(prettier@3.8.1)(svelte@5.48.2)
@@ -1916,8 +1916,8 @@ packages:
   '@sideway/pinpoint@2.0.0':
     resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
 
-  '@snaha/bee-compose@0.1.3':
-    resolution: {integrity: sha512-+ld2cXWVjnwHAE0pslplHTO8PuFxUDXwEMwB9lYYDBqcCxel4iwGKTd9MCvRHSZkJGliRRX608FYk/hk53+sbQ==}
+  '@snaha/bee-compose@0.1.5':
+    resolution: {integrity: sha512-m5A+eqD5rRDaF2RaRWJ0eHOcOsYhXLRbZN25/ydhyGEDB2wy0tNYeMVq5cBXlvWRbuHy1IsDa9MfGMCO6whrFQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6360,7 +6360,7 @@ snapshots:
 
   '@sideway/pinpoint@2.0.0': {}
 
-  '@snaha/bee-compose@0.1.3':
+  '@snaha/bee-compose@0.1.5':
     dependencies:
       commander: 12.1.0
 

--- a/swarm-ui/src/lib/utils/account-auth.ts
+++ b/swarm-ui/src/lib/utils/account-auth.ts
@@ -53,9 +53,12 @@ export async function getMasterKeyFromAccount(account: Account): Promise<Bytes> 
   } else if (account.type === 'agent') {
     // Agent accounts require the caller to collect the seed phrase via UI
     throw new SeedPhraseRequiredError(account.id.toString())
-  } else {
+  } else if (account.type === 'ethereum') {
     const signed = await connectAndSign()
     const encryptionKey = await deriveEncryptionKey(signed.publicKey, account.encryptionSalt)
     return await decryptMasterKey(account.encryptedMasterKey, encryptionKey)
+  } else {
+    // `local` accounts belong to the new UI and are never created here.
+    throw new Error('Unsupported account type for this app.')
   }
 }

--- a/swarm-ui/src/routes/(app)/connect/+page.svelte
+++ b/swarm-ui/src/routes/(app)/connect/+page.svelte
@@ -342,7 +342,7 @@
     <Typography variant="h3">Error</Typography>
     <Typography>{error}</Typography>
   </Vertical>
-{:else if isAuthenticating && selected}
+{:else if isAuthenticating && selected && selected.type !== 'local'}
   <Confirmation authenticationType={selected.type} />
 {:else if selected && authenticated}
   <Vertical --vertical-gap="var(--double-padding)" --vertical-align-items="center">

--- a/ui/src/lib/components/account-switcher.svelte
+++ b/ui/src/lib/components/account-switcher.svelte
@@ -4,6 +4,7 @@
 -->
 
 <script lang="ts">
+  import { EthAddress } from '@ethersphere/bee-js'
   import Check from '@lucide/svelte/icons/check'
 
   import Polycon from '$lib/components/polycon.svelte'
@@ -11,7 +12,7 @@
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
   import type { Account } from '$lib/types'
-  import { truncateAddress } from '$lib/utils'
+  import { display0x, truncateAddress } from '$lib/utils'
 
   const ITEM_CLASS =
     'flex h-9 w-full cursor-pointer items-center gap-2 rounded-md px-1.5 py-1 text-left text-sm outline-none hover:bg-muted focus-visible:bg-muted'
@@ -41,8 +42,8 @@
     }
   }
 
-  function switchTo(id: string) {
-    sessionStore.setCurrentAccount(id)
+  function switchTo(id: EthAddress) {
+    sessionStore.setCurrentAccount(id.toHex())
     close()
   }
 </script>
@@ -60,9 +61,11 @@
   >
     <span class="flex flex-col items-end">
       <span class="text-sm font-medium">{account.name}</span>
-      <span class="text-muted-foreground text-xs font-normal">{truncateAddress(account.id)}</span>
+      <span class="text-muted-foreground text-xs font-normal">
+        {truncateAddress(display0x(account.id))}
+      </span>
     </span>
-    <Polycon value={account.id} size={32} class="shrink-0 overflow-hidden rounded-lg" />
+    <Polycon value={account.id.toHex()} size={32} class="shrink-0 overflow-hidden rounded-lg" />
   </Button>
 
   {#if open}
@@ -72,17 +75,21 @@
       class="bg-popover text-popover-foreground absolute top-full right-0 z-50 mt-2 min-w-56 rounded-lg border p-1 shadow-md"
     >
       <div class="text-muted-foreground px-1.5 py-1 text-xs">Account</div>
-      {#each accountsStore.accounts as candidate (candidate.id)}
+      {#each accountsStore.accounts as candidate (candidate.id.toHex())}
         <button
           type="button"
           role="menuitemradio"
-          aria-checked={candidate.id === account.id}
+          aria-checked={candidate.id.equals(account.id)}
           class={ITEM_CLASS}
           onclick={() => switchTo(candidate.id)}
         >
-          <Polycon value={candidate.id} size={24} class="shrink-0 overflow-hidden rounded-md" />
+          <Polycon
+            value={candidate.id.toHex()}
+            size={24}
+            class="shrink-0 overflow-hidden rounded-md"
+          />
           <span class="flex-1 truncate whitespace-nowrap">{candidate.name}</span>
-          {#if candidate.id === account.id}
+          {#if candidate.id.equals(account.id)}
             <Check class="size-4 shrink-0" />
           {/if}
         </button>

--- a/ui/src/lib/components/copy-button.svelte
+++ b/ui/src/lib/components/copy-button.svelte
@@ -1,0 +1,35 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<script lang="ts">
+  import Check from '@lucide/svelte/icons/check'
+  import Copy from '@lucide/svelte/icons/copy'
+
+  import { Button } from '$lib/components/ui/button'
+  import { copyToClipboard } from '$lib/utils'
+
+  const FEEDBACK_DURATION_MS = 2000
+
+  let { text }: { text: string } = $props()
+
+  let copied = $state(false)
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+  async function handleCopy() {
+    const ok = await copyToClipboard(text)
+    if (!ok) return
+    copied = true
+    if (timeoutId) clearTimeout(timeoutId)
+    timeoutId = setTimeout(() => (copied = false), FEEDBACK_DURATION_MS)
+  }
+</script>
+
+<Button variant="ghost" size="xs" aria-label="Copy" onclick={handleCopy}>
+  {#if copied}
+    <Check />
+  {:else}
+    <Copy />
+  {/if}
+</Button>

--- a/ui/src/lib/components/home-account.svelte
+++ b/ui/src/lib/components/home-account.svelte
@@ -33,7 +33,6 @@
   import { Dialog } from '$lib/components/ui/dialog'
   import { Input } from '$lib/components/ui/input'
   import { Tabs } from '$lib/components/ui/tabs'
-  import { removeSharedAccountRecords } from '$lib/connect-handshake'
   import { backupFilename, createBackup } from '$lib/crypto/backup'
   import {
     PASSWORD_KDF_ITERATIONS,
@@ -49,7 +48,7 @@
   import routes from '$lib/routes'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
-  import type { AccessMethod, LocalAccount } from '$lib/types'
+  import type { AccessMethod, Account } from '$lib/types'
   import { copyToClipboard, display0x, notImplemented, truncateAddress } from '$lib/utils'
 
   const TOAST_DURATION_MS = 4000
@@ -62,7 +61,7 @@
   ]
 
   interface Props {
-    account: LocalAccount
+    account: Account
   }
 
   let { account }: Props = $props()
@@ -143,7 +142,7 @@
   function onNameChange() {
     const trimmed = name.trim()
     if (trimmed.length > 0 && trimmed !== account.name) {
-      accountsStore.rename(account.id, trimmed)
+      account.rename(trimmed)
     }
   }
 
@@ -269,7 +268,7 @@
       if (myAttempt !== attempt) {
         return
       }
-      accountsStore.setAccess(account.id, access, await encryptSeed(entropy, key))
+      account.setAccess(access, await encryptSeed(entropy, key))
       dialog = undefined
       newPassword = ''
       verifyNewPassword = ''
@@ -321,7 +320,9 @@
   }
 
   function deleteAccount() {
-    removeSharedAccountRecords(account)
+    // Removing the record drops its connected apps and drives with it, and the
+    // storage event de-authenticates any dApp proxy iframes.
+    accountsStore.remove(account.id)
     const next = accountsStore.accounts[0]
     if (next) {
       sessionStore.setCurrentAccount(next.id.toHex())

--- a/ui/src/lib/components/home-account.svelte
+++ b/ui/src/lib/components/home-account.svelte
@@ -49,8 +49,8 @@
   import routes from '$lib/routes'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
-  import type { AccessMethod, Account } from '$lib/types'
-  import { copyToClipboard, notImplemented, truncateAddress } from '$lib/utils'
+  import type { AccessMethod, LocalAccount } from '$lib/types'
+  import { copyToClipboard, display0x, notImplemented, truncateAddress } from '$lib/utils'
 
   const TOAST_DURATION_MS = 4000
   const MIN_PASSWORD_LENGTH = 8
@@ -62,7 +62,7 @@
   ]
 
   interface Props {
-    account: Account
+    account: LocalAccount
   }
 
   let { account }: Props = $props()
@@ -104,7 +104,7 @@
   let toastMessage = $state<string | undefined>(undefined)
   let toastTimer: ReturnType<typeof setTimeout> | undefined
 
-  const isLocal = $derived(account.stamps.length === 0)
+  const isLocal = $derived(account.postageStamps.length === 0)
   const accessLabel = $derived(methodLabel(account.access.type))
   const AccessIcon: Component = $derived(
     account.access.type === 'passkey'
@@ -113,6 +113,7 @@
         ? Wallet
         : KeyRound,
   )
+  const publicKeyDisplay = $derived(account.publicKey ? display0x(account.publicKey) : '')
   const privateKey = $derived(entropy ? privateKeyFromEntropy(entropy) : undefined)
   const phraseWords = $derived(entropy ? phraseFromEntropy(entropy).split(' ') : [])
   const newPasswordTooShort = $derived(
@@ -321,10 +322,9 @@
 
   function deleteAccount() {
     removeSharedAccountRecords(account)
-    accountsStore.remove(account.id)
     const next = accountsStore.accounts[0]
     if (next) {
-      sessionStore.setCurrentAccount(next.id)
+      sessionStore.setCurrentAccount(next.id.toHex())
     } else {
       sessionStore.clearCurrentAccount()
       goto(resolve(routes.ROOT))
@@ -372,12 +372,12 @@
 
 <div class="flex w-full flex-col gap-6">
   {#if isLocal}
-    <!-- Local account banner: no stamps yet, so the account is view-only. -->
+    <!-- Local account banner: no drives yet, so the account is view-only. -->
     <div class="bg-muted flex w-full flex-col gap-2 rounded-lg px-4 py-2">
       <div class="flex w-full items-center gap-2">
         <Info class="size-4 shrink-0" />
         <p class="flex-1 text-sm">Local account (view-only)</p>
-        <!-- Stamp purchase flow is still TBD in the design. -->
+        <!-- Drive purchase flow is still TBD in the design. -->
         <Button size="xs" onclick={notImplemented}>Upgrade</Button>
         <Button size="xs" variant="ghost" onclick={() => (bannerInfoShown = !bannerInfoShown)}>
           Info
@@ -385,8 +385,8 @@
       </div>
       {#if bannerInfoShown}
         <p class="text-muted-foreground pl-6 text-sm">
-          This is a local account, view-only and not synced. Upgrade by adding a postage stamp to
-          upload data and use your Swarm ID across all your devices.
+          This is a local account, view-only and not synced. Upgrade by adding a drive to upload
+          data and use your Swarm ID across all your devices.
         </p>
       {/if}
     </div>
@@ -398,7 +398,7 @@
     {#if expanded.identity}
       <div class="flex w-full items-center gap-2 pl-5">
         <Input bind:value={name} onchange={onNameChange} />
-        <Polycon value={account.id} size={32} class="shrink-0 overflow-hidden rounded-lg" />
+        <Polycon value={account.id.toHex()} size={32} class="shrink-0 overflow-hidden rounded-lg" />
       </div>
     {/if}
   </div>
@@ -440,8 +440,12 @@
       <div class="pl-5">
         <div class="border-border flex w-full flex-col rounded-lg border">
           <div class="flex h-12 w-full items-center gap-2 px-4">
-            <p class="flex-1 truncate text-sm">{truncateAddress(account.id)}</p>
-            <Button variant="ghost" size="sm" onclick={() => copyText(account.id, 'Address')}>
+            <p class="flex-1 truncate text-sm">{truncateAddress(display0x(account.id))}</p>
+            <Button
+              variant="ghost"
+              size="sm"
+              onclick={() => copyText(display0x(account.id), 'Address')}
+            >
               <Copy />
               Copy
             </Button>
@@ -461,13 +465,13 @@
               <div class="flex flex-col gap-1">
                 {@render keyBlock('Address', 'The unique identifier for your Swarm ID.')}
                 <div class="flex items-center gap-2">
-                  <p class="min-w-0 flex-1 text-sm break-all">{account.id}</p>
+                  <p class="min-w-0 flex-1 text-sm break-all">{display0x(account.id)}</p>
                   <Button
                     variant="ghost"
                     size="icon"
                     class="size-7 shrink-0"
                     aria-label="Copy address"
-                    onclick={() => copyText(account.id, 'Address')}
+                    onclick={() => copyText(display0x(account.id), 'Address')}
                   >
                     <Copy />
                   </Button>
@@ -480,13 +484,13 @@
                   'Can be used for establishing secure, private communication.',
                 )}
                 <div class="flex items-center gap-2">
-                  <p class="min-w-0 flex-1 text-sm break-all">{account.publicKey}</p>
+                  <p class="min-w-0 flex-1 text-sm break-all">{publicKeyDisplay}</p>
                   <Button
                     variant="ghost"
                     size="icon"
                     class="size-7 shrink-0"
                     aria-label="Copy public key"
-                    onclick={() => copyText(account.publicKey, 'Public key')}
+                    onclick={() => copyText(publicKeyDisplay, 'Public key')}
                   >
                     <Copy />
                   </Button>

--- a/ui/src/lib/components/home-apps.svelte
+++ b/ui/src/lib/components/home-apps.svelte
@@ -16,6 +16,7 @@
   import type { Account } from '$lib/types'
 
   const DEFAULT_CONNECTION_DAYS = 30
+  const MS_PER_DAY = 24 * 60 * 60 * 1000
   const DURATION_OPTIONS = [
     { value: '1', label: '1 day' },
     { value: '7', label: '7 days' },
@@ -31,7 +32,17 @@
 
   let { account }: Props = $props()
 
-  let connectionDays = $derived(String(account.appConnectionDays ?? DEFAULT_CONNECTION_DAYS))
+  // Connection lifetime is stored in ms (`settings.appSessionDuration`); the UI
+  // works in days.
+  let connectionDays = $derived(
+    String(
+      account.settings?.appSessionDuration !== undefined
+        ? Math.round(account.settings.appSessionDuration / MS_PER_DAY)
+        : DEFAULT_CONNECTION_DAYS,
+    ),
+  )
+  // Revoked tombstones stay in the record for sync; only show live entries.
+  const activeApps = $derived(account.connectedApps.filter((app) => !app.revokedAt))
   let openMenuFor = $state<string | undefined>(undefined)
 
   function isConnected(connectedUntil: number | undefined): boolean {
@@ -45,16 +56,13 @@
   }
 
   function disconnect(appUrl: string) {
-    // Revoke the shared record too — it holds the app secret the dApp's proxy
-    // iframe authenticates from; the UI-local store is just the display copy.
+    // Drops the app secret the dApp's proxy iframe authenticates from.
     disconnectSharedConnection(account, appUrl)
-    accountsStore.disconnectApp(account.id, appUrl)
     openMenuFor = undefined
   }
 
   function remove(appUrl: string) {
     removeSharedConnection(account, appUrl)
-    accountsStore.removeApp(account.id, appUrl)
     openMenuFor = undefined
   }
 </script>
@@ -74,11 +82,11 @@
 
   <div class="bg-border h-px w-full"></div>
 
-  {#if account.connectedApps.length === 0}
+  {#if activeApps.length === 0}
     <p class="text-muted-foreground py-8 text-center text-sm">No connected apps yet.</p>
   {:else}
     <div class="flex w-full flex-col">
-      {#each account.connectedApps as app (app.appUrl)}
+      {#each activeApps as app (app.appUrl)}
         <div class="border-border flex w-full items-center gap-3 border-b py-2.5">
           <AppIcon src={app.appIcon} name={app.appName} size={40} />
           <div class="flex min-w-0 flex-1 flex-col">

--- a/ui/src/lib/components/home-apps.svelte
+++ b/ui/src/lib/components/home-apps.svelte
@@ -11,8 +11,6 @@
   import AppIcon from '$lib/components/app-icon.svelte'
   import { Button } from '$lib/components/ui/button'
   import { Select } from '$lib/components/ui/select'
-  import { disconnectSharedConnection, removeSharedConnection } from '$lib/connect-handshake'
-  import { accountsStore } from '$lib/stores/accounts.svelte'
   import type { Account } from '$lib/types'
 
   const DEFAULT_CONNECTION_DAYS = 30
@@ -42,7 +40,7 @@
     ),
   )
   // Revoked tombstones stay in the record for sync; only show live entries.
-  const activeApps = $derived(account.connectedApps.filter((app) => !app.revokedAt))
+  const activeApps = $derived(account.activeApps)
   let openMenuFor = $state<string | undefined>(undefined)
 
   function isConnected(connectedUntil: number | undefined): boolean {
@@ -57,12 +55,12 @@
 
   function disconnect(appUrl: string) {
     // Drops the app secret the dApp's proxy iframe authenticates from.
-    disconnectSharedConnection(account, appUrl)
+    account.disconnectApp(appUrl)
     openMenuFor = undefined
   }
 
   function remove(appUrl: string) {
-    removeSharedConnection(account, appUrl)
+    account.removeApp(appUrl)
     openMenuFor = undefined
   }
 </script>
@@ -76,7 +74,7 @@
       options={DURATION_OPTIONS}
       bind:value={connectionDays}
       class="w-70"
-      onchange={(value) => accountsStore.setAppConnectionDays(account.id, Number(value))}
+      onchange={(value) => account.setAppConnectionDays(Number(value))}
     />
   </div>
 

--- a/ui/src/lib/connect-handshake.ts
+++ b/ui/src/lib/connect-handshake.ts
@@ -16,7 +16,6 @@
 import { type ConnectedApp, DEFAULT_SESSION_DURATION, deriveSecret } from '@snaha/swarm-id'
 
 import { privateKeyFromEntropy } from '$lib/crypto/mnemonic'
-import { accountsStore } from '$lib/stores/accounts.svelte'
 import type { ConnectRequest } from '$lib/stores/connect.svelte'
 import type { Account } from '$lib/types'
 import { bareHex } from '$lib/utils'
@@ -41,7 +40,7 @@ function saveConnection(account: Account, request: ConnectRequest, appSecret: st
     connectedUntil: now + connectionDuration(account),
     updatedAt: now,
   }
-  accountsStore.connectApp(account.id, connection)
+  account.connectApp(connection)
 }
 
 /**
@@ -106,27 +105,4 @@ export function reuseConnection(account: Account, request: ConnectRequest): bool
   saveConnection(account, request, existing.appSecret)
   sendSecretToOpener(account, request, existing.appSecret)
   return true
-}
-
-/**
- * Invalidate the app's connected-app record: drops the app secret so the dApp's
- * proxy iframe de-authenticates (storage event) and a reconnect needs a fresh
- * unlock ceremony.
- */
-export function disconnectSharedConnection(account: Account, appUrl: string): void {
-  accountsStore.disconnectApp(account.id, appUrl)
-}
-
-/** Disconnect and tombstone the record so the removal propagates to sync. */
-export function removeSharedConnection(account: Account, appUrl: string): void {
-  accountsStore.removeApp(account.id, appUrl)
-}
-
-/**
- * Erase the account's storage footprint: removing the record drops its
- * connected apps and drives with it, and the storage event de-authenticates any
- * dApp proxy iframes.
- */
-export function removeSharedAccountRecords(account: Account): void {
-  accountsStore.remove(account.id)
 }

--- a/ui/src/lib/connect-handshake.ts
+++ b/ui/src/lib/connect-handshake.ts
@@ -3,139 +3,35 @@
 /**
  * Completing a dApp connection from the connect popup.
  *
- * The proxy iframe embedded in the dApp authenticates from the shared
- * localStorage account document (written through the @snaha/swarm-id storage
- * manager): a nested account record that owns the `connectedApps` entry carrying
- * the app secret. Writing it fires a storage event in the iframe, which picks up
- * the session. When storage is partitioned the secret is handed to the iframe
- * via a `setSecret` postMessage instead.
+ * The account is the single nested record (the `@snaha/swarm-id` Zod model
+ * persisted under `STORAGE_KEY_ACCOUNTS`): it owns the `connectedApps` entry
+ * carrying the app secret the dApp's proxy iframe authenticates from. Writing it
+ * (via `accountsStore`) fires a storage event in the iframe, which picks up the
+ * session. When storage is partitioned the secret is handed to the iframe via a
+ * `setSecret` postMessage instead.
  *
- * Key model (master key = the account wallet's private key): the account is the
- * single app-facing identity, so the per-app secret derives straight from the
- * master key (`deriveSecret(master, appOrigin)`).
+ * Key model (master key = the account wallet's private key): the per-app secret
+ * derives straight from the master key (`deriveSecret(master, appOrigin)`).
  */
-import { BatchId, EthAddress, PrivateKey } from '@ethersphere/bee-js'
-import {
-  DEFAULT_SESSION_DURATION,
-  PARTITION_COUNT,
-  type Account as SharedAccount,
-  type ConnectedApp as SharedConnectedApp,
-  type PostageStamp as SharedPostageStamp,
-  createAccountsStorageManager,
-  deriveAccountDerivationKey,
-  deriveSecret,
-} from '@snaha/swarm-id'
+import { type ConnectedApp, DEFAULT_SESSION_DURATION, deriveSecret } from '@snaha/swarm-id'
 
 import { privateKeyFromEntropy } from '$lib/crypto/mnemonic'
 import { accountsStore } from '$lib/stores/accounts.svelte'
 import type { ConnectRequest } from '$lib/stores/connect.svelte'
 import type { Account } from '$lib/types'
-
-const MS_PER_DAY = 24 * 60 * 60 * 1000
-
-/** Shared-storage records use bare lowercase hex (no 0x prefix). */
-function bareHex(value: string): string {
-  return (value.startsWith('0x') ? value.slice(2) : value).toLowerCase()
-}
+import { bareHex } from '$lib/utils'
 
 function connectionDuration(account: Account): number {
-  return account.appConnectionDays !== undefined
-    ? account.appConnectionDays * MS_PER_DAY
-    : DEFAULT_SESSION_DURATION
-}
-
-/** The stamp the proxy should upload with: the account default or its first stamp. */
-function defaultBatchId(account: Account): BatchId | undefined {
-  const batchId = account.defaultStampBatchId ?? account.stamps[0]?.batchId
-  return batchId === undefined ? undefined : new BatchId(batchId)
-}
-
-/** The account's stamps in the shared (@snaha/swarm-id) PostageStamp shape. */
-function sharedStamps(account: Account): SharedPostageStamp[] {
-  return account.stamps.map((stamp) => ({
-    batchID: new BatchId(stamp.batchId),
-    signerKey: new PrivateKey(stamp.signerKey),
-    utilization: stamp.utilization,
-    usable: stamp.usable,
-    depth: stamp.depth,
-    amount: BigInt(stamp.amount),
-    bucketDepth: stamp.bucketDepth,
-    blockNumber: stamp.blockNumber,
-    immutableFlag: stamp.immutableFlag,
-    exists: stamp.exists,
-    batchTTL: stamp.batchTTL,
-    createdAt: stamp.createdAt,
-  }))
-}
-
-/** Upsert the matching shared account record via `mutate`, persisting the result. */
-function updateSharedAccount(
-  accountId: EthAddress,
-  mutate: (account: SharedAccount) => SharedAccount,
-): void {
-  const manager = createAccountsStorageManager()
-  manager.save(
-    manager.load().map((account) => (account.id.equals(accountId) ? mutate(account) : account)),
-  )
+  return account.settings?.appSessionDuration ?? DEFAULT_SESSION_DURATION
 }
 
 /**
- * Upsert the shared nested account record the proxy resolves a connection (and
- * its upload stamp) against. The account is its own single identity, owning its
- * connected apps and postage stamps inline.
- */
-async function saveSharedRecords(account: Account, masterKey: string): Promise<void> {
-  const accountId = new EthAddress(account.id)
-  const stampBatchId = defaultBatchId(account)
-  const publicKey = bareHex(account.publicKey)
-
-  const manager = createAccountsStorageManager()
-  const accounts = manager.load()
-  const existing = accounts.find((shared) => shared.id.equals(accountId))
-
-  if (existing) {
-    manager.save(
-      accounts.map((shared) =>
-        shared.id.equals(accountId)
-          ? {
-              ...shared,
-              name: account.name,
-              publicKey,
-              defaultPostageStampBatchID: stampBatchId ?? shared.defaultPostageStampBatchID,
-              postageStamps: sharedStamps(account),
-            }
-          : shared,
-      ),
-    )
-  } else {
-    manager.save([
-      ...accounts,
-      {
-        type: 'agent',
-        id: accountId,
-        name: account.name,
-        createdAt: account.createdAt,
-        derivationKey: await deriveAccountDerivationKey(masterKey),
-        publicKey,
-        defaultPostageStampBatchID: stampBatchId,
-        devices: [],
-        connectedApps: [],
-        postageStamps: sharedStamps(account),
-        partitionCount: PARTITION_COUNT,
-      },
-    ])
-  }
-}
-
-/**
- * Write the connected-app entry into the shared account record (this is what
- * fires the storage event the proxy iframe authenticates from) and mirror the
- * connection into the UI's own account record.
+ * Write the connected-app entry into the account record (this is what fires the
+ * storage event the proxy iframe authenticates from).
  */
 function saveConnection(account: Account, request: ConnectRequest, appSecret: string): void {
-  const accountId = new EthAddress(account.id)
   const now = Date.now()
-  const connection: SharedConnectedApp = {
+  const connection: ConnectedApp = {
     appUrl: request.appOrigin,
     appName: request.appName,
     appIcon: request.appIcon,
@@ -145,36 +41,19 @@ function saveConnection(account: Account, request: ConnectRequest, appSecret: st
     connectedUntil: now + connectionDuration(account),
     updatedAt: now,
   }
-
-  updateSharedAccount(accountId, (shared) => {
-    const has = shared.connectedApps.some((app) => app.appUrl === connection.appUrl)
-    const connectedApps = has
-      ? shared.connectedApps.map((app) =>
-          app.appUrl === connection.appUrl ? { ...app, ...connection, revokedAt: undefined } : app,
-        )
-      : [...shared.connectedApps, connection]
-    return { ...shared, connectedApps }
-  })
-
-  accountsStore.connectApp(account.id, {
-    appUrl: request.appOrigin,
-    appName: request.appName,
-    appIcon: request.appIcon,
-    appDescription: request.appDescription,
-    lastConnectedAt: now,
-    connectedUntil: connection.connectedUntil,
-  })
+  accountsStore.connectApp(account.id, connection)
 }
 
 /**
- * Storage-partitioning fallback: hand the secret straight to the proxy
- * iframe (our window.opener) since it can't see our localStorage. The
- * `identity*` fields carry the account's info (single-level model).
+ * Storage-partitioning fallback: hand the secret straight to the proxy iframe
+ * (our window.opener) since it can't see our localStorage. The `identity*`
+ * fields carry the account's info (single-level model).
  */
 function sendSecretToOpener(account: Account, request: ConnectRequest, appSecret: string): void {
   if (!request.partitionChallenge || !window.opener) {
     return
   }
+  const idHex = account.id.toHex()
   window.opener.postMessage(
     {
       type: 'setSecret',
@@ -182,10 +61,10 @@ function sendSecretToOpener(account: Account, request: ConnectRequest, appSecret
       challenge: request.partitionChallenge,
       data: {
         secret: appSecret,
-        identityId: bareHex(account.id),
+        identityId: idHex,
         identityName: account.name,
-        identityAddress: bareHex(account.id),
-        identityPublicKey: bareHex(account.publicKey),
+        identityAddress: idHex,
+        identityPublicKey: account.publicKey ?? '',
       },
     },
     window.location.origin,
@@ -203,7 +82,6 @@ export async function completeConnect(
   request: ConnectRequest,
 ): Promise<void> {
   const masterKey = bareHex(privateKeyFromEntropy(entropy))
-  await saveSharedRecords(account, masterKey)
   const appSecret = await deriveSecret(masterKey, request.appOrigin)
   saveConnection(account, request, appSecret)
   sendSecretToOpener(account, request, appSecret)
@@ -215,11 +93,7 @@ export async function completeConnect(
  * unlock + derivation is required.
  */
 export function reuseConnection(account: Account, request: ConnectRequest): boolean {
-  const accountId = new EthAddress(account.id)
-  const shared = createAccountsStorageManager()
-    .load()
-    .find((a) => a.id.equals(accountId))
-  const existing = shared?.connectedApps.find(
+  const existing = account.connectedApps.find(
     (app) =>
       app.appUrl === request.appOrigin &&
       app.appSecret !== undefined &&
@@ -234,49 +108,25 @@ export function reuseConnection(account: Account, request: ConnectRequest): bool
   return true
 }
 
-function revoked(app: SharedConnectedApp, tombstone: boolean): SharedConnectedApp {
-  const now = Date.now()
-  return {
-    ...app,
-    appSecret: undefined,
-    connectedUntil: undefined,
-    lastConnectedAt: 0,
-    updatedAt: now,
-    revokedAt: tombstone ? now : app.revokedAt,
-  }
-}
-
 /**
- * Invalidate the app's shared connected-app record: drops the app secret so
- * the dApp's proxy iframe de-authenticates (storage event) and a reconnect
- * needs a fresh unlock ceremony.
+ * Invalidate the app's connected-app record: drops the app secret so the dApp's
+ * proxy iframe de-authenticates (storage event) and a reconnect needs a fresh
+ * unlock ceremony.
  */
 export function disconnectSharedConnection(account: Account, appUrl: string): void {
-  updateSharedAccount(new EthAddress(account.id), (shared) => ({
-    ...shared,
-    connectedApps: shared.connectedApps.map((app) =>
-      app.appUrl === appUrl ? revoked(app, false) : app,
-    ),
-  }))
+  accountsStore.disconnectApp(account.id, appUrl)
 }
 
-/** Disconnect and tombstone the shared record so the removal propagates to sync. */
+/** Disconnect and tombstone the record so the removal propagates to sync. */
 export function removeSharedConnection(account: Account, appUrl: string): void {
-  updateSharedAccount(new EthAddress(account.id), (shared) => ({
-    ...shared,
-    connectedApps: shared.connectedApps.map((app) =>
-      app.appUrl === appUrl ? revoked(app, true) : app,
-    ),
-  }))
+  accountsStore.removeApp(account.id, appUrl)
 }
 
 /**
- * Erase the account's shared-storage footprint: removing the nested account
- * record drops its connected apps and stamps with it, and the storage event
- * de-authenticates any dApp proxy iframes.
+ * Erase the account's storage footprint: removing the record drops its
+ * connected apps and drives with it, and the storage event de-authenticates any
+ * dApp proxy iframes.
  */
 export function removeSharedAccountRecords(account: Account): void {
-  const accountId = new EthAddress(account.id)
-  const manager = createAccountsStorageManager()
-  manager.save(manager.load().filter((shared) => !shared.id.equals(accountId)))
+  accountsStore.remove(account.id)
 }

--- a/ui/src/lib/crypto/backup.test.ts
+++ b/ui/src/lib/crypto/backup.test.ts
@@ -1,28 +1,34 @@
 // Copyright 2026 The Swarm Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+import { EthAddress } from '@ethersphere/bee-js'
 import { describe, expect, it } from 'vitest'
 
-import type { Account } from '../types'
+import type { LocalAccount } from '../types'
+import { bareHex } from '../utils'
 import { backupFilename, createBackup, restoreBackup } from './backup'
 import { walletFromPhrase } from './mnemonic'
 
 const PHRASE = 'test test test test test test test test test test test junk'
 const OTHER_PHRASE = 'legal winner thank year wave sausage worth useful legal winner thank yellow'
+const MS_PER_DAY = 24 * 60 * 60 * 1000
 
-function accountFor(phrase: string): Account {
+function accountFor(phrase: string): LocalAccount {
   const wallet = walletFromPhrase(phrase)
   return {
-    id: wallet.address,
+    type: 'local',
+    id: new EthAddress(bareHex(wallet.address)),
     name: 'Jovial Einstein',
-    publicKey: wallet.publicKey,
+    publicKey: bareHex(wallet.publicKey),
     createdAt: 1765000000000,
+    derivationKey: 'f'.repeat(64),
     access: { type: 'password', kdfSalt: '00', kdfIterations: 1 },
     encryptedSeed: '00',
-    appConnectionDays: 30,
-    stamps: [],
+    settings: { appSessionDuration: 30 * MS_PER_DAY },
+    devices: [],
     connectedApps: [
       { appUrl: 'https://coucou.mail', appName: 'Coucou', lastConnectedAt: 1765000000000 },
     ],
+    postageStamps: [],
   }
 }
 
@@ -33,10 +39,10 @@ describe('backup round-trip', () => {
     const file = await createBackup(account, wallet.entropy)
 
     const restored = await restoreBackup(file, PHRASE)
-    expect(restored.id).toBe(account.id)
+    expect(restored.id.toHex()).toBe(account.id.toHex())
     expect(restored.name).toBe('Jovial Einstein')
     expect(restored.connectedApps).toHaveLength(1)
-    expect(restored.appConnectionDays).toBe(30)
+    expect(restored.settings?.appSessionDuration).toBe(30 * MS_PER_DAY)
     // The secret material never leaves the device.
     expect(file).not.toContain('encryptedSeed')
     expect(file).not.toContain('kdfSalt')

--- a/ui/src/lib/crypto/backup.ts
+++ b/ui/src/lib/crypto/backup.ts
@@ -6,10 +6,18 @@
  * a key derived from the recovery-phrase entropy, so the file is useless
  * without the phrase and restoring needs exactly: file + phrase.
  */
+import {
+  AccountSchemaV1,
+  type LocalAccount,
+  serializeConnectedApp,
+  serializePostageStamp,
+} from '@snaha/swarm-id'
+
 import { decryptSeed, deriveKeyFromSecret, encryptSeed } from '$lib/crypto/encryption'
 import { bytesToHex, hexToBytes } from '$lib/crypto/hex'
 import { walletFromPhrase } from '$lib/crypto/mnemonic'
-import type { Account, AccountData } from '$lib/types'
+import type { AccountData } from '$lib/types'
+import { bareHex } from '$lib/utils'
 
 const BACKUP_VERSION = 1
 const BACKUP_KEY_INFO = 'swarm-id-backup-v1'
@@ -43,17 +51,25 @@ function parseEnvelope(fileContents: string): BackupEnvelope | undefined {
   return undefined
 }
 
-/** Serialize and encrypt an account into .swarmid file contents. */
-export async function createBackup(account: Account, entropy: Uint8Array): Promise<string> {
-  const data: AccountData = {
-    id: account.id,
+/**
+ * Serialize and encrypt an account into .swarmid file contents. Byte-class
+ * fields (id, batch ids, stamps) are projected to hex through the lib
+ * serializers so the payload is plain JSON — never the access method or
+ * encrypted seed.
+ */
+export async function createBackup(account: LocalAccount, entropy: Uint8Array): Promise<string> {
+  const data = {
+    id: account.id.toHex(),
     name: account.name,
     publicKey: account.publicKey,
     createdAt: account.createdAt,
-    appConnectionDays: account.appConnectionDays,
-    defaultStampBatchId: account.defaultStampBatchId,
-    stamps: account.stamps,
-    connectedApps: account.connectedApps,
+    derivationKey: account.derivationKey,
+    settings: account.settings,
+    defaultPostageStampBatchID: account.defaultPostageStampBatchID?.toHex(),
+    devices: account.devices,
+    connectedApps: account.connectedApps.map(serializeConnectedApp),
+    postageStamps: account.postageStamps.map(serializePostageStamp),
+    partitionCount: account.partitionCount,
   }
 
   const salt = new Uint8Array(SALT_LENGTH)
@@ -117,11 +133,29 @@ export async function restoreBackup(fileContents: string, phrase: string): Promi
     throw new Error('The recovery phrase does not match this backup.')
   }
 
-  const data = JSON.parse(new TextDecoder().decode(plaintext)) as AccountData
-  if (data.id.toLowerCase() !== wallet.address.toLowerCase()) {
+  let raw: unknown
+  try {
+    raw = JSON.parse(new TextDecoder().decode(plaintext))
+  } catch {
+    throw new Error('Not a valid backup file.')
+  }
+  // Rehydrate byte-class fields through the shared Zod schema. Access/seed are
+  // device-local and never in the file, so pass placeholders and drop them.
+  const result = AccountSchemaV1.safeParse({
+    ...(raw as Record<string, unknown>),
+    type: 'local',
+    access: { type: 'password', kdfSalt: '', kdfIterations: 0 },
+    encryptedSeed: '',
+  })
+  if (!result.success || result.data.type !== 'local') {
+    throw new Error('Not a valid backup file.')
+  }
+  const parsed = result.data
+  if (parsed.id.toHex() !== bareHex(wallet.address)) {
     throw new Error('The recovery phrase does not match this backup.')
   }
-  return data
+  const { access: _access, encryptedSeed: _encryptedSeed, ...portable } = parsed
+  return portable
 }
 
 /** Backup filename like 20260610.swarmid */

--- a/ui/src/lib/crypto/unlock.ts
+++ b/ui/src/lib/crypto/unlock.ts
@@ -17,6 +17,9 @@ import type { Account } from '$lib/types'
  * or wallet.
  */
 export async function unlockAccount(account: Account, password?: string): Promise<Uint8Array> {
+  if (account.type !== 'local') {
+    throw new Error('Account has no device-local access method.')
+  }
   const access = account.access
 
   let key: CryptoKey

--- a/ui/src/lib/crypto/unlock.ts
+++ b/ui/src/lib/crypto/unlock.ts
@@ -17,9 +17,6 @@ import type { Account } from '$lib/types'
  * or wallet.
  */
 export async function unlockAccount(account: Account, password?: string): Promise<Uint8Array> {
-  if (account.type !== 'local') {
-    throw new Error('Account has no device-local access method.')
-  }
   const access = account.access
 
   let key: CryptoKey

--- a/ui/src/lib/dev/accounts.svelte.ts
+++ b/ui/src/lib/dev/accounts.svelte.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The /dev tooling and the sync subsystem drive off the same single account
+ * store as the product UI. This alias keeps the historical `sharedAccountsStore`
+ * name for those call sites; there is no longer a separate shared model.
+ */
+export { accountsStore as sharedAccountsStore } from '$lib/stores/accounts.svelte'

--- a/ui/src/lib/dev/dev-settings.svelte.ts
+++ b/ui/src/lib/dev/dev-settings.svelte.ts
@@ -1,0 +1,62 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Dev Settings Store
+ *
+ * Store for developer settings used in the /dev page.
+ * Controls mock behavior for testing various flows.
+ */
+import { browser } from '$app/environment'
+
+export type MockStampResult = 'success' | 'error'
+
+interface DevSettings {
+  mockStampEnabled: boolean
+  mockStampResult: MockStampResult
+}
+
+// Persist mock mode in localStorage so an explicit choice is durable and shared
+// across same-origin tabs (the buy flow often runs in a different tab/window than
+// /dev). It defaults to `import.meta.env.DEV` only when never set; once toggled,
+// the choice sticks until changed again.
+const MOCK_ENABLED_KEY = 'dev-mock-stamp-enabled'
+const MOCK_RESULT_KEY = 'dev-mock-stamp-result'
+
+function loadMockEnabled(): boolean {
+  if (!browser) return import.meta.env.DEV
+  const stored = localStorage.getItem(MOCK_ENABLED_KEY)
+  return stored === undefined || stored === null ? import.meta.env.DEV : stored === 'true'
+}
+
+function loadMockResult(): MockStampResult {
+  return browser && localStorage.getItem(MOCK_RESULT_KEY) === 'error' ? 'error' : 'success'
+}
+
+const settings = $state<DevSettings>({
+  mockStampEnabled: loadMockEnabled(),
+  mockStampResult: loadMockResult(),
+})
+
+if (browser) {
+  // Cross-tab sync: a disable/enable on /dev in another tab must reach a tab that
+  // already has the buy flow open, otherwise that tab's in-memory copy stays stale
+  // and keeps mocking.
+  window.addEventListener('storage', (e) => {
+    if (e.key === MOCK_ENABLED_KEY) settings.mockStampEnabled = loadMockEnabled()
+    if (e.key === MOCK_RESULT_KEY) settings.mockStampResult = loadMockResult()
+  })
+}
+
+export const devSettingsStore = {
+  get data() {
+    return settings
+  },
+  setMockStampEnabled(enabled: boolean) {
+    settings.mockStampEnabled = enabled
+    if (browser) localStorage.setItem(MOCK_ENABLED_KEY, String(enabled))
+  },
+  setMockStampResult(result: MockStampResult) {
+    settings.mockStampResult = result
+    if (browser) localStorage.setItem(MOCK_RESULT_KEY, result)
+  },
+}

--- a/ui/src/lib/dev/network-settings.svelte.ts
+++ b/ui/src/lib/dev/network-settings.svelte.ts
@@ -1,0 +1,58 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import {
+  DEFAULT_BEE_NODE_URL,
+  DEFAULT_GNOSIS_RPC_URL,
+  type NetworkSettings,
+  createNetworkSettingsStorageManager,
+} from '@snaha/swarm-id'
+
+import { browser } from '$app/environment'
+
+export interface NetworkSettingsStore {
+  settings: NetworkSettings
+  beeNodeUrl: string
+  gnosisRpcUrl: string
+  updateSettings(newSettings: NetworkSettings): void
+  reset(): void
+}
+
+function withNetworkSettingsStore(): NetworkSettingsStore {
+  const storageManager = browser ? createNetworkSettingsStorageManager() : undefined
+
+  const defaultSettings: NetworkSettings = {
+    beeNodeUrl: DEFAULT_BEE_NODE_URL,
+    gnosisRpcUrl: DEFAULT_GNOSIS_RPC_URL,
+  }
+
+  // Load initial settings from localStorage or use defaults
+  const initialSettings = storageManager?.load() ?? defaultSettings
+
+  let settings = $state<NetworkSettings>(initialSettings)
+
+  function updateSettings(newSettings: NetworkSettings) {
+    settings = newSettings
+    storageManager?.save(newSettings)
+  }
+
+  function reset() {
+    settings = defaultSettings
+    storageManager?.clear()
+  }
+
+  return {
+    get settings() {
+      return settings
+    },
+    get beeNodeUrl() {
+      return settings.beeNodeUrl
+    },
+    get gnosisRpcUrl() {
+      return settings.gnosisRpcUrl
+    },
+    updateSettings,
+    reset,
+  }
+}
+
+export const networkSettingsStore = withNetworkSettingsStore()

--- a/ui/src/lib/dev/postage-stamps.svelte.ts
+++ b/ui/src/lib/dev/postage-stamps.svelte.ts
@@ -65,6 +65,6 @@ export const postageStampsStore = {
       console.warn('[PostageStamps] Cannot update utilization: stamp not found')
       return
     }
-    sharedAccountsStore.updateDriveUtilization(found.accountId, batchID, newUtilization)
+    sharedAccountsStore.getAccount(found.accountId)?.updateDriveUtilization(batchID, newUtilization)
   },
 }

--- a/ui/src/lib/dev/postage-stamps.svelte.ts
+++ b/ui/src/lib/dev/postage-stamps.svelte.ts
@@ -1,0 +1,70 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BatchId, EthAddress } from '@ethersphere/bee-js'
+import { type PostageStamp, UtilizationAwareStamper, UtilizationStoreDB } from '@snaha/swarm-id'
+
+import { browser } from '$app/environment'
+
+import { sharedAccountsStore } from '$lib/dev/accounts.svelte'
+
+// ============================================================================
+// Postage-stamp runtime view
+//
+// Stamp DATA is owned by the nested account (`sharedAccountsStore`); this module
+// is the batchID-keyed RUNTIME over it: locate a stamp across accounts, build a
+// utilization-aware stamper, and record volatile utilization. It satisfies the
+// lib `PostageStampsStoreInterface` consumed by `createSyncAccount`.
+// ============================================================================
+
+let utilizationStore: UtilizationStoreDB | undefined
+
+const getUtilizationStore = () => {
+  if (!browser) {
+    throw new Error('Utilization store not available (browser only)')
+  }
+  if (!utilizationStore) {
+    utilizationStore = new UtilizationStoreDB()
+  }
+  return utilizationStore
+}
+
+/** Locate a stamp by batchID across all accounts, with its owning account id. */
+function findStamp(batchID: BatchId): { stamp: PostageStamp; accountId: EthAddress } | undefined {
+  for (const account of sharedAccountsStore.accounts) {
+    const stamp = account.postageStamps.find((s) => s.batchID.equals(batchID))
+    if (stamp) return { stamp, accountId: account.id }
+  }
+  return undefined
+}
+
+export const postageStampsStore = {
+  getStamp(batchID: BatchId): PostageStamp | undefined {
+    return findStamp(batchID)?.stamp
+  },
+
+  async getStamper(
+    batchID: BatchId,
+    options: { owner: EthAddress; encryptionKey: Uint8Array },
+  ): Promise<UtilizationAwareStamper | undefined> {
+    const found = findStamp(batchID)
+    if (!found) return undefined
+
+    return UtilizationAwareStamper.create(
+      found.stamp.signerKey.toUint8Array(),
+      found.stamp.batchID,
+      found.stamp.depth,
+      getUtilizationStore(),
+      options.owner,
+      options.encryptionKey,
+    )
+  },
+
+  updateStampUtilization(batchID: BatchId, newUtilization: number) {
+    const found = findStamp(batchID)
+    if (!found) {
+      console.warn('[PostageStamps] Cannot update utilization: stamp not found')
+      return
+    }
+    sharedAccountsStore.updateDriveUtilization(found.accountId, batchID, newUtilization)
+  },
+}

--- a/ui/src/lib/dev/refresh-account-from-swarm.ts
+++ b/ui/src/lib/dev/refresh-account-from-swarm.ts
@@ -105,7 +105,7 @@ export async function refreshAccountFromSwarm(accountId: string): Promise<Refres
       detectDeviceName(),
     )
 
-    sharedAccountsStore.applyRefreshed(ethAddress, {
+    account.applyRefreshed({
       devices: mergedDevices,
       connectedApps: mergedApps,
       postageStamps: mergedStamps,

--- a/ui/src/lib/dev/refresh-account-from-swarm.ts
+++ b/ui/src/lib/dev/refresh-account-from-swarm.ts
@@ -1,0 +1,124 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Pull the latest account snapshot from Swarm and fold it into local stores.
+ *
+ * Unlike `restoreAccountFromSwarm`, this doesn't need the master key — it
+ * uses the local account's `derivationKey` (already stored after sign-in)
+ * to derive the snapshot feed's owner and encryption key. So it's safe to
+ * call from any signed-in page, including after the temporary master key
+ * has been cleared.
+ */
+import { Bee, EthAddress, PrivateKey, Reference, Topic } from '@ethersphere/bee-js'
+import {
+  ACCOUNT_SYNC_TOPIC_PREFIX,
+  AsyncEpochFinder,
+  SnapshotDataUnavailableError,
+  deriveSecret,
+  deriveSwarmEncryptionKey,
+  deserializeAccountState,
+  detectDeviceName,
+  downloadDataWithChunkAPI,
+  getOrCreateDeviceId,
+  mergeConnectedApps,
+  mergeDevices,
+  mergeDevicesList,
+  mergePostageStamps,
+} from '@snaha/swarm-id'
+
+import { sharedAccountsStore } from '$lib/dev/accounts.svelte'
+import { networkSettingsStore } from '$lib/dev/network-settings.svelte'
+
+export type RefreshResult =
+  | { ok: true; refreshedAt: number }
+  // The backup feed has no reachable entry on this node — typically the
+  // previous backup was stamped by a now-expired batch and garbage-
+  // collected, and a republish with the new batch hasn't landed yet.
+  // Benign and self-healing; the UI guides the user to wait / publish.
+  | { ok: false; kind: 'no-backup' }
+  // Invalid id, missing local account, unretrievable chunks, or network
+  // failure — a genuine error the user should see.
+  | { ok: false; kind: 'error'; error: string }
+
+export async function refreshAccountFromSwarm(accountId: string): Promise<RefreshResult> {
+  let ethAddress: EthAddress
+  try {
+    ethAddress = new EthAddress(accountId)
+  } catch {
+    return { ok: false, kind: 'error', error: 'Invalid account id' }
+  }
+
+  const account = sharedAccountsStore.getAccount(ethAddress)
+  if (!account) {
+    return { ok: false, kind: 'error', error: 'No local account for this id' }
+  }
+
+  const bee = new Bee(networkSettingsStore.beeNodeUrl)
+
+  try {
+    // Derive the snapshot feed's owner / encryption key. Same derivation
+    // chain as `restoreAccountFromSwarm` but starting from the locally
+    // stored derivationKey instead of the master key.
+    const swarmEncryptionKey = await deriveSwarmEncryptionKey(account.derivationKey)
+    const backupKeyHex = await deriveSecret(swarmEncryptionKey, 'backup-key')
+    const backupKey = new PrivateKey(backupKeyHex)
+    const owner = backupKey.publicKey().address()
+    const topic = Topic.fromString(`${ACCOUNT_SYNC_TOPIC_PREFIX}:${account.id.toHex()}`)
+
+    // Note: feed SOCs are uploaded unencrypted (sync-account.ts doesn't
+    // pass encryptionKey to updater.update()), so the finder must not
+    // use one either.
+    const finder = new AsyncEpochFinder(bee, topic, owner)
+    const now = BigInt(Math.floor(Date.now() / 1000))
+    const refBytes = await finder.findAt(now)
+
+    if (!refBytes) {
+      return { ok: false, kind: 'no-backup' }
+    }
+
+    let data: Uint8Array
+    try {
+      data = await downloadDataWithChunkAPI(bee, new Reference(refBytes).toHex())
+    } catch (err) {
+      throw new SnapshotDataUnavailableError(new Reference(refBytes).toHex(), err)
+    }
+
+    const snapshot = deserializeAccountState(data)
+
+    console.debug(
+      `[RefreshAccount] devices=${snapshot.metadata.devices.length} apps=${snapshot.connectedApps.length} stamps=${snapshot.postageStamps.length} bee=${bee.url}`,
+    )
+
+    // Merge the remote snapshot into this account's nested local state and apply
+    // it WITHOUT re-publishing (refresh data shouldn't be re-uploaded). Reuses
+    // the exact publish-side merge primitives from the lib so the rules can't
+    // drift (#337): apps LWW by appUrl (tombstone-aware), stamps union by
+    // batchID (local wins), devices prefer the larger `lastSignedInAt`.
+    const mergedApps = mergeConnectedApps(account.connectedApps, snapshot.connectedApps)
+    const mergedStamps = mergePostageStamps(account.postageStamps, snapshot.postageStamps)
+
+    // Keep *this* device first-class even if the snapshot was written by a peer
+    // that doesn't know about us yet.
+    const mergedDevices = mergeDevices(
+      mergeDevicesList(account.devices, snapshot.metadata.devices),
+      getOrCreateDeviceId(),
+      detectDeviceName(),
+    )
+
+    sharedAccountsStore.applyRefreshed(ethAddress, {
+      devices: mergedDevices,
+      connectedApps: mergedApps,
+      postageStamps: mergedStamps,
+    })
+
+    return { ok: true, refreshedAt: Date.now() }
+  } catch (err) {
+    const error =
+      err instanceof SnapshotDataUnavailableError
+        ? `Backup feed entry exists but its chunks aren't retrievable from ${bee.url} (ref ${err.reference.slice(0, 8)}…)`
+        : err instanceof Error
+          ? err.message
+          : 'Unknown error'
+    return { ok: false, kind: 'error', error }
+  }
+}

--- a/ui/src/lib/dev/sync-hooks.ts
+++ b/ui/src/lib/dev/sync-hooks.ts
@@ -1,0 +1,30 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { syncStore } from '$lib/dev/sync.svelte'
+
+// How long to coalesce rapid account mutations before publishing once.
+const SYNC_DEBOUNCE_MS = 2000
+
+// Debounce timer per account
+const syncTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+/**
+ * Trigger sync for an account with debouncing
+ *
+ * Multiple rapid changes are batched into a single sync
+ */
+export function triggerSync(accountId: string): void {
+  // Clear existing timer
+  const existingTimer = syncTimers.get(accountId)
+  if (existingTimer) {
+    clearTimeout(existingTimer)
+  }
+
+  // Set new timer (2 second debounce)
+  const timer = setTimeout(() => {
+    syncStore.syncAccount(accountId)
+    syncTimers.delete(accountId)
+  }, SYNC_DEBOUNCE_MS)
+
+  syncTimers.set(accountId, timer)
+}

--- a/ui/src/lib/dev/sync.svelte.ts
+++ b/ui/src/lib/dev/sync.svelte.ts
@@ -1,0 +1,99 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { Bee } from '@ethersphere/bee-js'
+import {
+  DebouncedUtilizationUploader,
+  type SyncAccountFunction,
+  type SyncResult,
+  UtilizationStoreDB,
+  createSyncAccount,
+} from '@snaha/swarm-id'
+
+import { browser } from '$app/environment'
+
+import { sharedAccountsStore } from '$lib/dev/accounts.svelte'
+import { networkSettingsStore } from '$lib/dev/network-settings.svelte'
+import { postageStampsStore } from '$lib/dev/postage-stamps.svelte'
+
+// ============================================================================
+// Lazy Initialization (Browser Only)
+// ============================================================================
+
+// Lazy utilization store initialization
+let utilizationStore: UtilizationStoreDB | undefined
+
+const getUtilizationStore = () => {
+  if (!browser) return undefined
+
+  if (!utilizationStore) {
+    utilizationStore = new UtilizationStoreDB()
+  }
+
+  return utilizationStore
+}
+
+// Lazy debounced uploader initialization
+let utilizationUploader: DebouncedUtilizationUploader | undefined
+
+const getUtilizationUploader = () => {
+  if (!browser) return undefined
+
+  if (!utilizationUploader) {
+    utilizationUploader = new DebouncedUtilizationUploader()
+  }
+
+  return utilizationUploader
+}
+
+// Sync account function — recreated whenever the Bee node URL changes,
+// since createSyncAccount closes over a specific Bee client instance.
+let syncAccountFn: SyncAccountFunction | undefined
+let lastBeeUrl: string | undefined
+
+const getSyncAccount = () => {
+  if (!browser) return undefined
+
+  const currentUrl = networkSettingsStore.beeNodeUrl
+
+  if (!syncAccountFn || currentUrl !== lastBeeUrl) {
+    const utilStore = getUtilizationStore()
+    const utilUploader = getUtilizationUploader()
+    if (!utilStore || !utilUploader) return undefined
+
+    lastBeeUrl = currentUrl
+    syncAccountFn = createSyncAccount({
+      bee: new Bee(currentUrl),
+      accountsStore: sharedAccountsStore,
+      postageStampsStore,
+      utilizationStore: utilStore,
+      utilizationUploader: utilUploader,
+    })
+  }
+
+  return syncAccountFn
+}
+
+// ============================================================================
+// Export Sync Store
+// ============================================================================
+
+export const syncStore = {
+  /**
+   * Trigger sync for an account
+   * Called by store hooks when state changes
+   */
+  async syncAccount(accountId: string): Promise<SyncResult | undefined> {
+    if (!browser) {
+      console.warn('[StateSync] Sync disabled - not in browser')
+      return undefined
+    }
+
+    const syncAccount = getSyncAccount()
+    if (!syncAccount) {
+      console.warn('[StateSync] Sync function not available')
+      return undefined
+    }
+
+    return syncAccount(accountId)
+  },
+}

--- a/ui/src/lib/stores/accounts.svelte.ts
+++ b/ui/src/lib/stores/accounts.svelte.ts
@@ -1,96 +1,315 @@
 // Copyright 2026 The Swarm Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-import type { Account, ConnectedApp } from '$lib/types'
+import { BatchId, EthAddress } from '@ethersphere/bee-js'
+import {
+  type AccessMethod,
+  type Account,
+  type ConnectedApp,
+  type Device,
+  type PostageStamp,
+  STORAGE_KEY_ACCOUNTS,
+  createAccountsStorageManager,
+} from '@snaha/swarm-id'
 
-const STORAGE_KEY = 'swarm-id-accounts-v2'
+import { browser } from '$app/environment'
 
-function load(): Account[] {
-  if (typeof localStorage === 'undefined') {
-    return []
-  }
-  const raw = localStorage.getItem(STORAGE_KEY)
-  if (!raw) {
-    return []
-  }
-  try {
-    return JSON.parse(raw) as Account[]
-  } catch {
-    return []
-  }
+// ============================================================================
+// Accounts store — the single source of truth
+//
+// Wraps the `@snaha/swarm-id` Zod-validated storage manager (persisted under
+// `STORAGE_KEY_ACCOUNTS`): the SAME nested-account document the proxy iframe and
+// sync engine read. The product UI, the /dev tooling, and the sync subsystem all
+// drive off this one reactive store — there is no separate display model.
+//
+// The UI only ever creates `local` accounts. Mutations that touch `access` /
+// `encryptedSeed` therefore guard on `type === 'local'`.
+// ============================================================================
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000
+
+const storageManager = createAccountsStorageManager()
+
+function loadAccounts(): Account[] {
+  if (!browser) return []
+  return storageManager.load()
 }
 
-function createAccountsStore() {
-  let accounts = $state<Account[]>(load())
+let accounts = $state<Account[]>(loadAccounts())
 
-  function persist() {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify(accounts))
-  }
+if (browser) {
+  // Cross-tab refresh: another tab mutating the account document (sign-in,
+  // app connect, stamp purchase) updates this tab's reactive state too.
+  window.addEventListener('storage', (e) => {
+    if (e.key !== STORAGE_KEY_ACCOUNTS) return
+    accounts = loadAccounts()
+  })
+}
 
-  // Keep tabs in sync: another tab writing accounts updates this one.
-  if (typeof window !== 'undefined') {
-    window.addEventListener('storage', (event) => {
-      if (event.key === STORAGE_KEY) {
-        accounts = load()
-      }
-    })
-  }
+/**
+ * Optional sync hook. The /dev sync subsystem injects `triggerSync` so its
+ * mutations publish to Swarm; the plain product app leaves it unset, so a
+ * rename or app-connect never attempts a network publish.
+ */
+let syncHook: ((accountIdHex: string) => void) | undefined
 
-  function update(id: string, change: (account: Account) => Account) {
-    accounts = accounts.map((account) => (account.id === id ? change(account) : account))
-    persist()
-  }
+export function setAccountsSyncHook(hook: (accountIdHex: string) => void): void {
+  syncHook = hook
+}
 
+function toEthAddress(id: string | EthAddress): EthAddress {
+  return typeof id === 'string' ? new EthAddress(id) : id
+}
+
+function persist(): void {
+  storageManager.save(accounts)
+}
+
+function getById(id: string | EthAddress): Account | undefined {
+  const ethId = toEthAddress(id)
+  return accounts.find((account) => account.id.equals(ethId))
+}
+
+/**
+ * Map the matching account through `fn`, persist, and (unless `skipSync`) fire
+ * the sync hook for it. The single mutation primitive.
+ */
+function update(
+  id: string | EthAddress,
+  fn: (account: Account) => Account,
+  { skipSync = false }: { skipSync?: boolean } = {},
+): void {
+  const ethId = toEthAddress(id)
+  let changed = false
+  accounts = accounts.map((account) => {
+    if (!account.id.equals(ethId)) return account
+    changed = true
+    return fn(account)
+  })
+  if (!changed) return
+  persist()
+  if (!skipSync) syncHook?.(ethId.toHex())
+}
+
+/** Revoke an app connection: drop the secret so the dApp proxy de-authenticates. */
+function revoked(app: ConnectedApp, tombstone: boolean): ConnectedApp {
+  const now = Date.now()
   return {
-    get accounts() {
-      return accounts
-    },
-    get(id: string): Account | undefined {
-      return accounts.find((account) => account.id === id)
-    },
-    add(account: Account) {
-      // Replace any previous record for the same address (sign-in / restore).
-      accounts = [...accounts.filter((existing) => existing.id !== account.id), account]
-      persist()
-    },
-    rename(id: string, name: string) {
-      update(id, (account) => ({ ...account, name }))
-    },
-    remove(id: string) {
-      accounts = accounts.filter((account) => account.id !== id)
-      persist()
-    },
-    /** Swap the unlock method: new access metadata + seed re-encrypted for it. */
-    setAccess(id: string, access: Account['access'], encryptedSeed: string) {
-      update(id, (account) => ({ ...account, access, encryptedSeed }))
-    },
-    setAppConnectionDays(id: string, days: number) {
-      update(id, (account) => ({ ...account, appConnectionDays: days }))
-    },
-    /** Record a (re)connection — replaces any previous entry for the app. */
-    connectApp(id: string, app: ConnectedApp) {
-      update(id, (account) => ({
-        ...account,
-        connectedApps: [
-          ...account.connectedApps.filter((existing) => existing.appUrl !== app.appUrl),
-          app,
-        ],
-      }))
-    },
-    disconnectApp(id: string, appUrl: string) {
-      update(id, (account) => ({
-        ...account,
-        connectedApps: account.connectedApps.map((app) =>
-          app.appUrl === appUrl ? { ...app, connectedUntil: undefined } : app,
-        ),
-      }))
-    },
-    removeApp(id: string, appUrl: string) {
-      update(id, (account) => ({
-        ...account,
-        connectedApps: account.connectedApps.filter((app) => app.appUrl !== appUrl),
-      }))
-    },
+    ...app,
+    appSecret: undefined,
+    connectedUntil: undefined,
+    lastConnectedAt: 0,
+    updatedAt: now,
+    revokedAt: tombstone ? now : app.revokedAt,
   }
 }
 
-export const accountsStore = createAccountsStore()
+export const accountsStore = {
+  get accounts(): Account[] {
+    return accounts
+  },
+
+  /** Re-read from shared storage (e.g. after a direct storage manager write). */
+  reload(): void {
+    accounts = loadAccounts()
+  },
+
+  get(id: string | EthAddress): Account | undefined {
+    return getById(id)
+  },
+
+  /** Alias used by the sync engine / dev tooling (keyed by EthAddress). */
+  getAccount(id: EthAddress): Account | undefined {
+    return getById(id)
+  },
+
+  add(account: Account): Account {
+    // Replace any previous record for the same address (sign-in / restore).
+    accounts = [...accounts.filter((existing) => !existing.id.equals(account.id)), account]
+    persist()
+    return account
+  },
+
+  addAccount(account: Account): Account {
+    return accountsStore.add(account)
+  },
+
+  remove(id: string | EthAddress): void {
+    const ethId = toEthAddress(id)
+    accounts = accounts.filter((account) => !account.id.equals(ethId))
+    persist()
+  },
+
+  removeAccount(id: EthAddress): void {
+    accountsStore.remove(id)
+  },
+
+  /** Drop every account from this browser (used by the /dev "Clear all data" tool). */
+  clear(): void {
+    accounts = []
+    storageManager.clear()
+  },
+
+  rename(id: string | EthAddress, name: string): void {
+    update(id, (account) => ({ ...account, name }))
+  },
+
+  setAccountName(id: EthAddress, name: string): void {
+    accountsStore.rename(id, name)
+  },
+
+  /** Swap the unlock method: new access metadata + seed re-encrypted for it. */
+  setAccess(id: string | EthAddress, access: AccessMethod, encryptedSeed: string): void {
+    update(id, (account) =>
+      account.type === 'local' ? { ...account, access, encryptedSeed } : account,
+    )
+  },
+
+  /** How long app connections stay valid, set in days (stored as ms). */
+  setAppConnectionDays(id: string | EthAddress, days: number): void {
+    update(id, (account) => ({
+      ...account,
+      settings: { ...account.settings, appSessionDuration: days * MS_PER_DAY },
+    }))
+  },
+
+  setSessionDuration(id: EthAddress, appSessionDuration: number | undefined): void {
+    update(id, (account) => ({
+      ...account,
+      settings: { ...account.settings, appSessionDuration },
+    }))
+  },
+
+  // --------------------------------------------------------------------------
+  // Connected apps (account-owned, keyed by appUrl)
+  // --------------------------------------------------------------------------
+
+  /** All apps for an account, INCLUDING revoked tombstones (for the synced snapshot). */
+  getApps(id: EthAddress): ConnectedApp[] {
+    return getById(id)?.connectedApps ?? []
+  },
+
+  /** Displayable (non-revoked) apps for an account. */
+  getActiveApps(id: EthAddress): ConnectedApp[] {
+    return accountsStore.getApps(id).filter((app) => !app.revokedAt)
+  },
+
+  /** Record a (re)connection — replaces any previous entry for the app. */
+  connectApp(id: string | EthAddress, app: ConnectedApp): void {
+    update(id, (account) => {
+      const has = account.connectedApps.some((existing) => existing.appUrl === app.appUrl)
+      const connectedApps = has
+        ? account.connectedApps.map((existing) =>
+            existing.appUrl === app.appUrl
+              ? { ...existing, ...app, revokedAt: undefined }
+              : existing,
+          )
+        : [...account.connectedApps, app]
+      return { ...account, connectedApps }
+    })
+  },
+
+  disconnectApp(id: string | EthAddress, appUrl: string): void {
+    update(id, (account) => ({
+      ...account,
+      connectedApps: account.connectedApps.map((app) =>
+        app.appUrl === appUrl ? revoked(app, false) : app,
+      ),
+    }))
+  },
+
+  /** Disconnect and tombstone so the removal propagates to sync. */
+  removeApp(id: string | EthAddress, appUrl: string): void {
+    update(id, (account) => ({
+      ...account,
+      connectedApps: account.connectedApps.map((app) =>
+        app.appUrl === appUrl ? revoked(app, true) : app,
+      ),
+    }))
+  },
+
+  // --------------------------------------------------------------------------
+  // Drives — an account's owned Swarm storage, each backed by a postage stamp
+  // batch on the Bee node (persisted as the lib `postageStamps` field; the
+  // default is `defaultPostageStampBatchID`).
+  // --------------------------------------------------------------------------
+
+  getDrives(id: EthAddress): PostageStamp[] {
+    return getById(id)?.postageStamps ?? []
+  },
+
+  addDrive(id: EthAddress, drive: Omit<PostageStamp, 'createdAt'>): PostageStamp {
+    const newDrive: PostageStamp = { ...drive, createdAt: Date.now() }
+    update(id, (account) => {
+      if (account.postageStamps.some((existing) => existing.batchID.equals(drive.batchID))) {
+        throw new Error(`Drive with batch ID ${drive.batchID.toHex()} already exists`)
+      }
+      return { ...account, postageStamps: [...account.postageStamps, newDrive] }
+    })
+    return newDrive
+  },
+
+  removeDrive(
+    id: EthAddress,
+    batchID: BatchId,
+    { skipSync = false }: { skipSync?: boolean } = {},
+  ): void {
+    update(
+      id,
+      (account) => ({
+        ...account,
+        postageStamps: account.postageStamps.filter((drive) => !drive.batchID.equals(batchID)),
+        // Never leave a default pointing at a drive we just removed.
+        defaultPostageStampBatchID: account.defaultPostageStampBatchID?.equals(batchID)
+          ? undefined
+          : account.defaultPostageStampBatchID,
+      }),
+      { skipSync },
+    )
+  },
+
+  /** Update a drive's volatile utilization in place, WITHOUT firing sync. */
+  updateDriveUtilization(id: EthAddress, batchID: BatchId, utilization: number): void {
+    update(
+      id,
+      (account) => ({
+        ...account,
+        postageStamps: account.postageStamps.map((drive) =>
+          drive.batchID.equals(batchID) ? { ...drive, utilization } : drive,
+        ),
+      }),
+      { skipSync: true },
+    )
+  },
+
+  setDefaultDrive(id: string | EthAddress, batchID: BatchId | undefined): void {
+    update(id, (account) => ({ ...account, defaultPostageStampBatchID: batchID }))
+  },
+
+  updateDevices(id: EthAddress, devices: Device[]): void {
+    update(id, (account) => ({ ...account, devices }), { skipSync: true })
+  },
+
+  /**
+   * Apply state merged from a Swarm refresh to one account, WITHOUT re-publishing
+   * (the data came from Swarm).
+   */
+  applyRefreshed(
+    id: EthAddress,
+    fields: {
+      devices?: Device[]
+      connectedApps?: ConnectedApp[]
+      postageStamps?: PostageStamp[]
+    },
+  ): void {
+    update(
+      id,
+      (account) => ({
+        ...account,
+        devices: fields.devices ?? account.devices,
+        connectedApps: fields.connectedApps ?? account.connectedApps,
+        postageStamps: fields.postageStamps ?? account.postageStamps,
+      }),
+      { skipSync: true },
+    )
+  },
+}

--- a/ui/src/lib/stores/accounts.svelte.ts
+++ b/ui/src/lib/stores/accounts.svelte.ts
@@ -3,9 +3,9 @@
 import { BatchId, EthAddress } from '@ethersphere/bee-js'
 import {
   type AccessMethod,
-  type Account,
   type ConnectedApp,
   type Device,
+  type LocalAccount,
   type PostageStamp,
   STORAGE_KEY_ACCOUNTS,
   createAccountsStorageManager,
@@ -13,81 +13,176 @@ import {
 
 import { browser } from '$app/environment'
 
-// ============================================================================
-// Accounts store — the single source of truth
-//
-// Wraps the `@snaha/swarm-id` Zod-validated storage manager (persisted under
-// `STORAGE_KEY_ACCOUNTS`): the SAME nested-account document the proxy iframe and
-// sync engine read. The product UI, the /dev tooling, and the sync subsystem all
-// drive off this one reactive store — there is no separate display model.
-//
-// The UI only ever creates `local` accounts. Mutations that touch `access` /
-// `encryptedSeed` therefore guard on `type === 'local'`.
-// ============================================================================
-
 const MS_PER_DAY = 24 * 60 * 60 * 1000
 
-const storageManager = createAccountsStorageManager()
-
-function loadAccounts(): Account[] {
-  if (!browser) return []
-  return storageManager.load()
-}
-
-let accounts = $state<Account[]>(loadAccounts())
-
-if (browser) {
-  // Cross-tab refresh: another tab mutating the account document (sign-in,
-  // app connect, stamp purchase) updates this tab's reactive state too.
-  window.addEventListener('storage', (e) => {
-    if (e.key !== STORAGE_KEY_ACCOUNTS) return
-    accounts = loadAccounts()
-  })
-}
-
 /**
- * Optional sync hook. The /dev sync subsystem injects `triggerSync` so its
- * mutations publish to Swarm; the plain product app leaves it unset, so a
- * rename or app-connect never attempts a network publish.
+ * The account aggregate root. Fields are reactive (`$state`) so component reads
+ * update on mutation, and every mutator is a method **on the object** that
+ * persists the whole collection through the injected `onChange` — callers mutate
+ * the account they already hold (`account.addDrive(…)`), never a store method
+ * that takes an id and looks the account up.
+ *
+ * The shape is the shared `@snaha/swarm-id` `LocalAccount` (byte-class fields,
+ * serialized to hex by the lib storage manager). A drive is an account's owned
+ * Swarm storage, persisted as the lib `postageStamps` field. The private
+ * `#onChange` makes the class nominal, so plain `LocalAccount` data can't be
+ * mistaken for a live account.
  */
-let syncHook: ((accountIdHex: string) => void) | undefined
+export class Account {
+  readonly type = 'local' as const
+  readonly id: EthAddress
+  readonly createdAt: number
+  readonly derivationKey: string
+  // Initialized here so the runes compiler tracks them; real values are set
+  // from the record in the constructor.
+  name = $state('')
+  publicKey = $state<string | undefined>(undefined)
+  access = $state<AccessMethod>({ type: 'password', kdfSalt: '', kdfIterations: 0 })
+  encryptedSeed = $state('')
+  settings = $state<{ appSessionDuration?: number } | undefined>(undefined)
+  defaultPostageStampBatchID = $state<BatchId | undefined>(undefined)
+  devices = $state<Device[]>([])
+  connectedApps = $state<ConnectedApp[]>([])
+  postageStamps = $state<PostageStamp[]>([])
+  lastModified = $state<number | undefined>(undefined)
+  partitionCount = $state<number | undefined>(undefined)
+  readonly #onChange: (account: Account, options?: { skipSync?: boolean }) => void
 
-export function setAccountsSyncHook(hook: (accountIdHex: string) => void): void {
-  syncHook = hook
-}
+  constructor(
+    record: LocalAccount,
+    onChange: (account: Account, options?: { skipSync?: boolean }) => void,
+  ) {
+    this.id = record.id
+    this.createdAt = record.createdAt
+    this.derivationKey = record.derivationKey
+    this.name = record.name
+    this.publicKey = record.publicKey
+    this.access = record.access
+    this.encryptedSeed = record.encryptedSeed
+    this.settings = record.settings
+    this.defaultPostageStampBatchID = record.defaultPostageStampBatchID
+    this.devices = record.devices
+    this.connectedApps = record.connectedApps
+    this.postageStamps = record.postageStamps
+    this.lastModified = record.lastModified
+    this.partitionCount = record.partitionCount
+    this.#onChange = onChange
+  }
 
-function toEthAddress(id: string | EthAddress): EthAddress {
-  return typeof id === 'string' ? new EthAddress(id) : id
-}
+  #persist(options?: { skipSync?: boolean }) {
+    this.#onChange(this, options)
+  }
 
-function persist(): void {
-  storageManager.save(accounts)
-}
+  /** Active (non-revoked) connected apps — what the UI displays. */
+  get activeApps(): ConnectedApp[] {
+    return this.connectedApps.filter((app) => !app.revokedAt)
+  }
 
-function getById(id: string | EthAddress): Account | undefined {
-  const ethId = toEthAddress(id)
-  return accounts.find((account) => account.id.equals(ethId))
-}
+  rename(name: string) {
+    this.name = name
+    this.#persist()
+  }
 
-/**
- * Map the matching account through `fn`, persist, and (unless `skipSync`) fire
- * the sync hook for it. The single mutation primitive.
- */
-function update(
-  id: string | EthAddress,
-  fn: (account: Account) => Account,
-  { skipSync = false }: { skipSync?: boolean } = {},
-): void {
-  const ethId = toEthAddress(id)
-  let changed = false
-  accounts = accounts.map((account) => {
-    if (!account.id.equals(ethId)) return account
-    changed = true
-    return fn(account)
-  })
-  if (!changed) return
-  persist()
-  if (!skipSync) syncHook?.(ethId.toHex())
+  /** Swap the unlock method: new access metadata + seed re-encrypted for it. */
+  setAccess(access: AccessMethod, encryptedSeed: string) {
+    this.access = access
+    this.encryptedSeed = encryptedSeed
+    this.#persist()
+  }
+
+  /** How long app connections stay valid, set in days (stored as ms). */
+  setAppConnectionDays(days: number) {
+    this.settings = { ...this.settings, appSessionDuration: days * MS_PER_DAY }
+    this.#persist()
+  }
+
+  // --------------------------------------------------------------------------
+  // Connected apps (keyed by appUrl)
+  // --------------------------------------------------------------------------
+
+  /** Record a (re)connection — replaces any previous entry for the same app. */
+  connectApp(app: ConnectedApp) {
+    const has = this.connectedApps.some((existing) => existing.appUrl === app.appUrl)
+    this.connectedApps = has
+      ? this.connectedApps.map((existing) =>
+          existing.appUrl === app.appUrl ? { ...existing, ...app, revokedAt: undefined } : existing,
+        )
+      : [...this.connectedApps, app]
+    this.#persist()
+  }
+
+  disconnectApp(appUrl: string) {
+    this.connectedApps = this.connectedApps.map((app) =>
+      app.appUrl === appUrl ? revoked(app, false) : app,
+    )
+    this.#persist()
+  }
+
+  /** Disconnect and tombstone so the removal propagates to sync. */
+  removeApp(appUrl: string) {
+    this.connectedApps = this.connectedApps.map((app) =>
+      app.appUrl === appUrl ? revoked(app, true) : app,
+    )
+    this.#persist()
+  }
+
+  // --------------------------------------------------------------------------
+  // Drives — owned Swarm storage, each backed by a postage stamp batch (the lib
+  // `postageStamps` field). The default is `defaultPostageStampBatchID`.
+  // --------------------------------------------------------------------------
+
+  /**
+   * Add or replace a drive (deduped by batch id). The first drive added becomes
+   * the account default so uploads have something to spend against.
+   */
+  addDrive(drive: Omit<PostageStamp, 'createdAt'>): PostageStamp {
+    const newDrive: PostageStamp = { ...drive, createdAt: Date.now() }
+    this.postageStamps = [
+      ...this.postageStamps.filter((existing) => !existing.batchID.equals(drive.batchID)),
+      newDrive,
+    ]
+    this.defaultPostageStampBatchID ??= newDrive.batchID
+    this.#persist()
+    return newDrive
+  }
+
+  removeDrive(batchID: BatchId, { skipSync = false }: { skipSync?: boolean } = {}) {
+    this.postageStamps = this.postageStamps.filter((drive) => !drive.batchID.equals(batchID))
+    // Never leave a default pointing at a drive we just removed; fall back to
+    // whatever remains so the account never references a missing batch.
+    if (this.defaultPostageStampBatchID?.equals(batchID)) {
+      this.defaultPostageStampBatchID = this.postageStamps[0]?.batchID
+    }
+    this.#persist({ skipSync })
+  }
+
+  /** Update a drive's volatile utilization in place, WITHOUT firing sync. */
+  updateDriveUtilization(batchID: BatchId, utilization: number) {
+    this.postageStamps = this.postageStamps.map((drive) =>
+      drive.batchID.equals(batchID) ? { ...drive, utilization } : drive,
+    )
+    this.#persist({ skipSync: true })
+  }
+
+  setDefaultDrive(batchID: BatchId | undefined) {
+    this.defaultPostageStampBatchID = batchID
+    this.#persist()
+  }
+
+  /**
+   * Apply state merged from a Swarm refresh, WITHOUT re-publishing (the data
+   * came from Swarm).
+   */
+  applyRefreshed(fields: {
+    devices?: Device[]
+    connectedApps?: ConnectedApp[]
+    postageStamps?: PostageStamp[]
+  }) {
+    if (fields.devices) this.devices = fields.devices
+    if (fields.connectedApps) this.connectedApps = fields.connectedApps
+    if (fields.postageStamps) this.postageStamps = fields.postageStamps
+    this.#persist({ skipSync: true })
+  }
 }
 
 /** Revoke an app connection: drop the secret so the dApp proxy de-authenticates. */
@@ -103,6 +198,69 @@ function revoked(app: ConnectedApp, tombstone: boolean): ConnectedApp {
   }
 }
 
+// ============================================================================
+// Collection store — create / look up / remove whole accounts. Per-account
+// state changes live on the Account object itself.
+//
+// Backed by the `@snaha/swarm-id` Zod storage manager (key STORAGE_KEY_ACCOUNTS)
+// — the SAME nested-account document the proxy iframe and sync engine read. The
+// product UI, the /dev tooling and sync all drive off this one reactive store.
+// ============================================================================
+
+const storageManager = createAccountsStorageManager()
+
+/**
+ * Optional sync hook. The /dev sync subsystem injects `triggerSync` so its
+ * mutations publish to Swarm; the plain product app leaves it unset, so a
+ * rename or app-connect never attempts a network publish.
+ */
+let syncHook: ((accountIdHex: string) => void) | undefined
+
+export function setAccountsSyncHook(hook: (accountIdHex: string) => void): void {
+  syncHook = hook
+}
+
+let accounts = $state<Account[]>([])
+
+function persist(): void {
+  // Class instances are structurally `LocalAccount`; the lib serializer reads
+  // their fields and converts byte classes to hex.
+  storageManager.save(accounts)
+}
+
+/** Persist the collection and (unless skipped) publish the changed account. */
+function onChange(account: Account, options?: { skipSync?: boolean }): void {
+  persist()
+  if (!options?.skipSync) syncHook?.(account.id.toHex())
+}
+
+function hydrate(record: LocalAccount): Account {
+  return new Account(record, onChange)
+}
+
+function load(): Account[] {
+  if (!browser) return []
+  // The product UI only manages `local` accounts; ignore any other variant.
+  return storageManager
+    .load()
+    .filter((record): record is LocalAccount => record.type === 'local')
+    .map(hydrate)
+}
+
+accounts = load()
+
+if (browser) {
+  // Cross-tab refresh: another tab mutating the account document (sign-in,
+  // app connect, drive purchase) updates this tab's reactive state too.
+  window.addEventListener('storage', (event) => {
+    if (event.key === STORAGE_KEY_ACCOUNTS) accounts = load()
+  })
+}
+
+function toEthAddress(id: string | EthAddress): EthAddress {
+  return typeof id === 'string' ? new EthAddress(id) : id
+}
+
 export const accountsStore = {
   get accounts(): Account[] {
     return accounts
@@ -110,27 +268,25 @@ export const accountsStore = {
 
   /** Re-read from shared storage (e.g. after a direct storage manager write). */
   reload(): void {
-    accounts = loadAccounts()
+    accounts = load()
   },
 
   get(id: string | EthAddress): Account | undefined {
-    return getById(id)
+    const ethId = toEthAddress(id)
+    return accounts.find((account) => account.id.equals(ethId))
   },
 
   /** Alias used by the sync engine / dev tooling (keyed by EthAddress). */
   getAccount(id: EthAddress): Account | undefined {
-    return getById(id)
+    return accountsStore.get(id)
   },
 
-  add(account: Account): Account {
-    // Replace any previous record for the same address (sign-in / restore).
+  /** Create — or replace, for sign-in / restore — an account; returns the live object. */
+  add(record: LocalAccount): Account {
+    const account = hydrate(record)
     accounts = [...accounts.filter((existing) => !existing.id.equals(account.id)), account]
     persist()
     return account
-  },
-
-  addAccount(account: Account): Account {
-    return accountsStore.add(account)
   },
 
   remove(id: string | EthAddress): void {
@@ -139,177 +295,9 @@ export const accountsStore = {
     persist()
   },
 
-  removeAccount(id: EthAddress): void {
-    accountsStore.remove(id)
-  },
-
-  /** Drop every account from this browser (used by the /dev "Clear all data" tool). */
+  /** Wipe every account from this device (developer reset). */
   clear(): void {
     accounts = []
     storageManager.clear()
-  },
-
-  rename(id: string | EthAddress, name: string): void {
-    update(id, (account) => ({ ...account, name }))
-  },
-
-  setAccountName(id: EthAddress, name: string): void {
-    accountsStore.rename(id, name)
-  },
-
-  /** Swap the unlock method: new access metadata + seed re-encrypted for it. */
-  setAccess(id: string | EthAddress, access: AccessMethod, encryptedSeed: string): void {
-    update(id, (account) =>
-      account.type === 'local' ? { ...account, access, encryptedSeed } : account,
-    )
-  },
-
-  /** How long app connections stay valid, set in days (stored as ms). */
-  setAppConnectionDays(id: string | EthAddress, days: number): void {
-    update(id, (account) => ({
-      ...account,
-      settings: { ...account.settings, appSessionDuration: days * MS_PER_DAY },
-    }))
-  },
-
-  setSessionDuration(id: EthAddress, appSessionDuration: number | undefined): void {
-    update(id, (account) => ({
-      ...account,
-      settings: { ...account.settings, appSessionDuration },
-    }))
-  },
-
-  // --------------------------------------------------------------------------
-  // Connected apps (account-owned, keyed by appUrl)
-  // --------------------------------------------------------------------------
-
-  /** All apps for an account, INCLUDING revoked tombstones (for the synced snapshot). */
-  getApps(id: EthAddress): ConnectedApp[] {
-    return getById(id)?.connectedApps ?? []
-  },
-
-  /** Displayable (non-revoked) apps for an account. */
-  getActiveApps(id: EthAddress): ConnectedApp[] {
-    return accountsStore.getApps(id).filter((app) => !app.revokedAt)
-  },
-
-  /** Record a (re)connection — replaces any previous entry for the app. */
-  connectApp(id: string | EthAddress, app: ConnectedApp): void {
-    update(id, (account) => {
-      const has = account.connectedApps.some((existing) => existing.appUrl === app.appUrl)
-      const connectedApps = has
-        ? account.connectedApps.map((existing) =>
-            existing.appUrl === app.appUrl
-              ? { ...existing, ...app, revokedAt: undefined }
-              : existing,
-          )
-        : [...account.connectedApps, app]
-      return { ...account, connectedApps }
-    })
-  },
-
-  disconnectApp(id: string | EthAddress, appUrl: string): void {
-    update(id, (account) => ({
-      ...account,
-      connectedApps: account.connectedApps.map((app) =>
-        app.appUrl === appUrl ? revoked(app, false) : app,
-      ),
-    }))
-  },
-
-  /** Disconnect and tombstone so the removal propagates to sync. */
-  removeApp(id: string | EthAddress, appUrl: string): void {
-    update(id, (account) => ({
-      ...account,
-      connectedApps: account.connectedApps.map((app) =>
-        app.appUrl === appUrl ? revoked(app, true) : app,
-      ),
-    }))
-  },
-
-  // --------------------------------------------------------------------------
-  // Drives — an account's owned Swarm storage, each backed by a postage stamp
-  // batch on the Bee node (persisted as the lib `postageStamps` field; the
-  // default is `defaultPostageStampBatchID`).
-  // --------------------------------------------------------------------------
-
-  getDrives(id: EthAddress): PostageStamp[] {
-    return getById(id)?.postageStamps ?? []
-  },
-
-  addDrive(id: EthAddress, drive: Omit<PostageStamp, 'createdAt'>): PostageStamp {
-    const newDrive: PostageStamp = { ...drive, createdAt: Date.now() }
-    update(id, (account) => {
-      if (account.postageStamps.some((existing) => existing.batchID.equals(drive.batchID))) {
-        throw new Error(`Drive with batch ID ${drive.batchID.toHex()} already exists`)
-      }
-      return { ...account, postageStamps: [...account.postageStamps, newDrive] }
-    })
-    return newDrive
-  },
-
-  removeDrive(
-    id: EthAddress,
-    batchID: BatchId,
-    { skipSync = false }: { skipSync?: boolean } = {},
-  ): void {
-    update(
-      id,
-      (account) => ({
-        ...account,
-        postageStamps: account.postageStamps.filter((drive) => !drive.batchID.equals(batchID)),
-        // Never leave a default pointing at a drive we just removed.
-        defaultPostageStampBatchID: account.defaultPostageStampBatchID?.equals(batchID)
-          ? undefined
-          : account.defaultPostageStampBatchID,
-      }),
-      { skipSync },
-    )
-  },
-
-  /** Update a drive's volatile utilization in place, WITHOUT firing sync. */
-  updateDriveUtilization(id: EthAddress, batchID: BatchId, utilization: number): void {
-    update(
-      id,
-      (account) => ({
-        ...account,
-        postageStamps: account.postageStamps.map((drive) =>
-          drive.batchID.equals(batchID) ? { ...drive, utilization } : drive,
-        ),
-      }),
-      { skipSync: true },
-    )
-  },
-
-  setDefaultDrive(id: string | EthAddress, batchID: BatchId | undefined): void {
-    update(id, (account) => ({ ...account, defaultPostageStampBatchID: batchID }))
-  },
-
-  updateDevices(id: EthAddress, devices: Device[]): void {
-    update(id, (account) => ({ ...account, devices }), { skipSync: true })
-  },
-
-  /**
-   * Apply state merged from a Swarm refresh to one account, WITHOUT re-publishing
-   * (the data came from Swarm).
-   */
-  applyRefreshed(
-    id: EthAddress,
-    fields: {
-      devices?: Device[]
-      connectedApps?: ConnectedApp[]
-      postageStamps?: PostageStamp[]
-    },
-  ): void {
-    update(
-      id,
-      (account) => ({
-        ...account,
-        devices: fields.devices ?? account.devices,
-        connectedApps: fields.connectedApps ?? account.connectedApps,
-        postageStamps: fields.postageStamps ?? account.postageStamps,
-      }),
-      { skipSync: true },
-    )
   },
 }

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -1,58 +1,27 @@
 // Copyright 2026 The Swarm Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
+import type { LocalAccount } from '@snaha/swarm-id'
 
 /**
- * The account is the aggregate root: it owns its postage stamps and connected
- * apps directly (nested), rather than referencing them across flat collections.
- * All values are plain JSON so the whole account serializes as-is.
+ * The UI's account model IS the shared `@snaha/swarm-id` Zod model — a single,
+ * validated source of truth (no parallel hand-rolled interface). The identity
+ * UI only ever creates `local` accounts: the discriminated-union member whose
+ * BIP-39 entropy is encrypted at rest with a device-local access method
+ * (passkey / eth-wallet / password). Byte-typed fields (`id`, `postageStamps`,
+ * …) are bee-js classes at runtime and serialize to hex via the lib storage
+ * manager.
  */
+export type {
+  Account,
+  LocalAccount,
+  AccessMethod,
+  PostageStamp,
+  ConnectedApp,
+  AccountMetadata,
+} from '@snaha/swarm-id'
 
-/** How the encrypted seed is unlocked on this device. */
-export type AccessMethod =
-  | { type: 'passkey'; credentialId: string }
-  | { type: 'eth-wallet'; walletAddress: string; encryptionSalt: string }
-  | { type: 'password'; kdfSalt: string; kdfIterations: number }
-
-export interface PostageStamp {
-  batchId: string
-  signerKey: string
-  depth: number
-  amount: string
-  bucketDepth: number
-  blockNumber: number
-  immutableFlag: boolean
-  utilization: number
-  usable: boolean
-  exists: boolean
-  batchTTL?: number
-  createdAt: number
-}
-
-export interface ConnectedApp {
-  appUrl: string
-  appName: string
-  appIcon?: string
-  appDescription?: string
-  lastConnectedAt: number
-  connectedUntil?: number
-}
-
-export interface Account {
-  /** 0x-prefixed Ethereum address derived from the recovery phrase. */
-  id: string
-  name: string
-  /** Compressed secp256k1 public key (0x-prefixed hex). */
-  publicKey: string
-  createdAt: number
-  access: AccessMethod
-  /** BIP-39 entropy encrypted with the access-method key (hex: IV || ciphertext). */
-  encryptedSeed: string
-  /** How long app connections stay valid, in days. */
-  appConnectionDays?: number
-  defaultStampBatchId?: string
-  stamps: PostageStamp[]
-  connectedApps: ConnectedApp[]
-}
-
-/** The portable part of an account carried by sign-in sync and backup files. */
-export type AccountData = Omit<Account, 'access' | 'encryptedSeed'>
+/**
+ * The portable part of a local account carried by sign-in sync and backup
+ * files — everything except this device's unlock secrets.
+ */
+export type AccountData = Omit<LocalAccount, 'access' | 'encryptedSeed'>

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -3,16 +3,19 @@
 import type { LocalAccount } from '@snaha/swarm-id'
 
 /**
- * The UI's account model IS the shared `@snaha/swarm-id` Zod model — a single,
- * validated source of truth (no parallel hand-rolled interface). The identity
- * UI only ever creates `local` accounts: the discriminated-union member whose
- * BIP-39 entropy is encrypted at rest with a device-local access method
- * (passkey / eth-wallet / password). Byte-typed fields (`id`, `postageStamps`,
- * …) are bee-js classes at runtime and serialize to hex via the lib storage
- * manager.
+ * `Account` is the live, rich aggregate the app works with: a reactive class
+ * (its fields are `$state`) whose mutators are methods on the object
+ * (`account.addDrive(…)`, `account.rename(…)`). It wraps the shared
+ * `@snaha/swarm-id` `LocalAccount` shape (byte-class fields serialized to hex by
+ * the lib storage manager) and is type-only re-exported here so `$lib/types`
+ * stays the one type entry point with no runtime cycle.
+ *
+ * `LocalAccount` (+ the nested entity types) is the portable, validated DATA the
+ * account is built from / serialized to.
  */
+export type { Account } from '$lib/stores/accounts.svelte'
+
 export type {
-  Account,
   LocalAccount,
   AccessMethod,
   PostageStamp,

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -47,4 +47,19 @@ export function truncateAddress(address: string): string {
   return `${address.slice(0, ADDRESS_PREFIX_LENGTH)}...${address.slice(-ADDRESS_SUFFIX_LENGTH)}`
 }
 
+/**
+ * Render a bee-js byte class (or bare hex string) as 0x-prefixed hex for
+ * display/copy. bee-js `.toHex()` returns bare lowercase hex; the UI shows the
+ * 0x-prefixed form everywhere.
+ */
+export function display0x(value: string | { toHex(): string }): string {
+  const hex = typeof value === 'string' ? value : value.toHex()
+  return hex.startsWith('0x') ? hex : `0x${hex}`
+}
+
+/** Bare lowercase hex (no 0x prefix) — the form persisted in shared records. */
+export function bareHex(value: string): string {
+  return (value.startsWith('0x') ? value.slice(2) : value).toLowerCase()
+}
+
 export type WithElementRef<T, El extends HTMLElement = HTMLElement> = T & { ref?: El | null }

--- a/ui/src/routes/account/import/+page.svelte
+++ b/ui/src/routes/account/import/+page.svelte
@@ -39,7 +39,7 @@
       // Already set up on this device — just switch to it.
       const existing = accountsStore.get(wallet.address)
       if (existing) {
-        sessionStore.setCurrentAccount(existing.id)
+        sessionStore.setCurrentAccount(existing.id.toHex())
 
         // Came from a dApp connect popup — the phrase already unlocked the
         // account, so finish the handshake right away.

--- a/ui/src/routes/account/new/access/+page.svelte
+++ b/ui/src/routes/account/new/access/+page.svelte
@@ -6,10 +6,12 @@
 <script lang="ts">
   import { onMount } from 'svelte'
 
+  import { EthAddress } from '@ethersphere/bee-js'
   import ChevronLeft from '@lucide/svelte/icons/chevron-left'
   import Eye from '@lucide/svelte/icons/eye'
   import EyeOff from '@lucide/svelte/icons/eye-off'
   import LoaderCircle from '@lucide/svelte/icons/loader-circle'
+  import { PARTITION_COUNT, deriveAccountDerivationKey } from '@snaha/swarm-id'
 
   import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'
@@ -27,13 +29,14 @@
   } from '$lib/crypto/encryption'
   import { deriveWalletKey, requestWalletKeySource } from '$lib/crypto/eth-wallet'
   import { bytesToHex } from '$lib/crypto/hex'
-  import { walletFromPhrase } from '$lib/crypto/mnemonic'
+  import { privateKeyFromEntropy, walletFromPhrase } from '$lib/crypto/mnemonic'
   import { createPasskeyKey } from '$lib/crypto/passkey'
   import routes from '$lib/routes'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { connectStore } from '$lib/stores/connect.svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
-  import type { AccessMethod } from '$lib/types'
+  import type { AccessMethod, LocalAccount } from '$lib/types'
+  import { bareHex } from '$lib/utils'
 
   const MIN_PASSWORD_LENGTH = 8
   const TABS = [
@@ -83,22 +86,29 @@
     }
     const wallet = walletFromPhrase(draft.phrase)
     // Carry over data from a restore, or from an existing record for the same
-    // address — re-importing a phrase must not wipe stamps or connected apps.
+    // address — re-importing a phrase must not wipe drives or connected apps.
     const carried = draft.restored ?? accountsStore.get(wallet.address)
-    const account = {
-      id: wallet.address,
+    // The derivation key is computed from the master key (the wallet private
+    // key) while the entropy is in hand — the same chain the proxy/sync use.
+    const masterKey = bareHex(privateKeyFromEntropy(wallet.entropy))
+    const account: LocalAccount = {
+      type: 'local',
+      id: new EthAddress(bareHex(wallet.address)),
       name: draft.name,
-      publicKey: wallet.publicKey,
+      publicKey: bareHex(wallet.publicKey),
       createdAt: carried?.createdAt ?? Date.now(),
+      derivationKey: await deriveAccountDerivationKey(masterKey),
       access,
       encryptedSeed: await encryptSeed(wallet.entropy, key),
-      appConnectionDays: carried?.appConnectionDays,
-      defaultStampBatchId: carried?.defaultStampBatchId,
-      stamps: carried?.stamps ?? [],
+      settings: carried?.settings,
+      defaultPostageStampBatchID: carried?.defaultPostageStampBatchID,
+      devices: carried?.devices ?? [],
       connectedApps: carried?.connectedApps ?? [],
+      postageStamps: carried?.postageStamps ?? [],
+      partitionCount: carried?.partitionCount ?? PARTITION_COUNT,
     }
     accountsStore.add(account)
-    sessionStore.setCurrentAccount(wallet.address)
+    sessionStore.setCurrentAccount(account.id.toHex())
     const flow = draft.flow
 
     // Came from a dApp connect popup — finish the handshake and hand back.

--- a/ui/src/routes/account/new/access/+page.svelte
+++ b/ui/src/routes/account/new/access/+page.svelte
@@ -107,8 +107,9 @@
       postageStamps: carried?.postageStamps ?? [],
       partitionCount: carried?.partitionCount ?? PARTITION_COUNT,
     }
-    accountsStore.add(account)
-    sessionStore.setCurrentAccount(account.id.toHex())
+    // `add` returns the live reactive account; the handshake mutates it.
+    const liveAccount = accountsStore.add(account)
+    sessionStore.setCurrentAccount(liveAccount.id.toHex())
     const flow = draft.flow
 
     // Came from a dApp connect popup — finish the handshake and hand back.
@@ -116,7 +117,7 @@
     // leaves the Confirm buttons functional for a retry.
     const request = connectStore.request
     if (request) {
-      await completeConnect(account, wallet.entropy, request)
+      await completeConnect(liveAccount, wallet.entropy, request)
       sessionStore.setCompletedFlow(flow)
       sessionStore.clearDraft()
       goto(resolve(routes.CONNECT_DONE))

--- a/ui/src/routes/account/new/done/+page.svelte
+++ b/ui/src/routes/account/new/done/+page.svelte
@@ -45,7 +45,7 @@
       <div class="flex w-full max-w-96 flex-col items-center gap-8">
         <div class="flex flex-col items-center gap-4">
           <Polycon
-            value={account.id}
+            value={account.id.toHex()}
             size={IDENTICON_SIZE}
             class="shrink-0 overflow-hidden rounded-lg"
           />
@@ -59,16 +59,14 @@
 
           <div class="bg-muted flex w-full flex-col items-center rounded-lg p-2 text-center">
             <p class="text-sm font-bold">Want the full experience?</p>
-            <p class="text-sm">
-              Upload data and sync your Swarm ID across devices with a postage stamp.
-            </p>
+            <p class="text-sm">Upload data and sync your Swarm ID across devices with a drive.</p>
           </div>
         </div>
 
         <div class="flex w-full flex-col items-center gap-4">
           <div class="flex w-full flex-col items-center gap-2">
-            <!-- Stamp purchase flow is still TBD in the design. -->
-            <Button class="w-full" onclick={notImplemented}>Add a postage stamp</Button>
+            <!-- Drive purchase flow is still TBD in the design. -->
+            <Button class="w-full" onclick={notImplemented}>Add a drive</Button>
             <Button variant="outline" class="w-full" href={resolve(routes.HOME)}>
               Stay local for now
             </Button>

--- a/ui/src/routes/account/ready/+page.svelte
+++ b/ui/src/routes/account/ready/+page.svelte
@@ -46,7 +46,7 @@
       <div class="flex w-full max-w-96 flex-col items-center gap-8">
         <div class="flex flex-col items-center gap-4">
           <Polycon
-            value={account.id}
+            value={account.id.toHex()}
             size={IDENTICON_SIZE}
             class="shrink-0 overflow-hidden rounded-lg"
           />

--- a/ui/src/routes/connect/+page.svelte
+++ b/ui/src/routes/connect/+page.svelte
@@ -25,11 +25,11 @@
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { connectStore } from '$lib/stores/connect.svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
-  import type { Account } from '$lib/types'
-  import { notImplemented, truncateAddress } from '$lib/utils'
+  import type { Account, LocalAccount } from '$lib/types'
+  import { display0x, notImplemented, truncateAddress } from '$lib/utils'
 
   let missingRequest = $state(false)
-  let unlocking = $state<Account | undefined>(undefined)
+  let unlocking = $state<LocalAccount | undefined>(undefined)
   let pendingCeremony = $state(false)
   let busy = $state(false)
   let password = $state('')
@@ -76,12 +76,12 @@
   })
 
   async function select(account: Account) {
-    if (!request) {
+    if (!request || account.type !== 'local') {
       return
     }
     // A still-valid prior connection carries the secret — no unlock needed.
     if (reuseConnection(account, request)) {
-      sessionStore.setCurrentAccount(account.id)
+      sessionStore.setCurrentAccount(account.id.toHex())
       await goto(resolve(routes.CONNECT_DONE))
       return
     }
@@ -111,7 +111,7 @@
         return
       }
       await completeConnect(account, entropy, request)
-      sessionStore.setCurrentAccount(account.id)
+      sessionStore.setCurrentAccount(account.id.toHex())
       unlocking = undefined
       password = ''
       await goto(resolve(routes.CONNECT_DONE))
@@ -170,21 +170,21 @@
               <Tabs tabs={TABS} bind:value={() => activeTab, (value) => (selectedTab = value)} />
             {/if}
             <div class="flex w-full flex-col rounded-lg border p-1">
-              {#each shownAccounts as account (account.id)}
+              {#each shownAccounts as account (account.id.toHex())}
                 <button
                   type="button"
                   class="hover:bg-muted focus-visible:bg-muted flex w-full cursor-pointer items-center gap-2 rounded-md px-1.5 py-1.5 text-left text-sm outline-none"
                   onclick={() => select(account)}
                 >
                   <Polycon
-                    value={account.id}
+                    value={account.id.toHex()}
                     size={32}
                     class="shrink-0 overflow-hidden rounded-md"
                   />
                   <span class="flex min-w-0 flex-col">
                     <span class="truncate font-medium">{account.name}</span>
                     <span class="text-muted-foreground text-xs">
-                      {truncateAddress(account.id)}
+                      {truncateAddress(display0x(account.id))}
                     </span>
                   </span>
                 </button>

--- a/ui/src/routes/connect/+page.svelte
+++ b/ui/src/routes/connect/+page.svelte
@@ -25,11 +25,11 @@
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { connectStore } from '$lib/stores/connect.svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
-  import type { Account, LocalAccount } from '$lib/types'
+  import type { Account } from '$lib/types'
   import { display0x, notImplemented, truncateAddress } from '$lib/utils'
 
   let missingRequest = $state(false)
-  let unlocking = $state<LocalAccount | undefined>(undefined)
+  let unlocking = $state<Account | undefined>(undefined)
   let pendingCeremony = $state(false)
   let busy = $state(false)
   let password = $state('')
@@ -76,7 +76,7 @@
   })
 
   async function select(account: Account) {
-    if (!request || account.type !== 'local') {
+    if (!request) {
       return
     }
     // A still-valid prior connection carries the secret — no unlock needed.

--- a/ui/src/routes/connect/done/+page.svelte
+++ b/ui/src/routes/connect/done/+page.svelte
@@ -46,7 +46,7 @@
       <div class="flex w-full max-w-96 flex-col items-center gap-8">
         <div class="flex flex-col items-center gap-4">
           <Polycon
-            value={account.id}
+            value={account.id.toHex()}
             size={IDENTICON_SIZE}
             class="shrink-0 overflow-hidden rounded-lg"
           />

--- a/ui/src/routes/dev/+page.svelte
+++ b/ui/src/routes/dev/+page.svelte
@@ -686,7 +686,9 @@ Check console logs for details:
           assignError = 'Stamp not found in local storage.'
           return
         }
-        if (beeStamp.signerKey !== signerKeyToUse) {
+        // Compare by value — `signerKey` is a bee-js PrivateKey, so `!==` would
+        // always be true (distinct instances) and re-add the drive needlessly.
+        if (!beeStamp.signerKey.equals(signerKeyToUse)) {
           account.removeDrive(batchId)
           account.addDrive({ ...beeStamp, signerKey: signerKeyToUse })
         }
@@ -699,7 +701,10 @@ Check console logs for details:
     }
   }
 
-  function removeAccountDrive() {
+  // Clears the account's DEFAULT-drive pointer only; the stamp stays in the
+  // account's drives (delete it outright in "Stored Stamps" above). Assign is
+  // the symmetric op — it sets the default.
+  function clearDefaultDrive() {
     assignError = ''
     assignMessage = ''
     if (!selectedAccountId) {
@@ -708,7 +713,7 @@ Check console logs for details:
     }
     const accountId = new EthAddress(selectedAccountId)
     sharedAccountsStore.getAccount(accountId)?.setDefaultDrive(undefined)
-    assignMessage = `✅ Removed account drive from ${selectedAccountId.slice(0, 8)}…`
+    assignMessage = `✅ Cleared default drive for ${selectedAccountId.slice(0, 8)}…`
   }
 
   const LABEL_CLASS = 'flex flex-col gap-1.5 text-sm'
@@ -803,8 +808,9 @@ Check console logs for details:
           {accountCount} accounts, {connectionCount} connections, {driveCount} drives
         </p>
         <p class="text-muted-foreground text-xs">
-          Accounts appear here once they have a shared (sync/proxy) record — created the first time
-          an account connects to a dApp.
+          Every account on this device is listed here — the product UI, /dev and sync all read the
+          one shared account store, so accounts show up as soon as they're created (no dApp
+          connection required).
         </p>
         <div class="flex gap-2">
           <Button variant="destructive" onclick={clearAccount}>Clear account</Button>
@@ -1111,10 +1117,10 @@ Check console logs for details:
         </Button>
         <Button
           variant="destructive"
-          onclick={removeAccountDrive}
+          onclick={clearDefaultDrive}
           disabled={!accountHasDefaultDrive}
         >
-          Remove account drive
+          Clear default drive
         </Button>
       </div>
 

--- a/ui/src/routes/dev/+page.svelte
+++ b/ui/src/routes/dev/+page.svelte
@@ -629,7 +629,7 @@ Check console logs for details:
     }
   })
 
-  function assignAccountStamp() {
+  function assignAccountDrive() {
     assignError = ''
     assignMessage = ''
     if (!selectedStampId || !selectedAccountId) {
@@ -699,7 +699,7 @@ Check console logs for details:
     }
   }
 
-  function removeAccountStamp() {
+  function removeAccountDrive() {
     assignError = ''
     assignMessage = ''
     if (!selectedAccountId) {
@@ -1106,15 +1106,15 @@ Check console logs for details:
       </div>
 
       <div class="flex items-center gap-2">
-        <Button onclick={assignAccountStamp} disabled={!selectedStampId || !selectedAccountId}>
-          Set Account Stamp
+        <Button onclick={assignAccountDrive} disabled={!selectedStampId || !selectedAccountId}>
+          Set account drive
         </Button>
         <Button
           variant="destructive"
-          onclick={removeAccountStamp}
+          onclick={removeAccountDrive}
           disabled={!accountHasDefaultDrive}
         >
-          Remove Account Stamp
+          Remove account drive
         </Button>
       </div>
 

--- a/ui/src/routes/dev/+page.svelte
+++ b/ui/src/routes/dev/+page.svelte
@@ -1,0 +1,1190 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<script lang="ts">
+  import { SvelteMap } from 'svelte/reactivity'
+
+  import { BatchId, Bee, EthAddress, Identifier, PrivateKey, Utils } from '@ethersphere/bee-js'
+  import {
+    calculateStampAmountForDays,
+    derivePostageSignerKey,
+    downloadEncryptedSOC,
+    fetchChainState,
+    formatTTL,
+    rejectAfter,
+    uint8ArrayToHex,
+    uploadSOC,
+  } from '@snaha/swarm-id'
+
+  import { resolve } from '$app/paths'
+
+  import CopyButton from '$lib/components/copy-button.svelte'
+  import { Button } from '$lib/components/ui/button'
+  import { Input } from '$lib/components/ui/input'
+  import { Select } from '$lib/components/ui/select'
+  import { Tabs } from '$lib/components/ui/tabs'
+  import { sharedAccountsStore } from '$lib/dev/accounts.svelte'
+  import { devSettingsStore } from '$lib/dev/dev-settings.svelte'
+  import { networkSettingsStore } from '$lib/dev/network-settings.svelte'
+  import { postageStampsStore } from '$lib/dev/postage-stamps.svelte'
+  import { triggerSync } from '$lib/dev/sync-hooks'
+  import { syncStore } from '$lib/dev/sync.svelte'
+  import routes from '$lib/routes'
+  import { setAccountsSyncHook } from '$lib/stores/accounts.svelte'
+  import { sessionStore } from '$lib/stores/session.svelte'
+
+  import DeviceList from './device-list.svelte'
+  import StatusDot from './status-dot.svelte'
+
+  // Dev tooling drives Swarm publishing: register the sync hook so account
+  // mutations (here and in child panels) publish to Swarm after a debounce.
+  setAccountsSyncHook(triggerSync)
+
+  // Milliseconds per second — for converting TTL/Unix seconds to JS `Date` ms.
+  const MS_PER_SECOND = 1000
+
+  // How many days of validity to fund by default when auto-filling the
+  // stamp amount from current chain price. Bee enforces a 24h minimum on
+  // POST /stamps; 7 days gives comfortable headroom for dev testing without
+  // re-buying constantly.
+  const DEFAULT_STAMP_DAYS = 7
+
+  // Renders a listed stamp's remaining lifetime as "<ttl> (<date>)". batchTTL
+  // comes straight from the Bee node's /stamps response — authoritative for the
+  // batches it tracks, which is exactly what this list shows (no contract read
+  // needed here, and the default chain is local where the mainnet PostageStamp
+  // contract isn't deployed).
+  function formatStampExpiry(batchTTL: number): string {
+    if (!batchTTL || batchTTL <= 0) return 'Expired'
+    const date = new Date(Date.now() + batchTTL * MS_PER_SECOND).toLocaleDateString()
+    return `${formatTTL(batchTTL)} (${date})`
+  }
+
+  // Every stamp across all accounts (the account owns its stamps now).
+  const allStamps = $derived(sharedAccountsStore.accounts.flatMap((a) => a.postageStamps))
+
+  // Same set, but carrying the owning account — the Stored Stamps list needs the
+  // account id to delete a stamp from its nested collection.
+  const storedStampRows = $derived(
+    sharedAccountsStore.accounts.flatMap((a) =>
+      a.postageStamps.map((stamp) => ({ accountId: a.id, accountName: a.name, stamp })),
+    ),
+  )
+  let storedStampMessage = $state('')
+
+  // Delete a single stored stamp from local state only (dev cleanup — replaces
+  // the old hand-edit of localStorage). Local-only on purpose: a synced stamp
+  // delete is futile (no stamp tombstone yet — #337 — so a peer's union merge
+  // re-adds it).
+  function deleteStoredStamp(accountId: EthAddress, batchID: BatchId) {
+    sharedAccountsStore.removeDrive(accountId, batchID, { skipSync: true })
+    storedStampMessage = `🗑️ Deleted ${batchID.toHex().slice(0, 12)}… locally`
+  }
+
+  // Tab state
+  let activeTab = $state('overview')
+
+  const tabs = [
+    { value: 'overview', label: 'Overview' },
+    { value: 'stamps', label: 'Stamps' },
+    { value: 'sync', label: 'Sync' },
+    { value: 'devices', label: 'Devices' },
+  ]
+
+  // Demo app URL for connect flow testing (the new UI's demo runs on :3500).
+  const demoAppOrigin = 'http://localhost:3500'
+
+  // Sync state
+  let syncMessage = $state('')
+
+  // Stamp buying state
+  let beeUrl = $state('http://localhost:1633')
+  // Amount starts empty — autofilled from chain price on first chainstate
+  // load (see loadChainState). Hardcoding a default is fragile across chain
+  // configs: bee-compose's PriceOracle floor (24_000 PLUR/chunk/block) needs
+  // ≥ 414_720_000 PLUR/chunk for 24h, and other chains have different floors.
+  let stampAmount = $state('')
+  let stampDepth = $state('20')
+  let buying = $state(false)
+  let stampResult = $state<{ batchID: string; txHash: string } | undefined>(undefined)
+  let stampError = $state('')
+  let currentPrice = $state<bigint | undefined>(undefined)
+  let chainStateError = $state('')
+  let assignMessage = $state('')
+  let assignError = $state('')
+  let selectedStampId = $state('')
+  let selectedAccountId = $state('')
+
+  // Derived postage signer key + owner address for the selected account.
+  // Use the owner address to buy a stamp online, then paste the private key into
+  // the "Use existing one" screen as the signer key.
+  let accountSigner = $state<{ privateKey: string; owner: string } | undefined>(undefined)
+
+  $effect(() => {
+    const acct = selectedAccountId
+      ? sharedAccountsStore.getAccount(new EthAddress(selectedAccountId))
+      : undefined
+    if (!acct) {
+      accountSigner = undefined
+      return
+    }
+    // ponytail: fire-and-forget derive; effect re-runs when the selection changes
+    void (async () => {
+      const k = await derivePostageSignerKey(acct.derivationKey)
+      accountSigner = { privateKey: k, owner: new PrivateKey(k).publicKey().address().toHex() }
+    })()
+  })
+  let beeStamps = $state<
+    Array<{
+      batchID: string
+      utilization: number
+      usable: boolean
+      label: string
+      depth: number
+      amount: string
+      bucketDepth: number
+      blockNumber: number
+      immutableFlag: boolean
+      exists: boolean
+      batchTTL: number
+    }>
+  >([])
+  let beeStampsLoading = $state(false)
+  let beeStampsError = $state('')
+  let lastBeeUrl = $state('')
+
+  // Retrievability self-check: does the configured Bee node serve back a SOC we
+  // just wrote? (If not, no cross-device coordination — lock/intent/presence
+  // SOCs — can work there, and normal sync/download is unreliable too.)
+  let selfCheckStampId = $state('')
+  let selfCheckRunning = $state(false)
+  let selfCheckLog = $state<string[]>([])
+  // The address of the just-written test SOC — copy it to another device's
+  // "Read by address" to test cross-device retrievability.
+  let selfCheckSocAddress = $state('')
+
+  // Cross-device check: read a chunk BY ADDRESS that another device wrote
+  // (paste the SOC address printed by that device's self-check). On a
+  // load-balanced gateway the writer can read its own write back from its own
+  // backend, but a different device may hit a backend that can't retrieve it —
+  // this is the read that actually mirrors cross-device coordination.
+  let readAddr = $state('')
+  let readChecking = $state(false)
+  let readLog = $state<string[]>([])
+
+  // Partition-coordination timing overrides (gateway propagation tuning). Read
+  // by the proxy from this localStorage key on connect; blank fields fall back
+  // to the lib defaults. Must match PARTITION_TUNING_KEY in swarm-id-proxy.ts.
+  const PARTITION_TUNING_KEY = 'swarm-id-partition-tuning'
+  function loadTuning(): {
+    guardWindowMs?: number
+    guardPollMs?: number
+    readTimeoutMs?: number
+  } {
+    if (typeof localStorage === 'undefined') return {}
+    try {
+      return JSON.parse(localStorage.getItem(PARTITION_TUNING_KEY) ?? '{}') ?? {}
+    } catch {
+      return {}
+    }
+  }
+  const initialTuning = loadTuning()
+  let tuningWindow = $state(initialTuning.guardWindowMs?.toString() ?? '')
+  let tuningPoll = $state(initialTuning.guardPollMs?.toString() ?? '')
+  let tuningTimeout = $state(initialTuning.readTimeoutMs?.toString() ?? '')
+  let tuningSaved = $state('')
+
+  function saveTuning() {
+    const obj: Record<string, number> = {}
+    const add = (key: string, raw: string) => {
+      const n = Number(raw)
+      if (raw.trim() !== '' && Number.isFinite(n) && n >= 0) obj[key] = n
+    }
+    add('guardWindowMs', tuningWindow)
+    add('guardPollMs', tuningPoll)
+    add('readTimeoutMs', tuningTimeout)
+    localStorage.setItem(PARTITION_TUNING_KEY, JSON.stringify(obj))
+    tuningSaved = `Saved ${JSON.stringify(obj)} — reload the app/proxy to apply.`
+  }
+  function resetTuning() {
+    localStorage.removeItem(PARTITION_TUNING_KEY)
+    tuningWindow = ''
+    tuningPoll = ''
+    tuningTimeout = ''
+    tuningSaved = 'Cleared — reload to use defaults (window 12000 / poll 2500 / read 2500 ms).'
+  }
+
+  // Per-read timeout and the elapsed-since-upload checkpoints to poll at.
+  const SELF_CHECK_READ_TIMEOUT_MS = 3000
+  const SELF_CHECK_POLL_MS = [0, 2000, 5000, 10000, 20000]
+  const RANDOM_BYTES = 32
+
+  function randomBytes(): Uint8Array {
+    return crypto.getRandomValues(new Uint8Array(RANDOM_BYTES))
+  }
+
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+  async function runRetrievabilityCheck() {
+    selfCheckRunning = true
+    const log: string[] = []
+    selfCheckLog = log
+    const push = (line: string) => {
+      log.push(line)
+      selfCheckLog = [...log]
+    }
+    try {
+      const stamp = allStamps.find((s) => s.batchID.toHex() === selfCheckStampId)
+      if (!stamp) {
+        push('❌ Select a stored stamp to pay for the test chunk.')
+        return
+      }
+      // Test the node the proxy/app actually uses (network settings), not the
+      // dev-page stamp-buying URL which defaults to localhost.
+      const nodeUrl = networkSettingsStore.beeNodeUrl
+      const bee = new Bee(nodeUrl)
+      // Throwaway, fresh-per-run SOC: random owner key + identifier + encryption
+      // key + payload. Postage is paid by the stamp's signerKey; the SOC is
+      // owned by the throwaway signer — the same split a real presence beacon
+      // uses. A fresh address guarantees the read isn't served from a stale
+      // local cache.
+      const signer = new PrivateKey(randomBytes())
+      const encryptionKey = randomBytes()
+      const identifier = new Identifier(randomBytes())
+      const owner = signer.publicKey().address()
+
+      const stamper = await postageStampsStore.getStamper(stamp.batchID, {
+        owner,
+        encryptionKey,
+      })
+      if (!stamper) {
+        push('❌ Could not build a stamper for that batch.')
+        return
+      }
+
+      push(`Node: ${nodeUrl}`)
+      push(`Batch: ${stamp.batchID.toHex().slice(0, 12)}… (depth ${stamp.depth})`)
+      const t0 = Date.now()
+      const { socAddress } = await uploadSOC(
+        { mode: 'stamper', bee, stamper },
+        signer,
+        identifier,
+        randomBytes(),
+        { encryptionKey },
+      )
+      const addrHex = uint8ArrayToHex(socAddress)
+      selfCheckSocAddress = addrHex
+      push(`✅ Upload OK in ${Date.now() - t0}ms — SOC address ${addrHex}`)
+
+      let retrievedMs: number | undefined
+      let prev = 0
+      for (const checkpoint of SELF_CHECK_POLL_MS) {
+        await sleep(Math.max(0, checkpoint - prev))
+        prev = checkpoint
+        try {
+          await Promise.race([
+            downloadEncryptedSOC(bee, owner, identifier, encryptionKey),
+            rejectAfter(SELF_CHECK_READ_TIMEOUT_MS, 'read timed out'),
+          ])
+          retrievedMs = Date.now() - t0
+          break
+        } catch (error) {
+          push(
+            `  read @ ${checkpoint}ms: not yet (${error instanceof Error ? error.message : String(error)})`,
+          )
+        }
+      }
+
+      if (retrievedMs !== undefined) {
+        push(
+          `✅ Retrievable after ${retrievedMs}ms → this node serves back writes; multi-device coordination can work here.`,
+        )
+      } else {
+        push(
+          `❌ NOT retrievable within ~${SELF_CHECK_POLL_MS[SELF_CHECK_POLL_MS.length - 1] / 1000}s → this node does not serve back recently-written chunks. Cross-device coordination (lock/intent/presence SOCs) cannot work here, and normal sync/download will be unreliable too.`,
+        )
+      }
+    } catch (error) {
+      push(`❌ Error: ${error instanceof Error ? error.message : String(error)}`)
+    } finally {
+      selfCheckRunning = false
+    }
+  }
+
+  async function runReadByAddress() {
+    readChecking = true
+    const log: string[] = []
+    readLog = log
+    const push = (line: string) => {
+      log.push(line)
+      readLog = [...log]
+    }
+    try {
+      const addr = readAddr.trim().replace(/^0x/, '')
+      if (!/^[0-9a-fA-F]{64}$/.test(addr)) {
+        push('❌ Enter a 64-char hex chunk address (the SOC address from another device).')
+        return
+      }
+      const nodeUrl = networkSettingsStore.beeNodeUrl
+      const bee = new Bee(nodeUrl)
+      push(`Node: ${nodeUrl}`)
+      const t0 = Date.now()
+      let foundMs: number | undefined
+      let prev = 0
+      for (const checkpoint of SELF_CHECK_POLL_MS) {
+        await sleep(Math.max(0, checkpoint - prev))
+        prev = checkpoint
+        try {
+          await Promise.race([
+            bee.downloadChunk(addr),
+            rejectAfter(SELF_CHECK_READ_TIMEOUT_MS, 'read timed out'),
+          ])
+          foundMs = Date.now() - t0
+          break
+        } catch (error) {
+          push(
+            `  read @ ${checkpoint}ms: not yet (${error instanceof Error ? error.message : String(error)})`,
+          )
+        }
+      }
+      if (foundMs !== undefined) {
+        push(
+          `✅ Retrievable after ${foundMs}ms → this device CAN read the chunk the other device wrote; cross-device coordination can work.`,
+        )
+      } else {
+        push(
+          `❌ NOT retrievable within ~${SELF_CHECK_POLL_MS[SELF_CHECK_POLL_MS.length - 1] / 1000}s → this device cannot read the other device's chunk. The gateway isn't serving writes across nodes/sessions, so cross-device coordination cannot work here.`,
+        )
+      }
+    } catch (error) {
+      push(`❌ Error: ${error instanceof Error ? error.message : String(error)}`)
+    } finally {
+      readChecking = false
+    }
+  }
+
+  // Known dev signers (pre-funded with ETH + BZZ in the local Bee cluster)
+  const KNOWN_SIGNERS = [
+    {
+      value: '566058308ad5fa3888173c741a1fb902c9f1f19559b11fc2738dfc53637ce4e9',
+      label: 'Queen (node owner)',
+    },
+    {
+      value: '4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d',
+      label: 'Wallet 0 (pre-funded)',
+    },
+    {
+      value: '6cbed15c793ce57650b9877cf6fa156fbef513c4e6134f022a85b1ffdd59b2a1',
+      label: 'Wallet 1 (pre-funded)',
+    },
+  ]
+  let selectedSigner = $state(KNOWN_SIGNERS[0].value)
+
+  // Custom signer key settings
+  let useCustomSigner = $state(false)
+  let customSignerKey = $state('')
+  let customSignerError = $state<string | undefined>(undefined)
+
+  // Mock stamp widget settings — the store is the single source of truth
+  // (durable + cross-tab); the controls below read/write it directly.
+
+  // Validate custom signer key when enabled
+  $effect(() => {
+    if (useCustomSigner) {
+      if (customSignerKey.length === 0) {
+        customSignerError = 'Custom signer key is required'
+      } else if (!/^[0-9a-fA-F]+$/.test(customSignerKey)) {
+        customSignerError = 'Signer key must be a valid hex string'
+      } else if (customSignerKey.length !== 64) {
+        customSignerError = 'Signer key must be exactly 64 characters (hex)'
+      } else {
+        customSignerError = undefined
+      }
+    } else {
+      customSignerError = undefined
+    }
+  })
+
+  const stampOptions = $derived(
+    beeStamps.map((stamp) => ({
+      value: stamp.batchID,
+      label: `${stamp.batchID.slice(0, 10)}… (depth ${stamp.depth})`,
+    })),
+  )
+  // Stored stamps (with signerKey) usable to pay for the retrievability check.
+  const storedStampOptions = $derived(
+    allStamps.map((stamp) => ({
+      value: stamp.batchID.toHex(),
+      label: `${stamp.batchID.toHex().slice(0, 10)}… (depth ${stamp.depth})`,
+    })),
+  )
+  $effect(() => {
+    if (storedStampOptions.length && !selfCheckStampId) {
+      selfCheckStampId = storedStampOptions[0].value
+    }
+  })
+  const accountOptions = $derived(
+    sharedAccountsStore.accounts.map((account) => ({
+      value: account.id.toHex(),
+      label: `${account.name} (${account.id.toHex().slice(0, 10)}…)`,
+    })),
+  )
+  const selectedAccount = $derived(
+    selectedAccountId
+      ? sharedAccountsStore.getAccount(new EthAddress(selectedAccountId))
+      : undefined,
+  )
+  const accountHasDefaultDrive = $derived(!!selectedAccount?.defaultPostageStampBatchID)
+  const driveAssignments = $derived(
+    (() => {
+      const map = new SvelteMap<string, { account?: string }>()
+      for (const account of sharedAccountsStore.accounts) {
+        const batch = account.defaultPostageStampBatchID?.toHex()
+        if (batch) {
+          map.set(batch, { ...(map.get(batch) ?? {}), account: account.name })
+        }
+      }
+      return map
+    })(),
+  )
+
+  $effect(() => {
+    if (stampOptions.length && !selectedStampId) {
+      selectedStampId = stampOptions[0].value
+    } else if (
+      selectedStampId &&
+      !stampOptions.some((option) => option.value === selectedStampId)
+    ) {
+      selectedStampId = stampOptions[0]?.value ?? ''
+    }
+  })
+
+  $effect(() => {
+    if (accountOptions.length && !selectedAccountId) {
+      selectedAccountId = accountOptions[0].value
+    } else if (
+      selectedAccountId &&
+      !accountOptions.some((option) => option.value === selectedAccountId)
+    ) {
+      selectedAccountId = accountOptions[0]?.value ?? ''
+    }
+  })
+
+  async function triggerManualSync() {
+    // Get all accounts with a default stamp.
+    const accountsToSync = sharedAccountsStore.accounts.filter(
+      (account) => account.defaultPostageStampBatchID,
+    )
+
+    if (accountsToSync.length === 0) {
+      syncMessage = '❌ No accounts with default postage stamps found.'
+      return
+    }
+
+    syncMessage = `⏳ Syncing ${accountsToSync.length} accounts...`
+
+    const results: string[] = []
+    let successCount = 0
+    let errorCount = 0
+
+    for (const account of accountsToSync) {
+      try {
+        const result = await syncStore.syncAccount(account.id.toHex())
+
+        if (!result) {
+          results.push(`⚠️ ${account.name}: no snapshot captured (missing stamp?)`)
+          errorCount++
+          continue
+        }
+
+        if (result.status === 'error') {
+          results.push(`❌ ${account.name}: ${result.error}`)
+          errorCount++
+          continue
+        }
+
+        // Get default stamp to show utilization
+        const defaultStamp = account.defaultPostageStampBatchID
+        const stamp = defaultStamp ? postageStampsStore.getStamp(defaultStamp) : undefined
+        const utilization = stamp ? stamp.utilization.toFixed(2) : 'unknown'
+
+        if (result.status === 'success-unverified') {
+          results.push(
+            `⚠️ ${account.name}: synced, but root chunk not retrievable — ${result.warning}`,
+          )
+          errorCount++
+          continue
+        }
+
+        results.push(`✅ ${account.name}: ${utilization}% utilization`)
+        successCount++
+      } catch (error) {
+        results.push(
+          `❌ ${account.name}: ${error instanceof Error ? error.message : String(error)}`,
+        )
+        errorCount++
+      }
+    }
+
+    syncMessage = `Sync completed: ${successCount} succeeded, ${errorCount} failed
+
+${results.join('\n')}
+
+Check console logs for details:
+- [StateSync] Tracking X chunks
+- [StateSync] New utilization: Y%
+- [PostageStamps] Updated utilization`
+  }
+
+  async function buyStamp() {
+    buying = true
+    stampError = ''
+    stampResult = undefined
+
+    try {
+      // Buy a MUTABLE batch. Bee's POST /stamps defaults to immutable, but the
+      // multi-device partition scheme rewrites the partition-lock SOC on every
+      // lease refresh, which an immutable batch forbids. Request mutable
+      // explicitly so /dev-bought stamps work with partitioning.
+      const response = await fetch(`${beeUrl}/stamps/${stampAmount}/${stampDepth}`, {
+        method: 'POST',
+        headers: { immutable: 'false' },
+      })
+      if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(errorText || `HTTP ${response.status}`)
+      }
+      stampResult = await response.json()
+    } catch (e) {
+      stampError = e instanceof Error ? e.message : String(e)
+    } finally {
+      buying = false
+    }
+  }
+
+  // Clear this browser's accounts (which own their apps + stamps) + session.
+  function clearAccount() {
+    sharedAccountsStore.clear()
+    sessionStore.clearCurrentAccount()
+  }
+
+  // Full reset: every swarm* localStorage key + the IndexedDB utilization DB,
+  // then reload so all in-memory stores re-init from empty storage. onblocked
+  // resolves too — an open DB connection is closed by the reload, letting the
+  // pending delete finish.
+  async function clearAll() {
+    for (const key of Object.keys(localStorage)) {
+      if (key.startsWith('swarm')) localStorage.removeItem(key)
+    }
+    await new Promise<void>((resolve) => {
+      const req = indexedDB.deleteDatabase('swarm-utilization-store')
+      req.onsuccess = req.onerror = req.onblocked = () => resolve()
+    })
+    location.reload()
+  }
+
+  async function loadBeeStamps() {
+    beeStampsLoading = true
+    beeStampsError = ''
+    try {
+      const response = await fetch(`${beeUrl}/stamps`)
+      if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(errorText || `HTTP ${response.status}`)
+      }
+      const data = await response.json()
+      beeStamps = data.stamps ?? []
+      lastBeeUrl = beeUrl
+    } catch (error) {
+      beeStampsError = error instanceof Error ? error.message : String(error)
+      beeStamps = []
+    } finally {
+      beeStampsLoading = false
+    }
+  }
+
+  async function loadChainState() {
+    chainStateError = ''
+    try {
+      const state = await fetchChainState(beeUrl)
+      currentPrice = state.currentPrice
+      // Only autofill if the user hasn't typed (or pre-typed) a value yet.
+      // After the first fill, the user owns this field — switching bee URLs
+      // updates the displayed price but does not clobber their input.
+      if (stampAmount === '') {
+        stampAmount = calculateStampAmountForDays(state.currentPrice, DEFAULT_STAMP_DAYS).toString()
+      }
+    } catch (error) {
+      chainStateError = error instanceof Error ? error.message : String(error)
+      currentPrice = undefined
+    }
+  }
+
+  $effect(() => {
+    if (activeTab === 'stamps' && beeUrl && beeUrl !== lastBeeUrl && !beeStampsLoading) {
+      loadBeeStamps()
+      loadChainState()
+    }
+  })
+
+  function assignAccountStamp() {
+    assignError = ''
+    assignMessage = ''
+    if (!selectedStampId || !selectedAccountId) {
+      assignError = 'Select a stamp and an account first.'
+      return
+    }
+
+    // Validate custom signer if enabled
+    if (useCustomSigner && customSignerError) {
+      assignError = customSignerError
+      return
+    }
+
+    try {
+      const batchId = new BatchId(selectedStampId)
+      const accountId = new EthAddress(selectedAccountId)
+
+      // Determine which signer key to use
+      const signerKeyToUse =
+        useCustomSigner && customSignerKey
+          ? new PrivateKey(customSignerKey)
+          : new PrivateKey(selectedSigner)
+
+      if (!postageStampsStore.getStamp(batchId)) {
+        const beeStamp = beeStamps.find((s) => s.batchID === selectedStampId)
+        if (!beeStamp) {
+          assignError = 'Stamp data not found. Reload stamps first.'
+          return
+        }
+        sharedAccountsStore.addDrive(accountId, {
+          batchID: batchId,
+          signerKey: signerKeyToUse,
+          utilization: Utils.getStampUsage(
+            beeStamp.utilization,
+            beeStamp.depth,
+            beeStamp.bucketDepth,
+          ),
+          usable: beeStamp.usable,
+          depth: beeStamp.depth,
+          amount: BigInt(beeStamp.amount),
+          bucketDepth: beeStamp.bucketDepth,
+          blockNumber: beeStamp.blockNumber,
+          immutableFlag: beeStamp.immutableFlag,
+          exists: beeStamp.exists,
+        })
+      } else if (useCustomSigner) {
+        const beeStamp = postageStampsStore.getStamp(batchId)
+        if (!beeStamp) {
+          assignError = 'Stamp not found in local storage.'
+          return
+        }
+        if (beeStamp.signerKey !== signerKeyToUse) {
+          sharedAccountsStore.removeDrive(accountId, batchId)
+          sharedAccountsStore.addDrive(accountId, { ...beeStamp, signerKey: signerKeyToUse })
+        }
+      }
+
+      sharedAccountsStore.setDefaultDrive(accountId, batchId)
+      assignMessage = `✅ Set account drive for ${accountId.toHex().slice(0, 8)}…`
+    } catch (error) {
+      assignError = error instanceof Error ? error.message : String(error)
+    }
+  }
+
+  function removeAccountStamp() {
+    assignError = ''
+    assignMessage = ''
+    if (!selectedAccountId) {
+      assignError = 'Select an account first.'
+      return
+    }
+    const accountId = new EthAddress(selectedAccountId)
+    sharedAccountsStore.setDefaultDrive(accountId, undefined)
+    assignMessage = `✅ Removed account drive from ${selectedAccountId.slice(0, 8)}…`
+  }
+
+  const LABEL_CLASS = 'flex flex-col gap-1.5 text-sm'
+  const LABEL_TEXT_CLASS = 'text-muted-foreground'
+  const CARD_CLASS = 'flex flex-col gap-2 rounded-lg border bg-card p-4'
+</script>
+
+{#snippet copyRow(label: string, value: string, mono = true)}
+  <div class="flex flex-col gap-1.5">
+    <span class="text-muted-foreground text-sm">{label}</span>
+    <div class="flex items-center gap-2">
+      <span class={`text-sm break-all ${mono ? 'font-mono' : ''}`}>{value}</span>
+      <CopyButton text={value} />
+    </div>
+  </div>
+{/snippet}
+
+{#snippet signerCard(label: string, signer: { privateKey: string; owner: string })}
+  <div class={CARD_CLASS}>
+    <p class="font-mono text-sm font-semibold">{label}</p>
+    {@render copyRow('Owner Address', signer.owner)}
+    {@render copyRow('Private Key', signer.privateKey)}
+  </div>
+{/snippet}
+
+<div class="mx-auto flex w-full max-w-3xl flex-col gap-8 p-8">
+  <h2 class="text-xl font-bold">Developer Tools</h2>
+
+  <Tabs {tabs} bind:value={activeTab} />
+
+  <!-- Overview Tab -->
+  {#if activeTab === 'overview'}
+    {@const accountCount = sharedAccountsStore.accounts.length}
+    {@const connectionCount = sharedAccountsStore.accounts.reduce(
+      (n, a) => n + a.connectedApps.length,
+      0,
+    )}
+    {@const driveCount = allStamps.length}
+    {@const connectUrl = `${resolve(routes.CONNECT)}?origin=${encodeURIComponent(demoAppOrigin)}`}
+    <div class="flex flex-col gap-4">
+      <div class="flex flex-col gap-2">
+        <h4 class="text-sm font-semibold">Local Bee Endpoints</h4>
+        <div class="flex items-center gap-2">
+          <StatusDot endpoint="http://localhost:1633" />
+          <span class="font-mono text-sm">Queen API:</span>
+          <a
+            href="http://localhost:1633"
+            target="_blank"
+            rel="noopener"
+            class="text-primary font-mono text-sm">http://localhost:1633</a
+          >
+          <CopyButton text="http://localhost:1633" />
+        </div>
+        <div class="flex items-center gap-2">
+          <StatusDot endpoint="http://localhost:16331" />
+          <span class="font-mono text-sm">Worker API:</span>
+          <a
+            href="http://localhost:16331"
+            target="_blank"
+            rel="noopener"
+            class="text-primary font-mono text-sm">http://localhost:16331</a
+          >
+          <CopyButton text="http://localhost:16331" />
+        </div>
+        <div class="flex items-center gap-2">
+          <StatusDot endpoint="http://localhost:9545" method="json-rpc" />
+          <span class="font-mono text-sm">Blockchain RPC:</span>
+          <a
+            href="http://localhost:9545"
+            target="_blank"
+            rel="noopener"
+            class="text-primary font-mono text-sm">http://localhost:9545</a
+          >
+          <CopyButton text="http://localhost:9545" />
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <h4 class="text-sm font-semibold">Test Connect Flow</h4>
+        <p class="text-sm">Test the connect flow with the demo app:</p>
+        <div class="flex items-center gap-2">
+          <StatusDot endpoint={demoAppOrigin} />
+          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- template literal with resolve() -->
+          <a href={connectUrl} class="text-primary font-mono text-sm">localhost:3500 (demo)</a>
+          <CopyButton text={connectUrl} />
+        </div>
+      </div>
+
+      <div class="flex flex-col items-start gap-2">
+        <h4 class="text-sm font-semibold">Local Data</h4>
+        <p class="text-sm">
+          {accountCount} accounts, {connectionCount} connections, {driveCount} drives
+        </p>
+        <p class="text-muted-foreground text-xs">
+          Accounts appear here once they have a shared (sync/proxy) record — created the first time
+          an account connects to a dApp.
+        </p>
+        <div class="flex gap-2">
+          <Button variant="destructive" onclick={clearAccount}>Clear account</Button>
+          <Button variant="destructive" onclick={clearAll}>Clear all</Button>
+        </div>
+      </div>
+    </div>
+  {/if}
+
+  <!-- Stamps Tab -->
+  {#if activeTab === 'stamps'}
+    <div class="flex flex-col gap-4">
+      <!-- Mock Stamp Widget Settings -->
+      <div class="flex flex-col gap-2">
+        <h3 class="text-lg font-semibold">Mock Stamp Widget</h3>
+        <p class="text-sm">Control the behavior of the stamp purchase widget in the app.</p>
+
+        <div class="flex items-center gap-4">
+          <label class="flex cursor-pointer items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={devSettingsStore.data.mockStampEnabled}
+              onchange={(e) => devSettingsStore.setMockStampEnabled(e.currentTarget.checked)}
+            />
+            Enable mock mode
+          </label>
+        </div>
+
+        {#if devSettingsStore.data.mockStampEnabled}
+          <div class="flex items-center gap-4">
+            <span class="text-sm">Mock result:</span>
+            <label class="flex cursor-pointer items-center gap-2 text-sm">
+              <input
+                type="radio"
+                checked={devSettingsStore.data.mockStampResult === 'success'}
+                onchange={() => devSettingsStore.setMockStampResult('success')}
+              />
+              Success
+            </label>
+            <label class="flex cursor-pointer items-center gap-2 text-sm">
+              <input
+                type="radio"
+                checked={devSettingsStore.data.mockStampResult === 'error'}
+                onchange={() => devSettingsStore.setMockStampResult('error')}
+              />
+              Error
+            </label>
+          </div>
+        {/if}
+      </div>
+
+      <div class="bg-border my-4 h-px"></div>
+
+      <h3 class="text-lg font-semibold">Buy Postage Stamp</h3>
+      <p class="text-sm">Buy a postage stamp on the local blockchain for testing uploads.</p>
+
+      <div class="flex flex-col gap-2">
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Bee Node URL</span>
+          <Input bind:value={beeUrl} />
+        </label>
+        <div class="flex gap-4">
+          <label class={`${LABEL_CLASS} flex-1`}>
+            <span class={LABEL_TEXT_CLASS}>Amount</span>
+            <Input bind:value={stampAmount} />
+          </label>
+          <label class={`${LABEL_CLASS} w-32`}>
+            <span class={LABEL_TEXT_CLASS}>Depth (17-40)</span>
+            <Input bind:value={stampDepth} />
+          </label>
+        </div>
+        {#if currentPrice !== undefined}
+          {@const minAmount = calculateStampAmountForDays(currentPrice, 1)}
+          <p class="text-muted-foreground text-sm">
+            Chain price: {currentPrice.toLocaleString()} PLUR/chunk/block · 24h min: {minAmount.toLocaleString()}
+            PLUR · default fills {DEFAULT_STAMP_DAYS}d validity
+          </p>
+        {:else if chainStateError}
+          <p class="text-destructive text-sm">
+            Could not fetch chainstate from Bee: {chainStateError}
+          </p>
+        {/if}
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Signer Key</span>
+          <Select options={KNOWN_SIGNERS} bind:value={selectedSigner} />
+        </label>
+      </div>
+
+      <Button onclick={buyStamp} disabled={buying || !stampAmount}>
+        {buying ? 'Buying...' : 'Buy Stamp'}
+      </Button>
+
+      {#if stampResult}
+        {@const batchId = stampResult.batchID}
+        {@const txHash = stampResult.txHash}
+        <div class={CARD_CLASS}>
+          <p class="font-mono text-sm font-semibold">✅ Stamp purchased!</p>
+          {@render copyRow('Batch ID', batchId)}
+          <div class="flex gap-8">
+            {@render copyRow('Amount', stampAmount)}
+            {@render copyRow('Depth', stampDepth)}
+          </div>
+          {@render copyRow('Signer Key (for Stamper)', selectedSigner)}
+          {@render copyRow('Tx Hash', txHash)}
+          <p class="text-muted-foreground mt-2 text-sm">
+            Note: Wait ~30s for stamp to become usable.
+          </p>
+        </div>
+      {/if}
+
+      {#if stampError}
+        <div class={CARD_CLASS}>
+          <p class="text-destructive font-mono text-sm">❌ {stampError}</p>
+        </div>
+      {/if}
+
+      <div class="bg-border my-4 h-px"></div>
+
+      <h3 class="text-lg font-semibold">Stored Stamps (local)</h3>
+      <p class="text-muted-foreground text-sm">
+        The postage batches saved in this browser. Copy these fields before clearing storage — paste
+        them into the "Use existing one" screen to re-adopt the same batch on a fresh account (the
+        owner is derived from the signer key). Delete removes the stamp locally only (no sync).
+      </p>
+      {#if storedStampMessage}
+        <p class="font-mono text-sm">{storedStampMessage}</p>
+      {/if}
+      {#if storedStampRows.length === 0}
+        <p class="text-muted-foreground text-sm">No stamps stored locally.</p>
+      {:else}
+        <div class="flex flex-col gap-2">
+          {#each storedStampRows as { accountId, accountName, stamp } (stamp.batchID.toHex())}
+            <div class={CARD_CLASS}>
+              {@render copyRow('Batch ID', stamp.batchID.toHex())}
+              {@render copyRow('Signer Key', stamp.signerKey.toHex())}
+              <div class="flex gap-8">
+                {@render copyRow('Amount', stamp.amount.toString())}
+                {@render copyRow('Depth', String(stamp.depth))}
+                {@render copyRow('Block number', String(stamp.blockNumber))}
+              </div>
+              <div class="flex items-center justify-between gap-2">
+                <span class="text-muted-foreground text-sm">Account: {accountName}</span>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onclick={() => deleteStoredStamp(accountId, stamp.batchID)}>Delete</Button
+                >
+              </div>
+            </div>
+          {/each}
+        </div>
+      {/if}
+
+      <div class="bg-border my-4 h-px"></div>
+
+      <h3 class="text-lg font-semibold">Retrievability self-check</h3>
+      <p class="text-muted-foreground text-sm">
+        Writes a throwaway single-owner chunk to the Bee node from network settings ({networkSettingsStore.beeNodeUrl})
+        and reads it back, to confirm the node actually serves back what you write. Multi-device
+        coordination (and reliable sync/download) only works when this succeeds.
+      </p>
+      <div class="flex flex-col gap-2">
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Pay with stored stamp</span>
+          <Select options={storedStampOptions} bind:value={selfCheckStampId} />
+        </label>
+        <Button onclick={runRetrievabilityCheck} disabled={selfCheckRunning || !selfCheckStampId}>
+          {selfCheckRunning ? 'Checking…' : 'Run self-check'}
+        </Button>
+      </div>
+      {#if selfCheckLog.length}
+        <div class={CARD_CLASS}>
+          {#each selfCheckLog as line, i (i)}
+            <p class="font-mono text-sm break-all">{line}</p>
+          {/each}
+          {#if selfCheckSocAddress}
+            <div class="flex items-center gap-2">
+              <span class="text-muted-foreground text-sm"
+                >SOC address (copy to another device):</span
+              >
+              <CopyButton text={selfCheckSocAddress} />
+            </div>
+          {/if}
+        </div>
+      {/if}
+
+      <p class="text-muted-foreground mt-2 text-sm">
+        Cross-device check: run the self-check on another device, copy its SOC address, paste it
+        here, and read it back. The writer reading its own chunk can succeed on a load-balanced
+        gateway even when a different device cannot — this is the read that mirrors coordination.
+      </p>
+      <div class="flex flex-col gap-2">
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Chunk address from another device</span>
+          <Input bind:value={readAddr} />
+        </label>
+        <Button variant="secondary" onclick={runReadByAddress} disabled={readChecking || !readAddr}>
+          {readChecking ? 'Reading…' : 'Read by address'}
+        </Button>
+      </div>
+      {#if readLog.length}
+        <div class={CARD_CLASS}>
+          {#each readLog as line, i (i)}
+            <p class="font-mono text-sm break-all">{line}</p>
+          {/each}
+        </div>
+      {/if}
+
+      <div class="bg-border my-4 h-px"></div>
+
+      <h3 class="text-lg font-semibold">Partition tuning</h3>
+      <p class="text-muted-foreground text-sm">
+        Tune the multi-device intent-round timing for this gateway's propagation delay. Blank =
+        library default (window 12000 / poll 2500 / read 2500 ms). Reload the app after saving so
+        the proxy picks it up.
+      </p>
+      <div class="flex flex-col gap-2">
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Guard window (ms)</span>
+          <Input bind:value={tuningWindow} />
+        </label>
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Poll interval (ms)</span>
+          <Input bind:value={tuningPoll} />
+        </label>
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Read timeout (ms)</span>
+          <Input bind:value={tuningTimeout} />
+        </label>
+        <div class="flex items-center gap-2">
+          <Button onclick={saveTuning}>Save tuning</Button>
+          <Button variant="secondary" onclick={resetTuning}>Reset to defaults</Button>
+        </div>
+        {#if tuningSaved}
+          <p class="text-muted-foreground text-sm">{tuningSaved}</p>
+        {/if}
+      </div>
+
+      <div class="bg-border my-4 h-px"></div>
+
+      <div class="flex items-center justify-between">
+        <h3 class="text-lg font-semibold">Existing Stamps (Bee Node)</h3>
+        <Button variant="secondary" onclick={loadBeeStamps} disabled={beeStampsLoading}>
+          {beeStampsLoading ? 'Refreshing...' : 'Refresh'}
+        </Button>
+      </div>
+      {#if beeStampsError}
+        <p class="text-destructive text-sm">❌ {beeStampsError}</p>
+      {/if}
+      {#if beeStamps.length === 0}
+        <p class="text-muted-foreground text-sm">No stamps found on the Bee node.</p>
+      {:else}
+        <div class="flex flex-col gap-2">
+          {#each beeStamps as stamp (stamp.batchID)}
+            {@const assignment = driveAssignments.get(stamp.batchID)}
+            <div class="flex flex-col gap-2 rounded-lg border bg-card p-4">
+              <div class="flex items-center justify-between">
+                <p class="font-mono text-sm">{stamp.batchID}</p>
+                <CopyButton text={stamp.batchID} />
+              </div>
+              <div class="text-muted-foreground flex flex-wrap gap-2 text-sm">
+                <span>Depth: {stamp.depth}</span>
+                <span>Utilization: {stamp.utilization}</span>
+                <span>Expires: {formatStampExpiry(stamp.batchTTL)}</span>
+                <span>Account: {assignment?.account ?? '—'}</span>
+              </div>
+            </div>
+          {/each}
+        </div>
+      {/if}
+
+      <div class="bg-border my-4 h-px"></div>
+
+      <h3 class="text-lg font-semibold">Assign drive to account</h3>
+      <div class="flex flex-col gap-2">
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Stamp</span>
+          <Select options={stampOptions} bind:value={selectedStampId} />
+        </label>
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Account</span>
+          <Select options={accountOptions} bind:value={selectedAccountId} />
+        </label>
+
+        <label class="flex cursor-pointer items-center gap-2 text-sm">
+          <input type="checkbox" bind:checked={useCustomSigner} />
+          Use custom signer key
+        </label>
+
+        {#if useCustomSigner}
+          <label class={LABEL_CLASS}>
+            <span class={LABEL_TEXT_CLASS}>Custom Signer Key</span>
+            <Input bind:value={customSignerKey} aria-invalid={!!customSignerError} />
+            {#if customSignerError}
+              <span class="text-destructive text-xs">{customSignerError}</span>
+            {/if}
+          </label>
+        {/if}
+      </div>
+
+      <div class="flex items-center gap-2">
+        <Button onclick={assignAccountStamp} disabled={!selectedStampId || !selectedAccountId}>
+          Set Account Stamp
+        </Button>
+        <Button
+          variant="destructive"
+          onclick={removeAccountStamp}
+          disabled={!accountHasDefaultDrive}
+        >
+          Remove Account Stamp
+        </Button>
+      </div>
+
+      {#if assignMessage}
+        <p class="text-success text-sm">{assignMessage}</p>
+      {/if}
+      {#if assignError}
+        <p class="text-destructive text-sm">{assignError}</p>
+      {/if}
+
+      <div class="bg-border my-4 h-px"></div>
+
+      <h3 class="text-lg font-semibold">Signer Key / Owner Address</h3>
+      <p class="text-muted-foreground text-sm">
+        Buy a stamp online under the owner address, then paste the private key as the signer key in
+        the "Use existing one" screen. Reflects the account selected above.
+      </p>
+
+      {#if !selectedAccountId}
+        <p class="text-muted-foreground text-sm">Select an account above to view its signer key.</p>
+      {:else if accountSigner}
+        <div class="flex flex-col gap-2">
+          {@render signerCard('Account-level signer', accountSigner)}
+        </div>
+      {/if}
+    </div>
+  {/if}
+
+  <!-- Sync Tab -->
+  {#if activeTab === 'sync'}
+    <div class="flex flex-col gap-4">
+      <h3 class="text-lg font-semibold">Manual Sync Testing</h3>
+      <p class="text-sm">
+        Trigger a manual sync for ALL accounts to test postage stamp utilization tracking.
+      </p>
+      <div class="flex gap-4">
+        <Button onclick={triggerManualSync}>Sync All Accounts</Button>
+      </div>
+
+      {#if syncMessage}
+        <div class="flex flex-col gap-4 rounded-lg border bg-card p-4 whitespace-pre-wrap">
+          <p class="font-mono text-sm">{syncMessage}</p>
+        </div>
+      {/if}
+
+      <div class="flex flex-col gap-2">
+        <p class="text-muted-foreground text-sm">Requirements for sync:</p>
+        <p class="text-muted-foreground font-mono text-sm">
+          • At least one account with a default postage stamp
+        </p>
+        <p class="text-muted-foreground font-mono text-sm">
+          • Open browser console to see detailed logs
+        </p>
+      </div>
+    </div>
+  {/if}
+
+  <!-- Devices Tab -->
+  {#if activeTab === 'devices'}
+    <div class="flex flex-col gap-4">
+      <h3 class="text-lg font-semibold">Account Devices</h3>
+      <p class="text-sm">
+        Inspect the devices registered to an account and which partitions they currently hold.
+      </p>
+      <label class={LABEL_CLASS}>
+        <span class={LABEL_TEXT_CLASS}>Account</span>
+        <Select options={accountOptions} bind:value={selectedAccountId} />
+      </label>
+      {#if selectedAccount}
+        {#key selectedAccountId}
+          <DeviceList account={selectedAccount} />
+        {/key}
+      {:else}
+        <p class="text-muted-foreground text-sm">No accounts found.</p>
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/ui/src/routes/dev/+page.svelte
+++ b/ui/src/routes/dev/+page.svelte
@@ -79,7 +79,7 @@
   // delete is futile (no stamp tombstone yet — #337 — so a peer's union merge
   // re-adds it).
   function deleteStoredStamp(accountId: EthAddress, batchID: BatchId) {
-    sharedAccountsStore.removeDrive(accountId, batchID, { skipSync: true })
+    sharedAccountsStore.getAccount(accountId)?.removeDrive(batchID, { skipSync: true })
     storedStampMessage = `🗑️ Deleted ${batchID.toHex().slice(0, 12)}… locally`
   }
 
@@ -646,6 +646,11 @@ Check console logs for details:
     try {
       const batchId = new BatchId(selectedStampId)
       const accountId = new EthAddress(selectedAccountId)
+      const account = sharedAccountsStore.getAccount(accountId)
+      if (!account) {
+        assignError = 'Account not found.'
+        return
+      }
 
       // Determine which signer key to use
       const signerKeyToUse =
@@ -659,7 +664,7 @@ Check console logs for details:
           assignError = 'Stamp data not found. Reload stamps first.'
           return
         }
-        sharedAccountsStore.addDrive(accountId, {
+        account.addDrive({
           batchID: batchId,
           signerKey: signerKeyToUse,
           utilization: Utils.getStampUsage(
@@ -682,12 +687,12 @@ Check console logs for details:
           return
         }
         if (beeStamp.signerKey !== signerKeyToUse) {
-          sharedAccountsStore.removeDrive(accountId, batchId)
-          sharedAccountsStore.addDrive(accountId, { ...beeStamp, signerKey: signerKeyToUse })
+          account.removeDrive(batchId)
+          account.addDrive({ ...beeStamp, signerKey: signerKeyToUse })
         }
       }
 
-      sharedAccountsStore.setDefaultDrive(accountId, batchId)
+      account.setDefaultDrive(batchId)
       assignMessage = `✅ Set account drive for ${accountId.toHex().slice(0, 8)}…`
     } catch (error) {
       assignError = error instanceof Error ? error.message : String(error)
@@ -702,7 +707,7 @@ Check console logs for details:
       return
     }
     const accountId = new EthAddress(selectedAccountId)
-    sharedAccountsStore.setDefaultDrive(accountId, undefined)
+    sharedAccountsStore.getAccount(accountId)?.setDefaultDrive(undefined)
     assignMessage = `✅ Removed account drive from ${selectedAccountId.slice(0, 8)}…`
   }
 

--- a/ui/src/routes/dev/device-list.svelte
+++ b/ui/src/routes/dev/device-list.svelte
@@ -1,0 +1,354 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<script lang="ts">
+  import { onMount } from 'svelte'
+
+  import { Bee } from '@ethersphere/bee-js'
+  import CircleCheckBig from '@lucide/svelte/icons/circle-check-big'
+  import Laptop from '@lucide/svelte/icons/laptop'
+  import RefreshCw from '@lucide/svelte/icons/refresh-cw'
+  import {
+    type Account,
+    PartitionLease,
+    type PartitionLeaseStateSnapshot,
+    deriveSwarmEncryptionKey,
+    getOrCreateDeviceId,
+    hexToUint8Array,
+    leaseCacheStorageKey,
+  } from '@snaha/swarm-id'
+
+  import { browser } from '$app/environment'
+
+  import CopyButton from '$lib/components/copy-button.svelte'
+  import { Button } from '$lib/components/ui/button'
+  import { networkSettingsStore } from '$lib/dev/network-settings.svelte'
+  import { refreshAccountFromSwarm } from '$lib/dev/refresh-account-from-swarm'
+  import { syncStore } from '$lib/dev/sync.svelte'
+
+  const { account }: { account: Account } = $props()
+
+  // Re-read the shared lease cache this often so the self row picks up the
+  // proxy's per-tick `leasedUntil` advances even when `storage` events don't
+  // cross the iframe/tab boundary.
+  const LEASE_CACHE_POLL_MS = 3_000
+
+  const thisDeviceId = browser ? getOrCreateDeviceId() : undefined
+
+  const hasPostageBatch = $derived(!!account.defaultPostageStampBatchID)
+
+  // Refresh state — pull the snapshot from Swarm so peers added on other
+  // browsers show up here.
+  let refreshing = $state(false)
+  let refreshedAt = $state<number | undefined>(undefined)
+  let refreshError = $state<string | undefined>(undefined)
+  // True when the backup feed has no reachable entry yet (e.g. the prior
+  // backup expired with an old batch and the republish hasn't landed). Not
+  // an error — drives an informative note + "Publish backup now" action.
+  let noBackup = $state(false)
+  let publishing = $state(false)
+  // PEER active state, read through the PartitionLease model (lock SOCs on
+  // Swarm — the cross-device source of truth). Other machines don't share
+  // this tab's localStorage, so peers can only be observed via Swarm.
+  // Best-effort: empty when the Bee node can't serve the lock SOC chunk.
+  let holders = $state<{ partition: number; deviceId: string; leasedUntil: number }[]>([])
+
+  // SELF active state, read from the proxy-written localStorage lease cache
+  // (`swarm-id-lease-v2:<accountId>`). Shared across same-origin tabs, so it
+  // reflects the demo iframe's held partition without a Swarm read (which is
+  // currently 500ing). The proxy is the sole writer; refreshed ~every 10 s.
+  let leaseCache = $state<PartitionLeaseStateSnapshot | undefined>(undefined)
+
+  $effect(() => {
+    if (!browser) return
+    const key = leaseCacheStorageKey(account.id.toHex())
+    const read = () => {
+      const raw = localStorage.getItem(key)
+      leaseCache = raw ? (JSON.parse(raw) as PartitionLeaseStateSnapshot) : undefined
+    }
+    read()
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === key) read()
+    }
+    window.addEventListener('storage', onStorage)
+    // `storage` events don't reliably cross the iframe/tab boundary, so also
+    // poll the cache to pick up the proxy's per-tick `leasedUntil` advances.
+    const poll = setInterval(read, LEASE_CACHE_POLL_MS)
+    return () => {
+      window.removeEventListener('storage', onStorage)
+      clearInterval(poll)
+    }
+  })
+
+  async function doRefresh() {
+    if (refreshing) return
+    refreshing = true
+    refreshError = undefined
+    noBackup = false
+    try {
+      const result = await refreshAccountFromSwarm(account.id.toHex())
+      if (result.ok) {
+        refreshedAt = result.refreshedAt
+      } else if (result.kind === 'no-backup') {
+        noBackup = true
+      } else {
+        refreshError = result.error
+      }
+      // Always probe the lock SOCs even if the snapshot refresh failed —
+      // they're an independent source of truth for the active-state badge.
+      // Build a read-only PartitionLease and read its holders — the single
+      // in-code lease model (no parallel holder variable).
+      const partitionCount = account.partitionCount ?? 1
+      if (partitionCount > 1 && account.derivationKey) {
+        try {
+          const bee = new Bee(networkSettingsStore.beeNodeUrl)
+          const swarmKeyHex = await deriveSwarmEncryptionKey(account.derivationKey)
+          const lease = await PartitionLease.fromSwarmEncryptionKey({
+            bee,
+            deviceId: thisDeviceId ?? '',
+            swarmEncryptionKey: hexToUint8Array(swarmKeyHex),
+          })
+          await lease.refreshFromSwarm(partitionCount)
+          holders = lease.getHolders()
+        } catch (err) {
+          console.warn('[devices] reading lock SOCs failed:', err)
+        }
+      } else {
+        holders = []
+      }
+    } finally {
+      refreshing = false
+    }
+  }
+
+  // Republish the account snapshot to Swarm with the current default
+  // stamp, then re-read. Used when the backup is missing (e.g. after a
+  // batch swap). Best-effort: if the account isn't active, syncAccount
+  // refuses and we stay in the no-backup state — no worse than before.
+  async function doPublish() {
+    if (publishing) return
+    publishing = true
+    try {
+      await syncStore.syncAccount(account.id.toHex())
+    } catch (err) {
+      console.warn('[devices] publish backup failed:', err)
+    } finally {
+      publishing = false
+    }
+    await doRefresh()
+  }
+
+  // Refresh exactly once when the component mounts. No $effect — that
+  // re-fires whenever any tracked dependency changes (which happens every
+  // time `applyRefreshedSnapshot` mutates the account), producing a loop.
+  // onMount runs after initial render with no reactive subscriptions, so
+  // it fires once per fresh mount and never again. Re-mounting the panel
+  // (e.g. switching the selected account via {#key}) re-fires onMount —
+  // that's how "re-visit to refresh" still works.
+  onMount(() => {
+    if (browser) void doRefresh()
+  })
+
+  let tick = $state(0)
+  $effect(() => {
+    if (!browser) return
+    // Re-render the relative timestamp every 30 s.
+    const timer = setInterval(() => (tick = tick + 1), 30_000)
+    return () => clearInterval(timer)
+  })
+
+  function formatRelative(ms: number): string {
+    void tick // depend on tick so the formatted string stays fresh
+    const ago = Date.now() - ms
+    if (ago < 5_000) return 'just now'
+    if (ago < 60_000) return `${Math.floor(ago / 1_000)}s ago`
+    if (ago < 3_600_000) return `${Math.floor(ago / 60_000)}m ago`
+    return `${Math.floor(ago / 3_600_000)}h ago`
+  }
+
+  // Debug helper: is a lease still live, relative to now?
+  function leaseLiveness(leasedUntil: number): string {
+    void tick // re-evaluate as time passes
+    const now = Date.now()
+    return leasedUntil > now
+      ? `LIVE (now ${formatDateTime(now)})`
+      : `EXPIRED ${Math.floor((now - leasedUntil) / 1000)}s ago (now ${formatDateTime(now)})`
+  }
+
+  const deviceRows = $derived.by(() => {
+    // `tick` so the self lease-expiry check re-evaluates over time.
+    void tick
+    const now = Date.now()
+    return (account.devices ?? []).map((d) => {
+      const isThis = d.deviceId === thisDeviceId
+      if (isThis) {
+        // Self: read from the shared localStorage lease cache (proxy is the
+        // sole writer). The cache key is per-account and machine-local, so a
+        // live `self` lease in it means THIS machine holds that partition —
+        // independent of the device-id string stored inside (the proxy's
+        // captured id can differ from this tab's id even when the value is
+        // shared). So don't gate on the inner deviceId; just check liveness.
+        const self = leaseCache?.self
+        const active = self !== undefined && self.leasedUntil > now
+        return {
+          ...d,
+          isThis: true,
+          isActive: active,
+          partition: active ? self!.partition : undefined,
+        }
+      }
+      // Peers: cross-device, only observable via the lock SOC (Swarm).
+      const holderEntry = holders.find((h) => h.deviceId === d.deviceId)
+      return {
+        ...d,
+        isThis: false,
+        isActive: holderEntry !== undefined,
+        partition: holderEntry?.partition,
+      }
+    })
+  })
+
+  function formatDateTime(ms: number): string {
+    return new Date(ms).toLocaleString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+  }
+
+  function truncate(id: string): string {
+    if (id.length <= 16) return id
+    return `${id.slice(0, 8)}…${id.slice(-6)}`
+  }
+
+  const BADGE_CLASS =
+    'inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-semibold whitespace-nowrap'
+</script>
+
+<div class="flex flex-col gap-4 pt-8">
+  {#if !hasPostageBatch}
+    <div class="flex flex-col gap-2">
+      <p class="text-center font-bold">No synced account yet.</p>
+      <p class="text-center text-sm">
+        Multi-device sync requires a postage stamp. Assign one in the Stamps tab to enable uploading
+        and see all registered devices here.
+      </p>
+    </div>
+  {:else}
+    <div class="flex flex-col gap-2">
+      <div class="flex items-center justify-between gap-2">
+        <p class="font-medium">Devices</p>
+        <Button variant="ghost" size="xs" onclick={() => doRefresh()} disabled={refreshing}>
+          <RefreshCw />
+          {refreshing ? 'Refreshing…' : 'Refresh'}
+        </Button>
+      </div>
+      <p class="text-muted-foreground text-sm">
+        Devices registered to this account. At most {account.partitionCount ?? 1} can upload simultaneously.
+      </p>
+      {#if refreshError}
+        <p class="text-destructive text-sm">Refresh failed: {refreshError}</p>
+      {:else if noBackup}
+        <div class="flex flex-col items-start gap-2">
+          <p class="text-sm">
+            No backup found on this node yet. If you recently replaced your postage stamp, your
+            account republishes automatically — this can take a minute. Publish it now or refresh
+            again shortly.
+          </p>
+          <Button size="sm" onclick={() => doPublish()} disabled={publishing || refreshing}>
+            {publishing ? 'Publishing…' : 'Publish backup now'}
+          </Button>
+        </div>
+      {:else if refreshedAt}
+        <p class="text-muted-foreground text-sm">Last refreshed {formatRelative(refreshedAt)}</p>
+      {/if}
+    </div>
+
+    {#if deviceRows.length === 0}
+      <div class="flex flex-col gap-2">
+        <p class="text-center font-bold">No devices registered yet.</p>
+        <p class="text-center text-sm">Sign in on another device to register it here.</p>
+      </div>
+    {:else}
+      <div class="flex flex-col gap-4">
+        {#each deviceRows as row (row.deviceId)}
+          <div class="flex flex-col gap-2">
+            <div class="flex items-center gap-2">
+              <Laptop class="size-4 shrink-0" />
+              {#if row.name}
+                <div class="flex flex-col items-start">
+                  <p class="text-sm">{row.name}</p>
+                  <p class="text-muted-foreground font-mono text-xs">{truncate(row.deviceId)}</p>
+                </div>
+              {:else}
+                <p class="font-mono text-sm">{truncate(row.deviceId)}</p>
+              {/if}
+              <CopyButton text={row.deviceId} />
+            </div>
+
+            <div class="flex gap-2 pl-6">
+              {#if row.isThis}
+                <span class={`${BADGE_CLASS} bg-primary text-primary-foreground`}>This device</span>
+              {/if}
+              {#if row.isActive}
+                <span class={`${BADGE_CLASS} bg-success text-success-foreground`}>
+                  <CircleCheckBig class="size-3" />
+                  Active · partition {row.partition}
+                </span>
+              {:else}
+                <span class={`${BADGE_CLASS} bg-muted text-muted-foreground`}>Inactive</span>
+              {/if}
+            </div>
+
+            <div class="text-muted-foreground flex gap-4 pl-6 text-sm">
+              {#if row.createdAt}
+                <span>Added {formatDateTime(row.createdAt)}</span>
+              {/if}
+              {#if row.lastSignedInAt}
+                <span>Last seen {formatDateTime(row.lastSignedInAt)}</span>
+              {/if}
+            </div>
+          </div>
+          <div class="bg-border h-px"></div>
+        {/each}
+      </div>
+    {/if}
+
+    <!-- Debug: the self lease (shared localStorage cache) and the peer
+         holders (lock SOCs on Swarm), vs this device's id. -->
+    <div class="flex flex-col items-start gap-0.5">
+      <div class="bg-border h-px w-full"></div>
+      <p class="text-sm font-bold">Debug · lease state</p>
+      <p class="font-mono text-sm">this device: {thisDeviceId ?? '—'}</p>
+      {#if leaseCache?.self}
+        <p class="font-mono text-sm">
+          self (localStorage): partition {leaseCache.self.partition} — {leaseLiveness(
+            leaseCache.self.leasedUntil,
+          )}
+        </p>
+        <p class="font-mono text-sm">
+          self deviceId: {leaseCache.deviceId} (matches this device: {leaseCache.deviceId ===
+          thisDeviceId
+            ? 'yes'
+            : 'no'})
+        </p>
+      {:else}
+        <p class="font-mono text-sm">self (localStorage): none</p>
+      {/if}
+      {#if holders.length === 0}
+        <p class="text-sm">peers (lock SOCs): none observed</p>
+      {:else}
+        {#each holders as h (h.partition)}
+          <p class="font-mono text-sm">
+            peer partition {h.partition} → {h.deviceId} (until {formatDateTime(h.leasedUntil)})
+          </p>
+        {/each}
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/ui/src/routes/dev/status-dot.svelte
+++ b/ui/src/routes/dev/status-dot.svelte
@@ -1,0 +1,54 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<script lang="ts">
+  import { onMount } from 'svelte'
+
+  import { cn } from '$lib/utils'
+
+  const CHECK_INTERVAL_MS = 10000
+
+  type Status = 'online' | 'offline' | 'checking'
+  type CheckMethod = 'head' | 'json-rpc'
+
+  let { endpoint, method = 'head' }: { endpoint: string; method?: CheckMethod } = $props()
+
+  let status = $state<Status>('checking')
+
+  const dotClass: Record<Status, string> = {
+    online: 'bg-success',
+    offline: 'bg-destructive',
+    checking: 'bg-muted-foreground animate-pulse',
+  }
+
+  async function checkEndpoint() {
+    try {
+      if (method === 'json-rpc') {
+        // Use eth_blockNumber for JSON-RPC endpoints
+        const response = await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ jsonrpc: '2.0', method: 'eth_blockNumber', params: [], id: 1 }),
+        })
+        status = response.ok ? 'online' : 'offline'
+      } else {
+        // Use no-cors HEAD for regular HTTP endpoints
+        await fetch(endpoint, { method: 'HEAD', mode: 'no-cors' })
+        status = 'online'
+      }
+    } catch {
+      status = 'offline'
+    }
+  }
+
+  onMount(() => {
+    checkEndpoint()
+    const interval = setInterval(checkEndpoint, CHECK_INTERVAL_MS)
+    return () => clearInterval(interval)
+  })
+</script>
+
+<span class={cn('inline-block size-2 shrink-0 rounded-full', dotClass[status])} title={status}
+></span>

--- a/ui/src/routes/home/+page.svelte
+++ b/ui/src/routes/home/+page.svelte
@@ -20,13 +20,17 @@
 
   const TABS = [
     { value: 'apps', label: 'Apps' },
-    { value: 'stamps', label: 'Stamps' },
+    { value: 'drives', label: 'Drives' },
     { value: 'account', label: 'Account' },
   ]
 
-  const account = $derived(
-    sessionStore.currentAccountId ? accountsStore.get(sessionStore.currentAccountId) : undefined,
-  )
+  // The UI only manages `local` accounts; narrow once here so the home tabs and
+  // switcher work with a concrete `LocalAccount` (its `access`, etc.).
+  const account = $derived.by(() => {
+    const id = sessionStore.currentAccountId
+    const found = id ? accountsStore.get(id) : undefined
+    return found?.type === 'local' ? found : undefined
+  })
 
   let tab = $state('apps')
 
@@ -56,9 +60,9 @@
         {#key account.id}
           {#if tab === 'apps'}
             <HomeApps {account} />
-          {:else if tab === 'stamps'}
+          {:else if tab === 'drives'}
             <p class="text-muted-foreground py-8 text-center text-sm">
-              Postage stamp management is coming soon.
+              Drive management is coming soon.
             </p>
           {:else}
             <HomeAccount {account} />

--- a/ui/svelte.config.js
+++ b/ui/svelte.config.js
@@ -14,6 +14,10 @@ const config = {
     },
     prerender: {
       handleUnseenRoutes: 'warn',
+      // `*` keeps the default link-crawl; `/dev` is forced because the developer
+      // tools page is intentionally unlinked (no nav entry) and would otherwise
+      // not be emitted as a real file — a deep link to it 404s on GitHub Pages.
+      entries: ['*', '/dev'],
     },
   },
 }


### PR DESCRIPTION
Supersedes #373. Ports the developer tools page into the new `ui/` package **and** resolves that PR's review (agazso): _"redefines the `Account` type without a Zod type."_ The product UI now runs on the shared `@snaha/swarm-id` Zod `Account` — a single validated source of truth — while keeping the rich account-object ergonomics #373 introduced.

## 1. Developer tools page (`/dev`)

Reachable at `http://localhost:5500/dev`. Built on the **single nested account model** (the account owns its drives and connected apps inline). Four working tabs — including **Sync** and **Devices**, which #373 intentionally omitted because the old model had no sync subsystem wired in:

**Overview**
- Live status dots for the local Bee endpoints (Queen `:1633`, Worker `:16331`, Blockchain RPC `:9545`) + the demo origin.
- "Test connect flow" link to the demo (`:3500`).
- Local-data counts and a **Clear all data** action.

**Stamps**
- Buy a **mutable** postage stamp on the local chain (amount autofilled from chain price).
- List the node's stamps, showing which account holds each as a drive (and which is default).
- **Assign drive to account** (records the signer key, sets it default), with a custom-signer option and remove.

**Sync**
- **Sync All Accounts** — publishes each account's state snapshot to Swarm (epoch-feed SOC + partition lease).

**Devices**
- Per-account device list with **refresh-from-Swarm** (reads the published snapshot back) and lease/partition debug state.

Dev-only code lives under `ui/src/lib/dev/*` and `ui/src/routes/dev/*`.

## 2. One Zod-validated account model (the review fix)

#373 made `Account` a hand-rolled reactive class with **no Zod** and kept **two** account stores bridged by `mirror.ts`. This collapses both into the shared model:

- **Extend the lib schema** rather than reuse-as-is: add a `local` variant to `AccountSchemaV1` (`LocalAccountSchemaV1` + `AccessMethodSchemaV1` — passkey / eth-wallet / password + `encryptedSeed`), so the UI's existing auth is representable **with no crypto/behavior change**. The existing `passkey`/`ethereum`/`agent` variants are untouched; the UI's three methods nest under `account.access` so they never collide with the top-level `type` discriminator.
- `local` branches added to `serializeAccount` and `buildBackupHeader` (`LocalBackupHeaderSchemaV1`); new schemas/types exported. New unit tests cover the `local` serialize round-trip + backup header.
- **Single reactive store** on the lib key `swarm-id-accounts` — the SAME document the proxy iframe and sync engine read. Product UI, `/dev`, and sync all drive off it; `mirror.ts` and the parallel store are **deleted**. `/dev` changes now surface on Home immediately (no mirroring).
- Account creation computes `derivationKey` from the master key (entropy in hand); ids/keys render `0x`-prefixed via a `display0x` helper (bee-js `.toHex()` is bare).

## 3. `Account` is a rich object that owns its mutations

Kept from #373's commit 2, now wrapping the validated lib `LocalAccount`:

- `Account` is a reactive class (`$state` fields) — mutators are methods **on the object** (`account.rename(name)`, `account.addDrive(drive)`, `account.connectApp(app)`, `account.setDefaultDrive(id)`, …), persisting via an injected `onChange` (lib storage manager + optional sync hook). A private `#onChange` makes the class nominal.
- `accountsStore` is just the collection: `accounts` / `get` / `getAccount` / `add` (returns the live instance) / `remove` / `clear` / `reload`.

## 4. "stamp" → "drive" rename

"Drive" is the product term for an account's owned Swarm storage (backed by a postage-stamp batch):

- **Drive** (product): Home "Drives" tab, "Add a drive", `/dev` "Assign drive to account" / "N drives" / "Set/Remove account drive", and the account methods `addDrive`/`removeDrive`/`setDefaultDrive`/`updateDriveUtilization`.
- **Stamp** (Bee-node / wire — unchanged): buy-stamp, "Existing Stamps (Bee Node)", `routes/dev/bee.ts`, the `/stamps` endpoint, bee-js `BatchId`, and the lib fields `postageStamps` / `defaultPostageStampBatchID` (a drive _is_ a stamp batch).

Also narrows two legacy `swarm-ui` call sites for the widened union.

## Verification

- **`pnpm check:all` passes** — lint, `svelte-check` (0 errors), knip, 790 lib + ui tests (incl. the new `local` serialize round-trip and backup round-trip).
- **End-to-end against a fresh local `bee-compose` cluster** (queen + 3 workers + blockchain, reachability `Public`, non-deferred upload ~0.1s):
  - Create account → `type:'local'` record (bare-hex id, 64-char `derivationKey`, `access`, `encryptedSeed`, key `swarm-id-accounts`; no legacy `swarm-id-accounts-v2`).
  - `account.rename()` → switcher re-renders from the `$state` field **and** persists.
  - `/dev` buy stamp (chain tx) → **assign drive** (`addDrive`/`setDefaultDrive`) → Home drops the view-only banner immediately (one store, no mirror).
  - **Connect** demo → `completeConnect()` → `account.connectApp()` writes the connected app **with a live `appSecret`** into the same record; `account.disconnectApp()` clears it.
  - **Sync All Accounts → "1 succeeded, 0 failed"**; **Devices → refresh-from-Swarm** reads the snapshot back.

> **Notes for reviewers**
> - `ui` typechecks against `lib/dist`; run `pnpm build:lib` after pulling if `svelte-check` reports phantom missing-export errors.
> - **Local sync testing** needs two env things (not code): a freshly-meshed cluster (`pnpm dev:bee:fresh` on `@snaha/bee-compose` ≥ 0.1.5 so node reachability is `Public`), and the Bee node URL set to `http://localhost:1633` in **Network settings** — sync defaults to the public gateway, which a localhost browser can't reach.
> - **Migration:** the lib key `swarm-id-accounts` is canonical; per PoC policy there is **no migration** of old `swarm-id-accounts-v2` records — a pre-existing local-only account would be re-imported from its phrase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)