### PR TITLE
refactor(lib): require publicKey on the account schema

### DIFF
--- a/lib/src/schemas.test.ts
+++ b/lib/src/schemas.test.ts
@@ -8,6 +8,7 @@ import {
   TEST_BATCH_ID_HEX,
   TEST_BATCH_ID_2_HEX,
   TEST_PRIVATE_KEY_HEX,
+  TEST_PUBLIC_KEY_HEX,
   createAccount,
   createPostageStamp,
 } from "./test-fixtures"
@@ -85,6 +86,7 @@ describe("AccountSchemaV1 encryptedSeed", () => {
       name: "Test Account",
       createdAt: 1700000000000,
       derivationKey: "f".repeat(64),
+      publicKey: TEST_PUBLIC_KEY_HEX,
       access: { type: "password", kdfSalt: "00", kdfIterations: 100000 },
       encryptedSeed,
     }

--- a/lib/src/schemas.ts
+++ b/lib/src/schemas.ts
@@ -225,7 +225,7 @@ export const AccountSchemaV1 = z.object({
   derivationKey: z.string().length(64), // derived key for deterministic sub-key generation (64-char hex)
   // App-facing public key (compressed secp256k1). Surfaced to dApps as the
   // identity public key in ConnectionInfo. Was previously on the identity.
-  publicKey: CompressedPublicKeySchema.optional(),
+  publicKey: CompressedPublicKeySchema,
   // Device-local seed vault. Every account is a BIP-39 seed account: `access`
   // records how the seed is protected/unlocked on this device (passkey /
   // eth-wallet / password) and `encryptedSeed` is that seed encrypted at rest.
@@ -275,7 +275,7 @@ export const AccountMetadataSchemaV1 = z.object({
   accountName: z.string(),
   defaultPostageStampBatchID: z.string().length(64).optional(), // BatchId hex string
   // App-facing public key (compressed secp256k1 hex). Mirrors account.publicKey.
-  publicKey: CompressedPublicKeySchema.optional(),
+  publicKey: CompressedPublicKeySchema,
   // Per-account settings (was identity.settings).
   settings: z
     .object({

--- a/lib/src/sync/device-state.test.ts
+++ b/lib/src/sync/device-state.test.ts
@@ -16,6 +16,8 @@ import type { AccountStateSnapshot } from "../utils/account-state-snapshot"
 import type { ConnectedApp, Device, PostageStamp } from "../schemas"
 
 const ACCOUNT_ID = "aa".repeat(20)
+// Compressed secp256k1 public key (prefix byte + 32 bytes = 66 bare hex chars).
+const TEST_ACCOUNT_PUBLIC_KEY = "02" + "ab".repeat(32)
 
 function makeStamp(
   batchHex: string,
@@ -60,6 +62,7 @@ function makeView(overrides: Partial<DeviceStateView> = {}): DeviceStateView {
     accountName: { value: "acct", at: 1 },
     defaultPostageStampBatchID: { value: undefined, at: 1 },
     settings: { value: undefined, at: 1 },
+    accountPublicKey: TEST_ACCOUNT_PUBLIC_KEY,
     accountCreatedAt: 1_000_000,
     partitionCount: 2,
     ...overrides,
@@ -74,6 +77,7 @@ function viewToSnapshot(v: DeviceStateView): AccountStateSnapshot {
     metadata: {
       accountName: v.accountName.value,
       defaultPostageStampBatchID: v.defaultPostageStampBatchID.value,
+      publicKey: v.accountPublicKey,
       createdAt: 1_000_000,
       lastModified: 1_000_000,
       devices: [],
@@ -119,6 +123,7 @@ describe("accountStateToDeviceView — never-edited scalar clocks", () => {
       metadata: {
         accountName: "Account-A",
         defaultPostageStampBatchID: undefined,
+        publicKey: TEST_ACCOUNT_PUBLIC_KEY,
         createdAt: CREATED_AT,
         // Always freshly stamped at publish time — the trap the old fallback
         // (`?? lastModified`) fell into, re-clocking unedited fields every sync.
@@ -233,20 +238,18 @@ describe("foldAccount — per-field scalar LWW", () => {
 })
 
 describe("foldAccount — account immutables from any defining view", () => {
-  it("takes partitionCount/publicKey from a later view when views[0] omits them", () => {
+  it("takes partitionCount from a later view when views[0] has the default", () => {
     // views[0] is an older/partial feed: partitionCount defaulted to 1 (which
-    // would disable partition locking) and no publicKey. A later view carries the
-    // real values — the fold must prefer those, not views[0].
-    const partial = makeView({ partitionCount: 1, accountPublicKey: undefined })
-    const full = makeView({
-      partitionCount: 4,
-      accountPublicKey: "ab".repeat(32),
-    })
+    // would disable partition locking). A later view carries the real value —
+    // the fold must prefer that, not views[0]. publicKey is an account immutable
+    // present on every view, so it always comes from views[0].
+    const partial = makeView({ partitionCount: 1 })
+    const full = makeView({ partitionCount: 4 })
     const folded = foldAccount(
       [partial, full] as unknown as DeviceStateSnapshot[],
       [makeDevice("dev-a")],
     )
     expect(folded.partitionCount).toBe(4)
-    expect(folded.publicKey).toBe("ab".repeat(32))
+    expect(folded.publicKey).toBe(TEST_ACCOUNT_PUBLIC_KEY)
   })
 })

--- a/lib/src/sync/device-state.ts
+++ b/lib/src/sync/device-state.ts
@@ -75,7 +75,7 @@ export const DeviceStateSnapshotSchemaV1 = z.object({
   // Account-level immutables — carried on the robust per-device feed (not the
   // roster), so the fold reconstructs them without a shared doc. Identical
   // across devices.
-  accountPublicKey: z.string().optional(),
+  accountPublicKey: z.string(),
   accountCreatedAt: z.number(),
   partitionCount: z.number().int().min(1).default(1),
 })
@@ -89,7 +89,7 @@ export interface DeviceStateView {
   accountName: { value: string; at: number }
   defaultPostageStampBatchID: { value: string | undefined; at: number }
   settings: { value: AccountSettings | undefined; at: number }
-  accountPublicKey?: string
+  accountPublicKey: string
   accountCreatedAt: number
   partitionCount: number
 }
@@ -108,7 +108,7 @@ export interface FoldedAccount {
   defaultStampAt: number
   settingsAt: number
   createdAt: number
-  publicKey?: string
+  publicKey: string
   partitionCount: number
 }
 
@@ -315,10 +315,11 @@ export function foldAccount(
   }
 
   // Account immutables from any view that defines them — NOT just views[0],
-  // whose feed could be older/partial and omit one (publicKey is optional;
-  // partitionCount defaults to 1, which would silently disable partition locking
-  // for a multi-partition account). Fall back to the roster (min createdAt) so a
-  // fold with reachable roster but no readable device feed still has createdAt.
+  // whose feed could be older/partial and omit one (partitionCount defaults to 1,
+  // which would silently disable partition locking for a multi-partition
+  // account). Fall back to the roster (min createdAt) so a fold with reachable
+  // roster but no readable device feed still has createdAt. publicKey is carried
+  // on every view (callers pass a non-empty `views`), so `views[0]` always has it.
   const meta = views[0]
   const createdAt =
     meta?.accountCreatedAt ??
@@ -326,7 +327,7 @@ export function foldAccount(
       (min, d) => Math.min(min, d.createdAt),
       Number.MAX_SAFE_INTEGER,
     )
-  const publicKey = views.find((v) => v.accountPublicKey)?.accountPublicKey
+  const publicKey = views[0].accountPublicKey
   const partitionCount =
     views.find((v) => v.partitionCount > 1)?.partitionCount ??
     meta?.partitionCount ??

--- a/lib/src/sync/fold-account-from-swarm.ts
+++ b/lib/src/sync/fold-account-from-swarm.ts
@@ -67,5 +67,10 @@ export async function foldAccountFromSwarm(opts: {
     )
   ).filter((view): view is DeviceStateSnapshot => view !== undefined)
 
+  // No readable device feed → nothing to restore (the roster exists but every
+  // device's state was unreachable). Mirrors the `devices.length === 0` guard
+  // above, and guarantees `foldAccount` has a view carrying `accountPublicKey`.
+  if (views.length === 0) return undefined
+
   return { account: foldAccount(views, devices), devices }
 }

--- a/lib/src/test-fixtures.ts
+++ b/lib/src/test-fixtures.ts
@@ -15,6 +15,8 @@ export const TEST_BATCH_ID_HEX = "c".repeat(64)
 export const TEST_BATCH_ID_2_HEX = "e".repeat(64)
 export const TEST_PRIVATE_KEY_HEX = "d".repeat(64)
 export const TEST_DERIVATION_KEY_HEX = "f".repeat(64)
+// Compressed secp256k1 public key: 0x02/0x03 prefix byte + 32 bytes = 66 bare hex chars.
+export const TEST_PUBLIC_KEY_HEX = "02" + "ab".repeat(32)
 export const DIFFERENT_DERIVATION_KEY_HEX = "1".repeat(64)
 export const TEST_DEVICE_ID = "550e8400-e29b-41d4-a716-446655440000"
 
@@ -37,6 +39,7 @@ export function createAccount(overrides?: Partial<Account>): Account {
     id: new EthAddress(TEST_ETH_ADDRESS_HEX),
     name: "Test Account",
     createdAt: 1700000000000,
+    publicKey: TEST_PUBLIC_KEY_HEX,
     access: { type: "password", kdfSalt: "00", kdfIterations: 100000 },
     encryptedSeed: "aabbccdd",
     derivationKey: TEST_DERIVATION_KEY_HEX,

--- a/lib/src/utils/account-state-snapshot.test.ts
+++ b/lib/src/utils/account-state-snapshot.test.ts
@@ -14,6 +14,7 @@ import {
   TEST_BATCH_ID_HEX,
   TEST_BATCH_ID_2_HEX,
   TEST_PRIVATE_KEY_HEX,
+  TEST_PUBLIC_KEY_HEX,
   createAccount,
   createConnectedApp,
   createPostageStamp,
@@ -166,6 +167,7 @@ describe("device tracking in metadata", () => {
       accountId: TEST_ETH_ADDRESS_HEX,
       metadata: {
         accountName: "Test",
+        publicKey: TEST_PUBLIC_KEY_HEX,
         createdAt: 1700000000000,
         lastModified: Date.now(),
       },
@@ -387,6 +389,7 @@ describe("invalid data rejection", () => {
       accountId: TEST_ETH_ADDRESS_HEX,
       metadata: {
         accountName: "Test",
+        publicKey: TEST_PUBLIC_KEY_HEX,
         createdAt: 1700000000000,
         lastModified: Date.now(),
       },
@@ -419,6 +422,7 @@ describe("invalid data rejection", () => {
       accountId: TEST_ETH_ADDRESS_HEX,
       metadata: {
         accountName: "Test",
+        publicKey: TEST_PUBLIC_KEY_HEX,
         createdAt: 1700000000000,
         lastModified: Date.now(),
       },
@@ -490,6 +494,7 @@ describe("bee-js type conversions", () => {
       accountId: TEST_ETH_ADDRESS_HEX,
       metadata: {
         accountName: "Test",
+        publicKey: TEST_PUBLIC_KEY_HEX,
         createdAt: 1700000000000,
         lastModified: Date.now(),
       },


### PR DESCRIPTION
Makes the account `publicKey` required instead of optional — every account is constructed with a compressed secp256k1 public key (derived from the seed wallet).

- `AccountSchemaV1.publicKey` and its wire/backup projection `AccountMetadataSchemaV1.publicKey` are now required.
- Required is propagated through the device-state fold chain that feeds the metadata (`accountPublicKey` on the snapshot/view, `FoldedAccount.publicKey`).
- `foldAccountFromSwarm` now returns `undefined` when no device feed is readable, so it can't emit a keyless (garbage) snapshot.

Pre-production, so no migration for old snapshots.

> Stacked on #377 (the unified-account-model branch). Retarget to `main` once #377 merges.

Closes #378

🤖 Generated with [Claude Code](https://claude.com/claude-code)