### PR TITLE
feat(ui): developer tools page on the unified account model

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -355,6 +355,7 @@ export {
   AccountSchemaV1,
   AccountDataSchemaV1,
   AccessMethodSchemaV1,
+  PostageStampSchemaV1,
   isLocalAccount,
 } from "./schemas"
 

--- a/lib/src/utils/storage-managers.test.ts
+++ b/lib/src/utils/storage-managers.test.ts
@@ -1,12 +1,17 @@
 // Copyright 2026 The Swarm Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect } from "vitest"
-import { BatchId, PrivateKey } from "@ethersphere/bee-js"
-import { serializeAccount } from "./storage-managers"
+import { describe, it, expect, afterEach, vi } from "vitest"
+import { BatchId, EthAddress, PrivateKey } from "@ethersphere/bee-js"
+import {
+  createAccountsStorageManager,
+  serializeAccount,
+} from "./storage-managers"
 import { AccountSchemaV1 } from "../schemas"
+import { STORAGE_KEY_ACCOUNTS } from "../types"
 import {
   TEST_BATCH_ID_HEX,
+  TEST_ETH_ADDRESS_2_HEX,
   TEST_PRIVATE_KEY_HEX,
   createAccount,
   createPostageStamp,
@@ -57,5 +62,55 @@ describe("serializeAccount — device-local seed vault", () => {
       )
       expect(reparsed.access).toEqual(access)
     }
+  })
+})
+
+describe("createAccountsStorageManager().load() — invalid records", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  function stubLocalStorage(document: unknown) {
+    const store = new Map<string, string>([
+      [STORAGE_KEY_ACCOUNTS, JSON.stringify(document)],
+    ])
+    vi.stubGlobal("window", {
+      localStorage: {
+        getItem: (key: string) => store.get(key) ?? null,
+        setItem: (key: string, value: string) => void store.set(key, value),
+        removeItem: (key: string) => void store.delete(key),
+      },
+    })
+  }
+
+  it("skips an invalid record instead of dropping every account", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const good = createAccount()
+    const other = createAccount({
+      id: new EthAddress(TEST_ETH_ADDRESS_2_HEX),
+      name: "Other Account",
+    })
+    const corrupt = {
+      ...serializeAccount(other),
+      // Fails the schema's hex regex — e.g. a malformed write from a dev tool.
+      encryptedSeed: "not-hex",
+    }
+    stubLocalStorage({
+      version: 1,
+      data: [serializeAccount(good), corrupt],
+    })
+
+    const loaded = createAccountsStorageManager().load()
+
+    expect(loaded).toHaveLength(1)
+    expect(loaded[0].id.equals(good.id)).toBe(true)
+  })
+
+  it("returns [] when the document is not an array", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined)
+    stubLocalStorage({ version: 1, data: { not: "an array" } })
+
+    expect(createAccountsStorageManager().load()).toEqual([])
   })
 })

--- a/lib/src/utils/storage-managers.ts
+++ b/lib/src/utils/storage-managers.ts
@@ -29,17 +29,32 @@ import { PARTITION_COUNT } from "./batch-utilization"
 // ============================================================================
 
 /**
- * Parse accounts - Zod transforms handle type conversion
+ * Parse accounts - Zod transforms handle type conversion.
+ *
+ * Records are validated one by one: an invalid record is skipped (logged), not
+ * allowed to fail the whole document. Dropping every account for one bad record
+ * would present an empty list, and the next save would erase the document for
+ * real.
  */
 const parseAccountsV1: VersionParser<Account> = (data: unknown) => {
-  const result = z.array(AccountSchemaV1).safeParse(data)
+  const records = z.array(z.unknown()).safeParse(data)
 
-  if (!result.success) {
-    console.error("Parse failed:", result.error.format())
+  if (!records.success) {
+    console.error("Parse failed:", records.error.format())
     return []
   }
 
-  return result.data.map((account) => {
+  const accounts: Account[] = []
+  for (const record of records.data) {
+    const result = AccountSchemaV1.safeParse(record)
+    if (!result.success) {
+      console.error("Skipping invalid account record:", result.error.format())
+      continue
+    }
+    accounts.push(result.data)
+  }
+
+  return accounts.map((account) => {
     if (account.partitionCount === undefined && account.devices.length > 0) {
       return {
         ...account,

--- a/ui/src/lib/components/copy-button.svelte
+++ b/ui/src/lib/components/copy-button.svelte
@@ -1,0 +1,35 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<script lang="ts">
+  import Check from '@lucide/svelte/icons/check'
+  import Copy from '@lucide/svelte/icons/copy'
+
+  import { Button } from '$lib/components/ui/button'
+  import { copyToClipboard } from '$lib/utils'
+
+  const FEEDBACK_DURATION_MS = 2000
+
+  let { text }: { text: string } = $props()
+
+  let copied = $state(false)
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+
+  async function handleCopy() {
+    const ok = await copyToClipboard(text)
+    if (!ok) return
+    copied = true
+    if (timeoutId) clearTimeout(timeoutId)
+    timeoutId = setTimeout(() => (copied = false), FEEDBACK_DURATION_MS)
+  }
+</script>
+
+<Button variant="ghost" size="xs" aria-label="Copy" onclick={handleCopy}>
+  {#if copied}
+    <Check />
+  {:else}
+    <Copy />
+  {/if}
+</Button>

--- a/ui/src/lib/dev/network-settings.svelte.ts
+++ b/ui/src/lib/dev/network-settings.svelte.ts
@@ -1,0 +1,58 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import {
+  DEFAULT_BEE_NODE_URL,
+  DEFAULT_GNOSIS_RPC_URL,
+  type NetworkSettings,
+  createNetworkSettingsStorageManager,
+} from '@snaha/swarm-id'
+
+import { browser } from '$app/environment'
+
+export interface NetworkSettingsStore {
+  settings: NetworkSettings
+  beeNodeUrl: string
+  gnosisRpcUrl: string
+  updateSettings(newSettings: NetworkSettings): void
+  reset(): void
+}
+
+function withNetworkSettingsStore(): NetworkSettingsStore {
+  const storageManager = browser ? createNetworkSettingsStorageManager() : undefined
+
+  const defaultSettings: NetworkSettings = {
+    beeNodeUrl: DEFAULT_BEE_NODE_URL,
+    gnosisRpcUrl: DEFAULT_GNOSIS_RPC_URL,
+  }
+
+  // Load initial settings from localStorage or use defaults
+  const initialSettings = storageManager?.load() ?? defaultSettings
+
+  let settings = $state<NetworkSettings>(initialSettings)
+
+  function updateSettings(newSettings: NetworkSettings) {
+    settings = newSettings
+    storageManager?.save(newSettings)
+  }
+
+  function reset() {
+    settings = defaultSettings
+    storageManager?.clear()
+  }
+
+  return {
+    get settings() {
+      return settings
+    },
+    get beeNodeUrl() {
+      return settings.beeNodeUrl
+    },
+    get gnosisRpcUrl() {
+      return settings.gnosisRpcUrl
+    },
+    updateSettings,
+    reset,
+  }
+}
+
+export const networkSettingsStore = withNetworkSettingsStore()

--- a/ui/src/lib/dev/network-settings.svelte.ts
+++ b/ui/src/lib/dev/network-settings.svelte.ts
@@ -47,6 +47,11 @@ function withNetworkSettingsStore(): NetworkSettingsStore {
     get beeNodeUrl() {
       return settings.beeNodeUrl
     },
+    // Settable so the /dev page can bind its URL input straight to the shared
+    // setting; persists like updateSettings.
+    set beeNodeUrl(url: string) {
+      updateSettings({ ...settings, beeNodeUrl: url })
+    },
     get gnosisRpcUrl() {
       return settings.gnosisRpcUrl
     },

--- a/ui/src/lib/dev/postage-stamps.svelte.ts
+++ b/ui/src/lib/dev/postage-stamps.svelte.ts
@@ -1,0 +1,77 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BatchId, EthAddress } from '@ethersphere/bee-js'
+import { type PostageStamp, UtilizationAwareStamper, UtilizationStoreDB } from '@snaha/swarm-id'
+
+import { browser } from '$app/environment'
+
+import { accountsStore } from '$lib/stores/accounts.svelte'
+
+// ============================================================================
+// Postage-stamp runtime view
+//
+// Stamp DATA is owned by the nested account (`accountsStore`); this module
+// is the batchID-keyed RUNTIME over it: locate a stamp across accounts, build a
+// utilization-aware stamper, and record volatile utilization. It satisfies the
+// lib `PostageStampsStoreInterface` consumed by `createSyncAccount`.
+// ============================================================================
+
+let utilizationStore: UtilizationStoreDB | undefined
+
+const getUtilizationStore = () => {
+  if (!browser) {
+    throw new Error('Utilization store not available (browser only)')
+  }
+  if (!utilizationStore) {
+    utilizationStore = new UtilizationStoreDB()
+  }
+  return utilizationStore
+}
+
+/**
+ * Locate a LIVE stamp by batchID across all accounts, with its owning account
+ * id. Tombstoned (`deletedAt`) stamps are ignored so a deleted batch is never
+ * used to sign an upload, and re-assigning a previously-deleted batch revives
+ * it (the assign flow treats "not found" as a fresh add).
+ */
+function findStamp(batchID: BatchId): { stamp: PostageStamp; accountId: EthAddress } | undefined {
+  for (const account of accountsStore.accounts) {
+    const stamp = account.postageStamps.find(
+      (s) => s.batchID.equals(batchID) && s.deletedAt === undefined,
+    )
+    if (stamp) return { stamp, accountId: account.id }
+  }
+  return undefined
+}
+
+export const postageStampsStore = {
+  getStamp(batchID: BatchId): PostageStamp | undefined {
+    return findStamp(batchID)?.stamp
+  },
+
+  async getStamper(
+    batchID: BatchId,
+    options: { owner: EthAddress; encryptionKey: Uint8Array },
+  ): Promise<UtilizationAwareStamper | undefined> {
+    const found = findStamp(batchID)
+    if (!found) return undefined
+
+    return UtilizationAwareStamper.create(
+      found.stamp.signerKey.toUint8Array(),
+      found.stamp.batchID,
+      found.stamp.depth,
+      getUtilizationStore(),
+      options.owner,
+      options.encryptionKey,
+    )
+  },
+
+  updateStampUtilization(batchID: BatchId, newUtilization: number) {
+    const found = findStamp(batchID)
+    if (!found) {
+      console.warn('[PostageStamps] Cannot update utilization: stamp not found')
+      return
+    }
+    accountsStore.getAccount(found.accountId)?.updateStampUtilization(batchID, newUtilization)
+  },
+}

--- a/ui/src/lib/dev/refresh-account-from-swarm.ts
+++ b/ui/src/lib/dev/refresh-account-from-swarm.ts
@@ -1,0 +1,107 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Pull the latest account state from Swarm and fold it into local stores.
+ *
+ * Unlike `restoreAccountFromSwarm`, this doesn't need the master key — it uses
+ * the local account's `derivationKey` (already stored after sign-in) to derive
+ * the feed owner and encryption key. So it's safe to call from any signed-in
+ * page, including after the temporary master key has been cleared.
+ *
+ * It delegates the read to the lib's `foldAccountFromSwarm`, which scans the
+ * append-only device roster and folds every device's per-device state feed
+ * (Phase 3a). Doing the read in the lib keeps the discovery + merge rules in
+ * one place — the old hand-rolled reader pointed at the retired shared snapshot
+ * feed and would simply find nothing now that publishing is per-device.
+ */
+import { Bee, EthAddress } from '@ethersphere/bee-js'
+import {
+  detectDeviceName,
+  foldAccountFromSwarm,
+  getOrCreateDeviceId,
+  mergeConnectedApps,
+  mergeDevices,
+  mergeDevicesList,
+  mergePostageStamps,
+} from '@snaha/swarm-id'
+
+import { networkSettingsStore } from '$lib/dev/network-settings.svelte'
+import { accountsStore } from '$lib/stores/accounts.svelte'
+
+export type RefreshResult =
+  | { ok: true; refreshedAt: number }
+  // No device has published a state feed yet (empty roster) — the read
+  // equivalent of "no backup". Benign and self-healing; the UI guides the user
+  // to publish / wait.
+  | { ok: false; kind: 'no-backup' }
+  // Invalid id, missing local account, or a network failure — a genuine error
+  // the user should see.
+  | { ok: false; kind: 'error'; error: string }
+
+export async function refreshAccountFromSwarm(accountId: string): Promise<RefreshResult> {
+  let ethAddress: EthAddress
+  try {
+    ethAddress = new EthAddress(accountId)
+  } catch {
+    return { ok: false, kind: 'error', error: 'Invalid account id' }
+  }
+
+  const account = accountsStore.getAccount(ethAddress)
+  if (!account) {
+    return { ok: false, kind: 'error', error: 'No local account for this id' }
+  }
+
+  const bee = new Bee(networkSettingsStore.beeNodeUrl)
+
+  try {
+    const folded = await foldAccountFromSwarm({
+      bee,
+      derivationKey: account.derivationKey,
+      accountId: account.id.toHex(),
+    })
+
+    if (!folded) {
+      return { ok: false, kind: 'no-backup' }
+    }
+
+    const { account: state, devices } = folded
+    console.debug(
+      `[RefreshAccount] devices=${devices.length} apps=${state.connectedApps.length} stamps=${state.postageStamps.length} bee=${bee.url}`,
+    )
+
+    // `foldAccountFromSwarm` folds across the *remote* device feeds only — it
+    // knows nothing about local state that hasn't been published yet (e.g. a
+    // fresh stamp tombstone awaiting its debounced sync). Merge the folded
+    // collections with the local ones using the same LWW/tombstone primitives
+    // the publish side uses, so a local change can't be clobbered by an older
+    // remote value (and a local tombstone survives a stale remote active copy).
+    const mergedApps = mergeConnectedApps(account.connectedApps, state.connectedApps)
+    const mergedStamps = mergePostageStamps(account.postageStamps, state.postageStamps)
+    // Keep *this* device first-class even if no feed lists it yet.
+    const mergedDevices = mergeDevices(
+      mergeDevicesList(account.devices, state.devices),
+      getOrCreateDeviceId(),
+      detectDeviceName(),
+    )
+
+    // Apply WITHOUT re-publishing (the data came from Swarm). Scalars carry
+    // their per-field clocks so `applyRefreshed` folds them by LWW against the
+    // local value.
+    account.applyRefreshed({
+      devices: mergedDevices,
+      connectedApps: mergedApps,
+      postageStamps: mergedStamps,
+      accountName: state.accountName,
+      accountNameAt: state.accountNameAt,
+      defaultPostageStampBatchID: state.defaultPostageStampBatchID,
+      defaultStampAt: state.defaultStampAt,
+      settings: state.settings,
+      settingsAt: state.settingsAt,
+    })
+
+    return { ok: true, refreshedAt: Date.now() }
+  } catch (err) {
+    const error = err instanceof Error ? err.message : 'Unknown error'
+    return { ok: false, kind: 'error', error }
+  }
+}

--- a/ui/src/lib/dev/sync-hooks.ts
+++ b/ui/src/lib/dev/sync-hooks.ts
@@ -1,0 +1,34 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { syncStore } from '$lib/dev/sync.svelte'
+
+// How long to coalesce rapid account mutations before publishing once.
+const SYNC_DEBOUNCE_MS = 2000
+
+// Debounce timer per account
+const syncTimers = new Map<string, ReturnType<typeof setTimeout>>()
+
+/**
+ * Trigger sync for an account with debouncing
+ *
+ * Multiple rapid changes are batched into a single sync
+ */
+export function triggerSync(accountId: string): void {
+  // Clear existing timer
+  const existingTimer = syncTimers.get(accountId)
+  if (existingTimer) {
+    clearTimeout(existingTimer)
+  }
+
+  // Set new timer (2 second debounce). The publish is fire-and-forget, so guard
+  // the promise: an unhandled rejection here would surface as a console error
+  // (or crash strict environments) rather than a silent failed sync.
+  const timer = setTimeout(() => {
+    syncTimers.delete(accountId)
+    void syncStore.syncAccount(accountId).catch((err) => {
+      console.error(`[sync] account ${accountId} failed:`, err)
+    })
+  }, SYNC_DEBOUNCE_MS)
+
+  syncTimers.set(accountId, timer)
+}

--- a/ui/src/lib/dev/sync.svelte.ts
+++ b/ui/src/lib/dev/sync.svelte.ts
@@ -1,0 +1,99 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { Bee } from '@ethersphere/bee-js'
+import {
+  DebouncedUtilizationUploader,
+  type SyncAccountFunction,
+  type SyncResult,
+  UtilizationStoreDB,
+  createSyncAccount,
+} from '@snaha/swarm-id'
+
+import { browser } from '$app/environment'
+
+import { networkSettingsStore } from '$lib/dev/network-settings.svelte'
+import { postageStampsStore } from '$lib/dev/postage-stamps.svelte'
+import { accountsStore } from '$lib/stores/accounts.svelte'
+
+// ============================================================================
+// Lazy Initialization (Browser Only)
+// ============================================================================
+
+// Lazy utilization store initialization
+let utilizationStore: UtilizationStoreDB | undefined
+
+const getUtilizationStore = () => {
+  if (!browser) return undefined
+
+  if (!utilizationStore) {
+    utilizationStore = new UtilizationStoreDB()
+  }
+
+  return utilizationStore
+}
+
+// Lazy debounced uploader initialization
+let utilizationUploader: DebouncedUtilizationUploader | undefined
+
+const getUtilizationUploader = () => {
+  if (!browser) return undefined
+
+  if (!utilizationUploader) {
+    utilizationUploader = new DebouncedUtilizationUploader()
+  }
+
+  return utilizationUploader
+}
+
+// Sync account function — recreated whenever the Bee node URL changes,
+// since createSyncAccount closes over a specific Bee client instance.
+let syncAccountFn: SyncAccountFunction | undefined
+let lastBeeUrl: string | undefined
+
+const getSyncAccount = () => {
+  if (!browser) return undefined
+
+  const currentUrl = networkSettingsStore.beeNodeUrl
+
+  if (!syncAccountFn || currentUrl !== lastBeeUrl) {
+    const utilStore = getUtilizationStore()
+    const utilUploader = getUtilizationUploader()
+    if (!utilStore || !utilUploader) return undefined
+
+    lastBeeUrl = currentUrl
+    syncAccountFn = createSyncAccount({
+      bee: new Bee(currentUrl),
+      accountsStore,
+      postageStampsStore,
+      utilizationStore: utilStore,
+      utilizationUploader: utilUploader,
+    })
+  }
+
+  return syncAccountFn
+}
+
+// ============================================================================
+// Export Sync Store
+// ============================================================================
+
+export const syncStore = {
+  /**
+   * Trigger sync for an account
+   * Called by store hooks when state changes
+   */
+  async syncAccount(accountId: string): Promise<SyncResult | undefined> {
+    if (!browser) {
+      console.warn('[StateSync] Sync disabled - not in browser')
+      return undefined
+    }
+
+    const syncAccount = getSyncAccount()
+    if (!syncAccount) {
+      console.warn('[StateSync] Sync function not available')
+      return undefined
+    }
+
+    return syncAccount(accountId)
+  },
+}

--- a/ui/src/lib/stores/accounts.svelte.ts
+++ b/ui/src/lib/stores/accounts.svelte.ts
@@ -7,8 +7,10 @@ import {
   type ConnectedApp,
   type Device,
   type PostageStamp,
+  PostageStampSchemaV1,
   STORAGE_KEY_ACCOUNTS,
   createAccountsStorageManager,
+  serializePostageStamp,
 } from '@snaha/swarm-id'
 
 import { browser } from '$app/environment'
@@ -193,6 +195,11 @@ export class Account {
   addStamp(stamp: Omit<PostageStamp, 'createdAt' | 'deletedAt'>): PostageStamp {
     const now = Date.now()
     const newStamp: PostageStamp = { ...stamp, createdAt: now }
+    // Callers build stamps from raw Bee-node JSON. Validate the constructed
+    // record BEFORE it enters the collection: one malformed field would make
+    // this account's stored record unparseable, so the loader would skip the
+    // whole account on the next load. Throws to the caller's error display.
+    PostageStampSchemaV1.parse(serializePostageStamp(newStamp))
     this.postageStamps = [
       ...this.postageStamps.filter((existing) => !existing.batchID.equals(stamp.batchID)),
       newStamp,

--- a/ui/src/lib/stores/accounts.svelte.ts
+++ b/ui/src/lib/stores/accounts.svelte.ts
@@ -20,12 +20,12 @@ type AccountSettings = { appSessionDuration?: number }
 /**
  * The account aggregate root. Fields are reactive (`$state`) so component reads
  * update on mutation, and every mutator is a method **on the object** that
- * persists the whole collection through the injected `onChange` — callers mutate
- * the account they already hold (`account.rename(…)`), never a store method that
- * takes an id and looks the account up.
+ * commits the whole collection through the injected `#commit` callback — callers
+ * mutate the account they already hold (`account.rename(…)`), never a store
+ * method that takes an id and looks the account up.
  *
  * The shape is the shared `@snaha/swarm-id` `Account` record (byte-class fields,
- * serialized to hex by the lib storage manager). The private `#onChange` makes
+ * serialized to hex by the lib storage manager). The private `#commit` makes
  * the class nominal, so a plain record can't be mistaken for a live account.
  *
  * Instances are stable per account id: a cross-tab storage refresh updates the
@@ -36,8 +36,12 @@ type AccountSettings = { appSessionDuration?: number }
  * Scalar fields each carry a per-field last-writer-wins clock
  * (`accountNameAt` / `defaultStampAt` / `settingsAt`) so concurrent edits to
  * different scalars on different devices converge instead of clobbering. A
- * mutator that changes a scalar MUST stamp the matching clock; the sync engine
- * (a follow-up PR) folds them by LWW.
+ * mutator that changes a scalar MUST stamp the matching clock; the /dev sync
+ * subsystem folds them by LWW (`applyRefreshed`).
+ *
+ * Members split into two groups: the product mutators the shipping app calls,
+ * and — below the `DEV-ONLY` banner — stamp/refresh mutators used **only** by
+ * the local `/dev` tooling. See that banner for why they live here.
  */
 export class Account {
   readonly id: EthAddress
@@ -59,11 +63,18 @@ export class Account {
   settingsAt = $state<number | undefined>(undefined)
   lastModified = $state<number | undefined>(undefined)
   partitionCount = $state<number | undefined>(undefined)
-  readonly #onChange: () => void
+  // Persist-and-publish this account's change, bound to `this` in the ctor so
+  // mutators just call `this.#commit()`. `skipSync: true` saves the collection
+  // WITHOUT a Swarm publish (the change came from a remote fold, or is a
+  // volatile field peers don't need) — only ever passed by the dev mutators.
+  readonly #commit: (options?: { skipSync?: boolean }) => void
 
-  constructor(record: AccountRecord, onChange: () => void) {
+  constructor(
+    record: AccountRecord,
+    commit: (account: Account, options?: { skipSync?: boolean }) => void,
+  ) {
     this.id = record.id
-    this.#onChange = onChange
+    this.#commit = (options) => commit(this, options)
     this.applyRecord(record)
   }
 
@@ -93,16 +104,12 @@ export class Account {
     this.partitionCount = record.partitionCount
   }
 
-  #persist() {
-    this.#onChange()
-  }
-
   /** Active (non-revoked) connected apps — what the UI displays. */
   get activeApps(): ConnectedApp[] {
     return this.connectedApps.filter((app) => !app.revokedAt)
   }
 
-  /** Live (non-tombstoned) stamps — what the UI displays. */
+  /** Live (non-tombstoned) stamps — what the UI displays (mutators are dev-only, below). */
   get stamps(): PostageStamp[] {
     return this.postageStamps.filter((stamp) => stamp.deletedAt === undefined)
   }
@@ -112,7 +119,7 @@ export class Account {
     this.name = name
     this.accountNameAt = now
     this.lastModified = now
-    this.#persist()
+    this.#commit()
   }
 
   /** Swap the unlock method: new access metadata + seed re-encrypted for it. */
@@ -120,7 +127,7 @@ export class Account {
     this.access = access
     this.encryptedSeed = encryptedSeed
     this.lastModified = Date.now()
-    this.#persist()
+    this.#commit()
   }
 
   /** How long app connections stay valid, set in days (stored as ms). */
@@ -129,7 +136,7 @@ export class Account {
     this.settings = { ...this.settings, appSessionDuration: daysToMs(days) }
     this.settingsAt = now
     this.lastModified = now
-    this.#persist()
+    this.#commit()
   }
 
   // --------------------------------------------------------------------------
@@ -145,7 +152,7 @@ export class Account {
         )
       : [...this.connectedApps, app]
     this.lastModified = Date.now()
-    this.#persist()
+    this.#commit()
   }
 
   disconnectApp(appUrl: string) {
@@ -153,7 +160,7 @@ export class Account {
       app.appUrl === appUrl ? revoked(app, false) : app,
     )
     this.lastModified = Date.now()
-    this.#persist()
+    this.#commit()
   }
 
   /** Disconnect and tombstone so the removal propagates to sync. */
@@ -162,7 +169,125 @@ export class Account {
       app.appUrl === appUrl ? revoked(app, true) : app,
     )
     this.lastModified = Date.now()
-    this.#persist()
+    this.#commit()
+  }
+
+  // ==========================================================================
+  // DEV-ONLY MUTATORS
+  //
+  // Consumed exclusively by the local-only /dev tooling (`routes/dev`,
+  // `lib/dev`): buying/assigning/removing stamps and folding a hand-triggered
+  // Swarm refresh. The shipping app NEVER calls these — a stamp only reaches the
+  // product UI once the storage/drives PR adds a purchase flow. They live on the
+  // class (not a `lib/dev` free function) because they need the private
+  // `#commit` seam; kept together here so what ships is easy to tell from what
+  // is dev scaffolding.
+  // ==========================================================================
+
+  /**
+   * Add or replace a stamp (deduped by batch id). The first stamp added becomes
+   * the account default so uploads have something to spend against. Re-adding a
+   * previously removed batch revives it (a fresh `createdAt` beats the old
+   * tombstone on merge).
+   */
+  addStamp(stamp: Omit<PostageStamp, 'createdAt' | 'deletedAt'>): PostageStamp {
+    const now = Date.now()
+    const newStamp: PostageStamp = { ...stamp, createdAt: now }
+    this.postageStamps = [
+      ...this.postageStamps.filter((existing) => !existing.batchID.equals(stamp.batchID)),
+      newStamp,
+    ]
+    if (this.defaultPostageStampBatchID === undefined) {
+      this.defaultPostageStampBatchID = newStamp.batchID
+      this.defaultStampAt = now
+    }
+    this.lastModified = now
+    this.#commit()
+    return newStamp
+  }
+
+  /**
+   * Tombstone a stamp (set `deletedAt`, keep it in the array) so the removal
+   * propagates across devices — `mergePostageStamps` keeps the tombstone and
+   * lets it beat any peer's stale active copy. A hard delete would be silently
+   * re-added on the next fold from a device feed that still has the batch.
+   */
+  removeStamp(batchID: BatchId) {
+    const now = Date.now()
+    this.postageStamps = this.postageStamps.map((stamp) =>
+      stamp.batchID.equals(batchID) ? { ...stamp, deletedAt: now } : stamp,
+    )
+    // Never leave a default pointing at a stamp we just removed; fall back to a
+    // remaining live stamp so the account never references a deleted batch.
+    if (this.defaultPostageStampBatchID?.equals(batchID)) {
+      this.defaultPostageStampBatchID = this.postageStamps.find(
+        (stamp) => stamp.deletedAt === undefined,
+      )?.batchID
+      this.defaultStampAt = now
+    }
+    this.lastModified = now
+    this.#commit()
+  }
+
+  /** Update a stamp's volatile utilization in place, WITHOUT firing sync. */
+  updateStampUtilization(batchID: BatchId, utilization: number) {
+    this.postageStamps = this.postageStamps.map((stamp) =>
+      stamp.batchID.equals(batchID) ? { ...stamp, utilization } : stamp,
+    )
+    this.#commit({ skipSync: true })
+  }
+
+  setDefaultStamp(batchID: BatchId | undefined) {
+    const now = Date.now()
+    this.defaultPostageStampBatchID = batchID
+    this.defaultStampAt = now
+    this.lastModified = now
+    this.#commit()
+  }
+
+  /**
+   * Apply state merged from a Swarm refresh, WITHOUT re-publishing (the data
+   * came from Swarm). Collections replace wholesale (already merged upstream).
+   * Scalars are folded by per-field LWW: a remote value wins only if its clock
+   * is newer than ours, so a stale device can't clobber a local edit.
+   */
+  applyRefreshed(fields: {
+    devices?: Device[]
+    connectedApps?: ConnectedApp[]
+    postageStamps?: PostageStamp[]
+    accountName?: string
+    accountNameAt?: number
+    defaultPostageStampBatchID?: BatchId | undefined
+    defaultStampAt?: number
+    settings?: AccountSettings | undefined
+    settingsAt?: number
+  }) {
+    if (fields.devices) this.devices = fields.devices
+    if (fields.connectedApps) this.connectedApps = fields.connectedApps
+    if (fields.postageStamps) this.postageStamps = fields.postageStamps
+    if (
+      fields.accountName !== undefined &&
+      fields.accountNameAt !== undefined &&
+      fields.accountNameAt > (this.accountNameAt ?? this.createdAt)
+    ) {
+      this.name = fields.accountName
+      this.accountNameAt = fields.accountNameAt
+    }
+    if (
+      fields.defaultStampAt !== undefined &&
+      fields.defaultStampAt > (this.defaultStampAt ?? this.createdAt)
+    ) {
+      this.defaultPostageStampBatchID = fields.defaultPostageStampBatchID
+      this.defaultStampAt = fields.defaultStampAt
+    }
+    if (
+      fields.settingsAt !== undefined &&
+      fields.settingsAt > (this.settingsAt ?? this.createdAt)
+    ) {
+      this.settings = fields.settings
+      this.settingsAt = fields.settingsAt
+    }
+    this.#commit({ skipSync: true })
   }
 }
 
@@ -186,22 +311,33 @@ function revoked(app: ConnectedApp, tombstone: boolean): ConnectedApp {
 // state changes live on the Account object itself.
 //
 // Backed by the `@snaha/swarm-id` Zod storage manager (key STORAGE_KEY_ACCOUNTS)
-// — the SAME nested-account document the proxy iframe reads. The product UI
-// drives off this one reactive store.
+// — the SAME nested-account document the proxy iframe and sync engine read. The
+// product UI, the /dev tooling and sync all drive off this one reactive store.
 // ============================================================================
 
 const storageManager = createAccountsStorageManager()
 
 let accounts = $state<Account[]>([])
 
+/** Save the whole collection to storage — the lib serializer converts the class
+ * instances' byte-class fields to hex. No sync. */
 function persist(): void {
-  // Class instances are structurally `Account` records; the lib serializer
-  // reads their fields and converts byte classes to hex.
   storageManager.save(accounts)
 }
 
+/**
+ * Commit one account's change: `persist()` the collection, then publish this
+ * account to Swarm sync — unless `skipSync`, used when the change came from a
+ * remote fold or touches only a volatile field peers don't need. Injected into
+ * each `Account` as its `#commit`.
+ */
+function commitAccount(account: Account, options?: { skipSync?: boolean }): void {
+  persist()
+  if (!options?.skipSync) syncHook?.(account.id.toHex())
+}
+
 function hydrate(record: AccountRecord): Account {
-  return new Account(record, persist)
+  return new Account(record, commitAccount)
 }
 
 function load(): Account[] {
@@ -268,4 +404,31 @@ export const accountsStore = {
     accounts = accounts.filter((account) => !account.id.equals(ethId))
     persist()
   },
+
+  // ----- Dev-only: consumed only by the /dev tooling (see the class banner) ---
+
+  /** `EthAddress`-typed lookup used by the /dev tooling and sync engine. */
+  getAccount(id: EthAddress): Account | undefined {
+    return accountsStore.get(id)
+  },
+
+  /** Wipe every account from this device (developer reset). */
+  clear(): void {
+    accounts = []
+    storageManager.clear()
+  },
+}
+
+// ----------------------------------------------------------------------------
+// Dev-only sync seam — consumed only by the /dev sync subsystem.
+//
+// The plain product app leaves the hook unset, so a rename or app-connect never
+// attempts a network publish; the /dev page sets `triggerSync` in onMount so its
+// mutations publish to Swarm.
+// ----------------------------------------------------------------------------
+
+let syncHook: ((accountIdHex: string) => void) | undefined
+
+export function setAccountsSyncHook(hook: ((accountIdHex: string) => void) | undefined): void {
+  syncHook = hook
 }

--- a/ui/src/routes/dev/+page.svelte
+++ b/ui/src/routes/dev/+page.svelte
@@ -557,13 +557,12 @@ Check console logs for details:
       // multi-device partition scheme rewrites the partition-lock SOC on every
       // lease refresh, which an immutable batch forbids. Request mutable
       // explicitly so /dev-bought stamps work with partitioning.
-      const response = await fetch(
-        `${networkSettingsStore.beeNodeUrl}/stamps/${stampAmount}/${stampDepth}`,
-        {
-          method: 'POST',
-          headers: { immutable: 'false' },
-        },
-      )
+      // Tolerate a trailing slash (the default gateway URL has one).
+      const base = networkSettingsStore.beeNodeUrl.replace(/\/$/, '')
+      const response = await fetch(`${base}/stamps/${stampAmount}/${stampDepth}`, {
+        method: 'POST',
+        headers: { immutable: 'false' },
+      })
       if (!response.ok) {
         const errorText = await response.text()
         throw new Error(errorText || `HTTP ${response.status}`)
@@ -606,7 +605,9 @@ Check console logs for details:
     beeStampsLoading = true
     beeStampsError = ''
     try {
-      const response = await fetch(`${url}/stamps`)
+      // Tolerate a trailing slash (the default gateway URL has one);
+      // `lastBeeUrl` keeps the raw value so the effect's guard compares equal.
+      const response = await fetch(`${url.replace(/\/$/, '')}/stamps`)
       if (!response.ok) {
         const errorText = await response.text()
         throw new Error(errorText || `HTTP ${response.status}`)

--- a/ui/src/routes/dev/+page.svelte
+++ b/ui/src/routes/dev/+page.svelte
@@ -595,6 +595,10 @@ Check console logs for details:
 
   async function loadBeeStamps() {
     const url = networkSettingsStore.beeNodeUrl
+    // Record the attempt BEFORE fetching — success or failure. The auto-load
+    // effect is guarded by `url !== lastBeeUrl`; recording only on success made
+    // every failure re-arm the effect, hammering an unreachable node in a loop.
+    lastBeeUrl = url
     beeStampsLoading = true
     beeStampsError = ''
     try {
@@ -605,7 +609,6 @@ Check console logs for details:
       }
       const data = await response.json()
       beeStamps = data.stamps ?? []
-      lastBeeUrl = url
     } catch (error) {
       beeStampsError = error instanceof Error ? error.message : String(error)
       beeStamps = []

--- a/ui/src/routes/dev/+page.svelte
+++ b/ui/src/routes/dev/+page.svelte
@@ -1,0 +1,1164 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<script lang="ts">
+  import { onMount } from 'svelte'
+  import { SvelteMap } from 'svelte/reactivity'
+
+  import { BatchId, Bee, EthAddress, Identifier, PrivateKey, Utils } from '@ethersphere/bee-js'
+  import {
+    calculateStampAmountForDays,
+    derivePostageSignerKey,
+    downloadEncryptedSOC,
+    fetchChainState,
+    formatTTL,
+    rejectAfter,
+    uint8ArrayToHex,
+    uploadSOC,
+  } from '@snaha/swarm-id'
+
+  import { resolve } from '$app/paths'
+
+  import CopyButton from '$lib/components/copy-button.svelte'
+  import { Button } from '$lib/components/ui/button'
+  import { Input } from '$lib/components/ui/input'
+  import { Select } from '$lib/components/ui/select'
+  import { Tabs } from '$lib/components/ui/tabs'
+  import { networkSettingsStore } from '$lib/dev/network-settings.svelte'
+  import { postageStampsStore } from '$lib/dev/postage-stamps.svelte'
+  import { triggerSync } from '$lib/dev/sync-hooks'
+  import { syncStore } from '$lib/dev/sync.svelte'
+  import routes from '$lib/routes'
+  import { accountsStore, setAccountsSyncHook } from '$lib/stores/accounts.svelte'
+  import { sessionStore } from '$lib/stores/session.svelte'
+
+  import DeviceList from './device-list.svelte'
+  import StatusDot from './status-dot.svelte'
+
+  // Dev tooling drives Swarm publishing: register the sync hook while this page
+  // is mounted so account mutations (here and in child panels) publish to Swarm
+  // after a debounce — and reset it on unmount so the product UI stops
+  // publishing once the user navigates away from /dev.
+  onMount(() => {
+    setAccountsSyncHook(triggerSync)
+    return () => setAccountsSyncHook(undefined)
+  })
+
+  // Milliseconds per second — for converting TTL/Unix seconds to JS `Date` ms.
+  const MS_PER_SECOND = 1000
+
+  // How many days of validity to fund by default when auto-filling the
+  // stamp amount from current chain price. Bee enforces a 24h minimum on
+  // POST /stamps; 7 days gives comfortable headroom for dev testing without
+  // re-buying constantly.
+  const DEFAULT_STAMP_DAYS = 7
+
+  // Renders a listed stamp's remaining lifetime as "<ttl> (<date>)". batchTTL
+  // comes straight from the Bee node's /stamps response — authoritative for the
+  // batches it tracks, which is exactly what this list shows (no contract read
+  // needed here, and the default chain is local where the mainnet PostageStamp
+  // contract isn't deployed).
+  function formatStampExpiry(batchTTL: number): string {
+    if (!batchTTL || batchTTL <= 0) return 'Expired'
+    const date = new Date(Date.now() + batchTTL * MS_PER_SECOND).toLocaleDateString()
+    return `${formatTTL(batchTTL)} (${date})`
+  }
+
+  // Every live (non-tombstoned) stamp across all accounts — the account owns its
+  // stamps now, and a removed stamp lingers as a `deletedAt` tombstone so its
+  // deletion can propagate, so list only the live stamps.
+  const allStamps = $derived(accountsStore.accounts.flatMap((a) => a.stamps))
+
+  // Same set, but carrying the owning account — the Stored Stamps list needs the
+  // account id to delete a stamp from its nested collection.
+  const storedStampRows = $derived(
+    accountsStore.accounts.flatMap((a) =>
+      a.stamps.map((stamp) => ({ accountId: a.id, accountName: a.name, stamp })),
+    ),
+  )
+  let storedStampMessage = $state('')
+
+  // Delete a single stored stamp (dev cleanup — replaces the old hand-edit of
+  // localStorage). `removeStamp` tombstones the stamp (`deletedAt`) and lets the
+  // deletion sync: `mergePostageStamps` keeps the tombstone (#337), so a peer's
+  // fold no longer resurrects it.
+  function deleteStoredStamp(accountId: EthAddress, batchID: BatchId) {
+    accountsStore.getAccount(accountId)?.removeStamp(batchID)
+    storedStampMessage = `🗑️ Removed ${batchID.toHex().slice(0, 12)}…`
+  }
+
+  // Tab state
+  let activeTab = $state('overview')
+
+  const tabs = [
+    { value: 'overview', label: 'Overview' },
+    { value: 'stamps', label: 'Stamps' },
+    { value: 'sync', label: 'Sync' },
+    { value: 'devices', label: 'Devices' },
+  ]
+
+  // Demo app URL for connect flow testing (the new UI's demo runs on :3500).
+  const demoAppOrigin = 'http://localhost:3500'
+
+  // Sync state
+  let syncMessage = $state('')
+
+  // Stamp buying state
+  let beeUrl = $state('http://localhost:1633')
+  // Amount starts empty — autofilled from chain price on first chainstate
+  // load (see loadChainState). Hardcoding a default is fragile across chain
+  // configs: bee-compose's PriceOracle floor (24_000 PLUR/chunk/block) needs
+  // ≥ 414_720_000 PLUR/chunk for 24h, and other chains have different floors.
+  let stampAmount = $state('')
+  let stampDepth = $state('20')
+  let buying = $state(false)
+  let stampResult = $state<{ batchID: string; txHash: string } | undefined>(undefined)
+  let stampError = $state('')
+  let currentPrice = $state<bigint | undefined>(undefined)
+  let chainStateError = $state('')
+  let assignMessage = $state('')
+  let assignError = $state('')
+  let selectedStampId = $state('')
+  let selectedAccountId = $state('')
+
+  // Derived postage signer key + owner address for the selected account.
+  // Use the owner address to buy a stamp online, then paste the private key into
+  // the "Use existing one" screen as the signer key.
+  let accountSigner = $state<{ privateKey: string; owner: string } | undefined>(undefined)
+
+  $effect(() => {
+    const acct = selectedAccountId
+      ? accountsStore.getAccount(new EthAddress(selectedAccountId))
+      : undefined
+    if (!acct) {
+      accountSigner = undefined
+      return
+    }
+    // ponytail: fire-and-forget derive; effect re-runs when the selection changes
+    void (async () => {
+      const k = await derivePostageSignerKey(acct.derivationKey)
+      accountSigner = { privateKey: k, owner: new PrivateKey(k).publicKey().address().toHex() }
+    })()
+  })
+  let beeStamps = $state<
+    Array<{
+      batchID: string
+      utilization: number
+      usable: boolean
+      label: string
+      depth: number
+      amount: string
+      bucketDepth: number
+      blockNumber: number
+      immutableFlag: boolean
+      exists: boolean
+      batchTTL: number
+    }>
+  >([])
+  let beeStampsLoading = $state(false)
+  let beeStampsError = $state('')
+  let lastBeeUrl = $state('')
+
+  // Retrievability self-check: does the configured Bee node serve back a SOC we
+  // just wrote? (If not, no cross-device coordination — lock/intent/presence
+  // SOCs — can work there, and normal sync/download is unreliable too.)
+  let selfCheckStampId = $state('')
+  let selfCheckRunning = $state(false)
+  let selfCheckLog = $state<string[]>([])
+  // The address of the just-written test SOC — copy it to another device's
+  // "Read by address" to test cross-device retrievability.
+  let selfCheckSocAddress = $state('')
+
+  // Cross-device check: read a chunk BY ADDRESS that another device wrote
+  // (paste the SOC address printed by that device's self-check). On a
+  // load-balanced gateway the writer can read its own write back from its own
+  // backend, but a different device may hit a backend that can't retrieve it —
+  // this is the read that actually mirrors cross-device coordination.
+  let readAddr = $state('')
+  let readChecking = $state(false)
+  let readLog = $state<string[]>([])
+
+  // Partition-coordination timing overrides (gateway propagation tuning). Read
+  // by the proxy from this localStorage key on connect; blank fields fall back
+  // to the lib defaults. Must match PARTITION_TUNING_KEY in swarm-id-proxy.ts.
+  const PARTITION_TUNING_KEY = 'swarm-id-partition-tuning'
+  function loadTuning(): {
+    guardWindowMs?: number
+    guardPollMs?: number
+    readTimeoutMs?: number
+  } {
+    if (typeof localStorage === 'undefined') return {}
+    try {
+      return JSON.parse(localStorage.getItem(PARTITION_TUNING_KEY) ?? '{}') ?? {}
+    } catch {
+      return {}
+    }
+  }
+  const initialTuning = loadTuning()
+  let tuningWindow = $state(initialTuning.guardWindowMs?.toString() ?? '')
+  let tuningPoll = $state(initialTuning.guardPollMs?.toString() ?? '')
+  let tuningTimeout = $state(initialTuning.readTimeoutMs?.toString() ?? '')
+  let tuningSaved = $state('')
+
+  function saveTuning() {
+    const obj: Record<string, number> = {}
+    const add = (key: string, raw: string) => {
+      const n = Number(raw)
+      if (raw.trim() !== '' && Number.isFinite(n) && n >= 0) obj[key] = n
+    }
+    add('guardWindowMs', tuningWindow)
+    add('guardPollMs', tuningPoll)
+    add('readTimeoutMs', tuningTimeout)
+    localStorage.setItem(PARTITION_TUNING_KEY, JSON.stringify(obj))
+    tuningSaved = `Saved ${JSON.stringify(obj)} — reload the app/proxy to apply.`
+  }
+  function resetTuning() {
+    localStorage.removeItem(PARTITION_TUNING_KEY)
+    tuningWindow = ''
+    tuningPoll = ''
+    tuningTimeout = ''
+    tuningSaved = 'Cleared — reload to use defaults (window 12000 / poll 2500 / read 2500 ms).'
+  }
+
+  // Per-read timeout and the elapsed-since-upload checkpoints to poll at.
+  const SELF_CHECK_READ_TIMEOUT_MS = 3000
+  const SELF_CHECK_POLL_MS = [0, 2000, 5000, 10000, 20000]
+  const RANDOM_BYTES = 32
+
+  function randomBytes(): Uint8Array {
+    return crypto.getRandomValues(new Uint8Array(RANDOM_BYTES))
+  }
+
+  const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))
+
+  async function runRetrievabilityCheck() {
+    selfCheckRunning = true
+    const log: string[] = []
+    selfCheckLog = log
+    const push = (line: string) => {
+      log.push(line)
+      selfCheckLog = [...log]
+    }
+    try {
+      const stamp = allStamps.find((s) => s.batchID.toHex() === selfCheckStampId)
+      if (!stamp) {
+        push('❌ Select a stored stamp to pay for the test chunk.')
+        return
+      }
+      // Test the node the proxy/app actually uses (network settings), not the
+      // dev-page stamp-buying URL which defaults to localhost.
+      const nodeUrl = networkSettingsStore.beeNodeUrl
+      const bee = new Bee(nodeUrl)
+      // Throwaway, fresh-per-run SOC: random owner key + identifier + encryption
+      // key + payload. Postage is paid by the stamp's signerKey; the SOC is
+      // owned by the throwaway signer — the same split a real presence beacon
+      // uses. A fresh address guarantees the read isn't served from a stale
+      // local cache.
+      const signer = new PrivateKey(randomBytes())
+      const encryptionKey = randomBytes()
+      const identifier = new Identifier(randomBytes())
+      const owner = signer.publicKey().address()
+
+      const stamper = await postageStampsStore.getStamper(stamp.batchID, {
+        owner,
+        encryptionKey,
+      })
+      if (!stamper) {
+        push('❌ Could not build a stamper for that batch.')
+        return
+      }
+
+      push(`Node: ${nodeUrl}`)
+      push(`Batch: ${stamp.batchID.toHex().slice(0, 12)}… (depth ${stamp.depth})`)
+      const t0 = Date.now()
+      const { socAddress } = await uploadSOC(
+        { mode: 'stamper', bee, stamper },
+        signer,
+        identifier,
+        randomBytes(),
+        { encryptionKey },
+      )
+      const addrHex = uint8ArrayToHex(socAddress)
+      selfCheckSocAddress = addrHex
+      push(`✅ Upload OK in ${Date.now() - t0}ms — SOC address ${addrHex}`)
+
+      let retrievedMs: number | undefined
+      let prev = 0
+      for (const checkpoint of SELF_CHECK_POLL_MS) {
+        await sleep(Math.max(0, checkpoint - prev))
+        prev = checkpoint
+        try {
+          await Promise.race([
+            downloadEncryptedSOC(bee, owner, identifier, encryptionKey),
+            rejectAfter(SELF_CHECK_READ_TIMEOUT_MS, 'read timed out'),
+          ])
+          retrievedMs = Date.now() - t0
+          break
+        } catch (error) {
+          push(
+            `  read @ ${checkpoint}ms: not yet (${error instanceof Error ? error.message : String(error)})`,
+          )
+        }
+      }
+
+      if (retrievedMs !== undefined) {
+        push(
+          `✅ Retrievable after ${retrievedMs}ms → this node serves back writes; multi-device coordination can work here.`,
+        )
+      } else {
+        push(
+          `❌ NOT retrievable within ~${SELF_CHECK_POLL_MS[SELF_CHECK_POLL_MS.length - 1] / 1000}s → this node does not serve back recently-written chunks. Cross-device coordination (lock/intent/presence SOCs) cannot work here, and normal sync/download will be unreliable too.`,
+        )
+      }
+    } catch (error) {
+      push(`❌ Error: ${error instanceof Error ? error.message : String(error)}`)
+    } finally {
+      selfCheckRunning = false
+    }
+  }
+
+  async function runReadByAddress() {
+    readChecking = true
+    const log: string[] = []
+    readLog = log
+    const push = (line: string) => {
+      log.push(line)
+      readLog = [...log]
+    }
+    try {
+      const addr = readAddr.trim().replace(/^0x/, '')
+      if (!/^[0-9a-fA-F]{64}$/.test(addr)) {
+        push('❌ Enter a 64-char hex chunk address (the SOC address from another device).')
+        return
+      }
+      const nodeUrl = networkSettingsStore.beeNodeUrl
+      const bee = new Bee(nodeUrl)
+      push(`Node: ${nodeUrl}`)
+      const t0 = Date.now()
+      let foundMs: number | undefined
+      let prev = 0
+      for (const checkpoint of SELF_CHECK_POLL_MS) {
+        await sleep(Math.max(0, checkpoint - prev))
+        prev = checkpoint
+        try {
+          await Promise.race([
+            bee.downloadChunk(addr),
+            rejectAfter(SELF_CHECK_READ_TIMEOUT_MS, 'read timed out'),
+          ])
+          foundMs = Date.now() - t0
+          break
+        } catch (error) {
+          push(
+            `  read @ ${checkpoint}ms: not yet (${error instanceof Error ? error.message : String(error)})`,
+          )
+        }
+      }
+      if (foundMs !== undefined) {
+        push(
+          `✅ Retrievable after ${foundMs}ms → this device CAN read the chunk the other device wrote; cross-device coordination can work.`,
+        )
+      } else {
+        push(
+          `❌ NOT retrievable within ~${SELF_CHECK_POLL_MS[SELF_CHECK_POLL_MS.length - 1] / 1000}s → this device cannot read the other device's chunk. The gateway isn't serving writes across nodes/sessions, so cross-device coordination cannot work here.`,
+        )
+      }
+    } catch (error) {
+      push(`❌ Error: ${error instanceof Error ? error.message : String(error)}`)
+    } finally {
+      readChecking = false
+    }
+  }
+
+  // Known dev signers (pre-funded with ETH + BZZ in the local Bee cluster)
+  const KNOWN_SIGNERS = [
+    {
+      value: '566058308ad5fa3888173c741a1fb902c9f1f19559b11fc2738dfc53637ce4e9',
+      label: 'Queen (node owner)',
+    },
+    {
+      value: '4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d',
+      label: 'Wallet 0 (pre-funded)',
+    },
+    {
+      value: '6cbed15c793ce57650b9877cf6fa156fbef513c4e6134f022a85b1ffdd59b2a1',
+      label: 'Wallet 1 (pre-funded)',
+    },
+  ]
+  let selectedSigner = $state(KNOWN_SIGNERS[0].value)
+
+  // Custom signer key settings
+  let useCustomSigner = $state(false)
+  let customSignerKey = $state('')
+  let customSignerError = $state<string | undefined>(undefined)
+
+  // Mock stamp widget settings — the store is the single source of truth
+  // (durable + cross-tab); the controls below read/write it directly.
+
+  // Validate custom signer key when enabled
+  $effect(() => {
+    if (useCustomSigner) {
+      if (customSignerKey.length === 0) {
+        customSignerError = 'Custom signer key is required'
+      } else if (!/^[0-9a-fA-F]+$/.test(customSignerKey)) {
+        customSignerError = 'Signer key must be a valid hex string'
+      } else if (customSignerKey.length !== 64) {
+        customSignerError = 'Signer key must be exactly 64 characters (hex)'
+      } else {
+        customSignerError = undefined
+      }
+    } else {
+      customSignerError = undefined
+    }
+  })
+
+  const stampOptions = $derived(
+    beeStamps.map((stamp) => ({
+      value: stamp.batchID,
+      label: `${stamp.batchID.slice(0, 10)}… (depth ${stamp.depth})`,
+    })),
+  )
+  // Stored stamps (with signerKey) usable to pay for the retrievability check.
+  const storedStampOptions = $derived(
+    allStamps.map((stamp) => ({
+      value: stamp.batchID.toHex(),
+      label: `${stamp.batchID.toHex().slice(0, 10)}… (depth ${stamp.depth})`,
+    })),
+  )
+  $effect(() => {
+    if (storedStampOptions.length && !selfCheckStampId) {
+      selfCheckStampId = storedStampOptions[0].value
+    }
+  })
+  const accountOptions = $derived(
+    accountsStore.accounts.map((account) => ({
+      value: account.id.toHex(),
+      label: `${account.name} (${account.id.toHex().slice(0, 10)}…)`,
+    })),
+  )
+  const selectedAccount = $derived(
+    selectedAccountId ? accountsStore.getAccount(new EthAddress(selectedAccountId)) : undefined,
+  )
+  const accountHasDefaultStamp = $derived(!!selectedAccount?.defaultPostageStampBatchID)
+  const stampAssignments = $derived(
+    (() => {
+      const map = new SvelteMap<string, { account?: string }>()
+      for (const account of accountsStore.accounts) {
+        const batch = account.defaultPostageStampBatchID?.toHex()
+        if (batch) {
+          map.set(batch, { ...(map.get(batch) ?? {}), account: account.name })
+        }
+      }
+      return map
+    })(),
+  )
+
+  $effect(() => {
+    if (stampOptions.length && !selectedStampId) {
+      selectedStampId = stampOptions[0].value
+    } else if (
+      selectedStampId &&
+      !stampOptions.some((option) => option.value === selectedStampId)
+    ) {
+      selectedStampId = stampOptions[0]?.value ?? ''
+    }
+  })
+
+  $effect(() => {
+    if (accountOptions.length && !selectedAccountId) {
+      selectedAccountId = accountOptions[0].value
+    } else if (
+      selectedAccountId &&
+      !accountOptions.some((option) => option.value === selectedAccountId)
+    ) {
+      selectedAccountId = accountOptions[0]?.value ?? ''
+    }
+  })
+
+  async function triggerManualSync() {
+    // Get all accounts with a default stamp.
+    const accountsToSync = accountsStore.accounts.filter(
+      (account) => account.defaultPostageStampBatchID,
+    )
+
+    if (accountsToSync.length === 0) {
+      syncMessage = '❌ No accounts with default postage stamps found.'
+      return
+    }
+
+    syncMessage = `⏳ Syncing ${accountsToSync.length} accounts...`
+
+    const results: string[] = []
+    let successCount = 0
+    let errorCount = 0
+
+    for (const account of accountsToSync) {
+      try {
+        const result = await syncStore.syncAccount(account.id.toHex())
+
+        if (!result) {
+          results.push(`⚠️ ${account.name}: no snapshot captured (missing stamp?)`)
+          errorCount++
+          continue
+        }
+
+        if (result.status === 'error') {
+          results.push(`❌ ${account.name}: ${result.error}`)
+          errorCount++
+          continue
+        }
+
+        // Get default stamp to show utilization
+        const defaultStamp = account.defaultPostageStampBatchID
+        const stamp = defaultStamp ? postageStampsStore.getStamp(defaultStamp) : undefined
+        const utilization = stamp ? stamp.utilization.toFixed(2) : 'unknown'
+
+        if (result.status === 'success-unverified') {
+          results.push(
+            `⚠️ ${account.name}: synced, but root chunk not retrievable — ${result.warning}`,
+          )
+          errorCount++
+          continue
+        }
+
+        results.push(`✅ ${account.name}: ${utilization}% utilization`)
+        successCount++
+      } catch (error) {
+        results.push(
+          `❌ ${account.name}: ${error instanceof Error ? error.message : String(error)}`,
+        )
+        errorCount++
+      }
+    }
+
+    syncMessage = `Sync completed: ${successCount} succeeded, ${errorCount} failed
+
+${results.join('\n')}
+
+Check console logs for details:
+- [StateSync] Tracking X chunks
+- [StateSync] New utilization: Y%
+- [PostageStamps] Updated utilization`
+  }
+
+  async function buyStamp() {
+    buying = true
+    stampError = ''
+    stampResult = undefined
+
+    try {
+      // Buy a MUTABLE batch. Bee's POST /stamps defaults to immutable, but the
+      // multi-device partition scheme rewrites the partition-lock SOC on every
+      // lease refresh, which an immutable batch forbids. Request mutable
+      // explicitly so /dev-bought stamps work with partitioning.
+      const response = await fetch(`${beeUrl}/stamps/${stampAmount}/${stampDepth}`, {
+        method: 'POST',
+        headers: { immutable: 'false' },
+      })
+      if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(errorText || `HTTP ${response.status}`)
+      }
+      stampResult = await response.json()
+    } catch (e) {
+      stampError = e instanceof Error ? e.message : String(e)
+    } finally {
+      buying = false
+    }
+  }
+
+  // Clear this browser's accounts (which own their apps + stamps) + session.
+  function clearAccount() {
+    accountsStore.clear()
+    sessionStore.clearCurrentAccount()
+  }
+
+  // Full reset: every swarm* localStorage key + the IndexedDB utilization DB,
+  // then reload so all in-memory stores re-init from empty storage. onblocked
+  // resolves too — an open DB connection is closed by the reload, letting the
+  // pending delete finish.
+  async function clearAll() {
+    for (const key of Object.keys(localStorage)) {
+      if (key.startsWith('swarm')) localStorage.removeItem(key)
+    }
+    await new Promise<void>((resolve) => {
+      const req = indexedDB.deleteDatabase('swarm-utilization-store')
+      req.onsuccess = req.onerror = req.onblocked = () => resolve()
+    })
+    location.reload()
+  }
+
+  async function loadBeeStamps() {
+    beeStampsLoading = true
+    beeStampsError = ''
+    try {
+      const response = await fetch(`${beeUrl}/stamps`)
+      if (!response.ok) {
+        const errorText = await response.text()
+        throw new Error(errorText || `HTTP ${response.status}`)
+      }
+      const data = await response.json()
+      beeStamps = data.stamps ?? []
+      lastBeeUrl = beeUrl
+    } catch (error) {
+      beeStampsError = error instanceof Error ? error.message : String(error)
+      beeStamps = []
+    } finally {
+      beeStampsLoading = false
+    }
+  }
+
+  async function loadChainState() {
+    chainStateError = ''
+    try {
+      const state = await fetchChainState(beeUrl)
+      currentPrice = state.currentPrice
+      // Only autofill if the user hasn't typed (or pre-typed) a value yet.
+      // After the first fill, the user owns this field — switching bee URLs
+      // updates the displayed price but does not clobber their input.
+      if (stampAmount === '') {
+        stampAmount = calculateStampAmountForDays(state.currentPrice, DEFAULT_STAMP_DAYS).toString()
+      }
+    } catch (error) {
+      chainStateError = error instanceof Error ? error.message : String(error)
+      currentPrice = undefined
+    }
+  }
+
+  $effect(() => {
+    if (activeTab === 'stamps' && beeUrl && beeUrl !== lastBeeUrl && !beeStampsLoading) {
+      loadBeeStamps()
+      loadChainState()
+    }
+  })
+
+  function assignAccountStamp() {
+    assignError = ''
+    assignMessage = ''
+    if (!selectedStampId || !selectedAccountId) {
+      assignError = 'Select a stamp and an account first.'
+      return
+    }
+
+    // Validate custom signer if enabled
+    if (useCustomSigner && customSignerError) {
+      assignError = customSignerError
+      return
+    }
+
+    try {
+      const batchId = new BatchId(selectedStampId)
+      const accountId = new EthAddress(selectedAccountId)
+      const account = accountsStore.getAccount(accountId)
+      if (!account) {
+        assignError = 'Account not found.'
+        return
+      }
+
+      // Determine which signer key to use
+      const signerKeyToUse =
+        useCustomSigner && customSignerKey
+          ? new PrivateKey(customSignerKey)
+          : new PrivateKey(selectedSigner)
+
+      if (!postageStampsStore.getStamp(batchId)) {
+        const beeStamp = beeStamps.find((s) => s.batchID === selectedStampId)
+        if (!beeStamp) {
+          assignError = 'Stamp data not found. Reload stamps first.'
+          return
+        }
+        account.addStamp({
+          batchID: batchId,
+          signerKey: signerKeyToUse,
+          utilization: Utils.getStampUsage(
+            beeStamp.utilization,
+            beeStamp.depth,
+            beeStamp.bucketDepth,
+          ),
+          usable: beeStamp.usable,
+          depth: beeStamp.depth,
+          amount: BigInt(beeStamp.amount),
+          bucketDepth: beeStamp.bucketDepth,
+          blockNumber: beeStamp.blockNumber,
+          immutableFlag: beeStamp.immutableFlag,
+          exists: beeStamp.exists,
+        })
+      } else if (useCustomSigner) {
+        const beeStamp = postageStampsStore.getStamp(batchId)
+        if (!beeStamp) {
+          assignError = 'Stamp not found in local storage.'
+          return
+        }
+        // Compare by value — `signerKey` is a bee-js PrivateKey, so `!==` would
+        // always be true (distinct instances) and re-add the stamp needlessly.
+        if (!beeStamp.signerKey.equals(signerKeyToUse)) {
+          account.removeStamp(batchId)
+          account.addStamp({ ...beeStamp, signerKey: signerKeyToUse })
+        }
+      }
+
+      account.setDefaultStamp(batchId)
+      assignMessage = `✅ Set account stamp for ${accountId.toHex().slice(0, 8)}…`
+    } catch (error) {
+      assignError = error instanceof Error ? error.message : String(error)
+    }
+  }
+
+  // Clears the account's DEFAULT-stamp pointer only; the stamp stays in the
+  // account's stamps (delete it outright in "Stored Stamps" above). Assign is
+  // the symmetric op — it sets the default.
+  function clearDefaultStamp() {
+    assignError = ''
+    assignMessage = ''
+    if (!selectedAccountId) {
+      assignError = 'Select an account first.'
+      return
+    }
+    const accountId = new EthAddress(selectedAccountId)
+    accountsStore.getAccount(accountId)?.setDefaultStamp(undefined)
+    assignMessage = `✅ Cleared default stamp for ${selectedAccountId.slice(0, 8)}…`
+  }
+
+  const LABEL_CLASS = 'flex flex-col gap-1.5 text-sm'
+  const LABEL_TEXT_CLASS = 'text-muted-foreground'
+  const CARD_CLASS = 'flex flex-col gap-2 rounded-lg border bg-card p-4'
+</script>
+
+{#snippet copyRow(label: string, value: string, mono = true)}
+  <div class="flex flex-col gap-1.5">
+    <span class="text-muted-foreground text-sm">{label}</span>
+    <div class="flex items-center gap-2">
+      <span class={`text-sm break-all ${mono ? 'font-mono' : ''}`}>{value}</span>
+      <CopyButton text={value} />
+    </div>
+  </div>
+{/snippet}
+
+{#snippet signerCard(label: string, signer: { privateKey: string; owner: string })}
+  <div class={CARD_CLASS}>
+    <p class="font-mono text-sm font-semibold">{label}</p>
+    {@render copyRow('Owner Address', signer.owner)}
+    {@render copyRow('Private Key', signer.privateKey)}
+  </div>
+{/snippet}
+
+<div class="mx-auto flex w-full max-w-3xl flex-col gap-8 p-8">
+  <h2 class="text-xl font-bold">Developer Tools</h2>
+
+  <Tabs {tabs} bind:value={activeTab} />
+
+  <!-- Overview Tab -->
+  {#if activeTab === 'overview'}
+    {@const accountCount = accountsStore.accounts.length}
+    {@const connectionCount = accountsStore.accounts.reduce(
+      (n, a) => n + a.connectedApps.length,
+      0,
+    )}
+    {@const stampCount = allStamps.length}
+    {@const connectUrl = `${resolve(routes.CONNECT)}?origin=${encodeURIComponent(demoAppOrigin)}`}
+    <div class="flex flex-col gap-4">
+      <div class="flex flex-col gap-2">
+        <h4 class="text-sm font-semibold">Local Bee Endpoints</h4>
+        <div class="flex items-center gap-2">
+          <StatusDot endpoint="http://localhost:1633" />
+          <span class="font-mono text-sm">Queen API:</span>
+          <a
+            href="http://localhost:1633"
+            target="_blank"
+            rel="noopener"
+            class="text-primary font-mono text-sm">http://localhost:1633</a
+          >
+          <CopyButton text="http://localhost:1633" />
+        </div>
+        <div class="flex items-center gap-2">
+          <StatusDot endpoint="http://localhost:16331" />
+          <span class="font-mono text-sm">Worker API:</span>
+          <a
+            href="http://localhost:16331"
+            target="_blank"
+            rel="noopener"
+            class="text-primary font-mono text-sm">http://localhost:16331</a
+          >
+          <CopyButton text="http://localhost:16331" />
+        </div>
+        <div class="flex items-center gap-2">
+          <StatusDot endpoint="http://localhost:9545" method="json-rpc" />
+          <span class="font-mono text-sm">Blockchain RPC:</span>
+          <a
+            href="http://localhost:9545"
+            target="_blank"
+            rel="noopener"
+            class="text-primary font-mono text-sm">http://localhost:9545</a
+          >
+          <CopyButton text="http://localhost:9545" />
+        </div>
+      </div>
+
+      <div class="flex flex-col gap-2">
+        <h4 class="text-sm font-semibold">Test Connect Flow</h4>
+        <p class="text-sm">Test the connect flow with the demo app:</p>
+        <div class="flex items-center gap-2">
+          <StatusDot endpoint={demoAppOrigin} />
+          <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -- template literal with resolve() -->
+          <a href={connectUrl} class="text-primary font-mono text-sm">localhost:3500 (demo)</a>
+          <CopyButton text={connectUrl} />
+        </div>
+      </div>
+
+      <div class="flex flex-col items-start gap-2">
+        <h4 class="text-sm font-semibold">Local Data</h4>
+        <p class="text-sm">
+          {accountCount} accounts, {connectionCount} connections, {stampCount} stamps
+        </p>
+        <p class="text-muted-foreground text-xs">
+          Every account on this device is listed here — the product UI, /dev and sync all read the
+          one shared account store, so accounts show up as soon as they're created (no dApp
+          connection required).
+        </p>
+        <div class="flex gap-2">
+          <Button variant="destructive" onclick={clearAccount}>Clear account</Button>
+          <Button variant="destructive" onclick={clearAll}>Clear all</Button>
+        </div>
+      </div>
+    </div>
+  {/if}
+
+  <!-- Stamps Tab -->
+  {#if activeTab === 'stamps'}
+    <div class="flex flex-col gap-4">
+      <h3 class="text-lg font-semibold">Buy Postage Stamp</h3>
+      <p class="text-sm">Buy a postage stamp on the local blockchain for testing uploads.</p>
+
+      <div class="flex flex-col gap-2">
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Bee Node URL</span>
+          <Input bind:value={beeUrl} />
+        </label>
+        <div class="flex gap-4">
+          <label class={`${LABEL_CLASS} flex-1`}>
+            <span class={LABEL_TEXT_CLASS}>Amount</span>
+            <Input bind:value={stampAmount} />
+          </label>
+          <label class={`${LABEL_CLASS} w-32`}>
+            <span class={LABEL_TEXT_CLASS}>Depth (17-40)</span>
+            <Input bind:value={stampDepth} />
+          </label>
+        </div>
+        {#if currentPrice !== undefined}
+          {@const minAmount = calculateStampAmountForDays(currentPrice, 1)}
+          <p class="text-muted-foreground text-sm">
+            Chain price: {currentPrice.toLocaleString()} PLUR/chunk/block · 24h min: {minAmount.toLocaleString()}
+            PLUR · default fills {DEFAULT_STAMP_DAYS}d validity
+          </p>
+        {:else if chainStateError}
+          <p class="text-destructive text-sm">
+            Could not fetch chainstate from Bee: {chainStateError}
+          </p>
+        {/if}
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Signer Key</span>
+          <Select options={KNOWN_SIGNERS} bind:value={selectedSigner} />
+        </label>
+      </div>
+
+      <Button onclick={buyStamp} disabled={buying || !stampAmount}>
+        {buying ? 'Buying...' : 'Buy Stamp'}
+      </Button>
+
+      {#if stampResult}
+        {@const batchId = stampResult.batchID}
+        {@const txHash = stampResult.txHash}
+        <div class={CARD_CLASS}>
+          <p class="font-mono text-sm font-semibold">✅ Stamp purchased!</p>
+          {@render copyRow('Batch ID', batchId)}
+          <div class="flex gap-8">
+            {@render copyRow('Amount', stampAmount)}
+            {@render copyRow('Depth', stampDepth)}
+          </div>
+          {@render copyRow('Signer Key (for Stamper)', selectedSigner)}
+          {@render copyRow('Tx Hash', txHash)}
+          <p class="text-muted-foreground mt-2 text-sm">
+            Note: Wait ~30s for stamp to become usable.
+          </p>
+        </div>
+      {/if}
+
+      {#if stampError}
+        <div class={CARD_CLASS}>
+          <p class="text-destructive font-mono text-sm">❌ {stampError}</p>
+        </div>
+      {/if}
+
+      <div class="bg-border my-4 h-px"></div>
+
+      <h3 class="text-lg font-semibold">Stored Stamps (local)</h3>
+      <p class="text-muted-foreground text-sm">
+        The postage batches saved in this browser. Copy these fields before clearing storage — paste
+        them into the "Use existing one" screen to re-adopt the same batch on a fresh account (the
+        owner is derived from the signer key). Delete removes the stamp locally only (no sync).
+      </p>
+      {#if storedStampMessage}
+        <p class="font-mono text-sm">{storedStampMessage}</p>
+      {/if}
+      {#if storedStampRows.length === 0}
+        <p class="text-muted-foreground text-sm">No stamps stored locally.</p>
+      {:else}
+        <div class="flex flex-col gap-2">
+          {#each storedStampRows as { accountId, accountName, stamp } (stamp.batchID.toHex())}
+            <div class={CARD_CLASS}>
+              {@render copyRow('Batch ID', stamp.batchID.toHex())}
+              {@render copyRow('Signer Key', stamp.signerKey.toHex())}
+              <div class="flex gap-8">
+                {@render copyRow('Amount', stamp.amount.toString())}
+                {@render copyRow('Depth', String(stamp.depth))}
+                {@render copyRow('Block number', String(stamp.blockNumber))}
+              </div>
+              <div class="flex items-center justify-between gap-2">
+                <span class="text-muted-foreground text-sm">Account: {accountName}</span>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onclick={() => deleteStoredStamp(accountId, stamp.batchID)}>Delete</Button
+                >
+              </div>
+            </div>
+          {/each}
+        </div>
+      {/if}
+
+      <div class="bg-border my-4 h-px"></div>
+
+      <h3 class="text-lg font-semibold">Retrievability self-check</h3>
+      <p class="text-muted-foreground text-sm">
+        Writes a throwaway single-owner chunk to the Bee node from network settings ({networkSettingsStore.beeNodeUrl})
+        and reads it back, to confirm the node actually serves back what you write. Multi-device
+        coordination (and reliable sync/download) only works when this succeeds.
+      </p>
+      <div class="flex flex-col gap-2">
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Pay with stored stamp</span>
+          <Select options={storedStampOptions} bind:value={selfCheckStampId} />
+        </label>
+        <Button onclick={runRetrievabilityCheck} disabled={selfCheckRunning || !selfCheckStampId}>
+          {selfCheckRunning ? 'Checking…' : 'Run self-check'}
+        </Button>
+      </div>
+      {#if selfCheckLog.length}
+        <div class={CARD_CLASS}>
+          {#each selfCheckLog as line, i (i)}
+            <p class="font-mono text-sm break-all">{line}</p>
+          {/each}
+          {#if selfCheckSocAddress}
+            <div class="flex items-center gap-2">
+              <span class="text-muted-foreground text-sm"
+                >SOC address (copy to another device):</span
+              >
+              <CopyButton text={selfCheckSocAddress} />
+            </div>
+          {/if}
+        </div>
+      {/if}
+
+      <p class="text-muted-foreground mt-2 text-sm">
+        Cross-device check: run the self-check on another device, copy its SOC address, paste it
+        here, and read it back. The writer reading its own chunk can succeed on a load-balanced
+        gateway even when a different device cannot — this is the read that mirrors coordination.
+      </p>
+      <div class="flex flex-col gap-2">
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Chunk address from another device</span>
+          <Input bind:value={readAddr} />
+        </label>
+        <Button variant="secondary" onclick={runReadByAddress} disabled={readChecking || !readAddr}>
+          {readChecking ? 'Reading…' : 'Read by address'}
+        </Button>
+      </div>
+      {#if readLog.length}
+        <div class={CARD_CLASS}>
+          {#each readLog as line, i (i)}
+            <p class="font-mono text-sm break-all">{line}</p>
+          {/each}
+        </div>
+      {/if}
+
+      <div class="bg-border my-4 h-px"></div>
+
+      <h3 class="text-lg font-semibold">Partition tuning</h3>
+      <p class="text-muted-foreground text-sm">
+        Tune the multi-device intent-round timing for this gateway's propagation delay. Blank =
+        library default (window 12000 / poll 2500 / read 2500 ms). Reload the app after saving so
+        the proxy picks it up.
+      </p>
+      <div class="flex flex-col gap-2">
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Guard window (ms)</span>
+          <Input bind:value={tuningWindow} />
+        </label>
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Poll interval (ms)</span>
+          <Input bind:value={tuningPoll} />
+        </label>
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Read timeout (ms)</span>
+          <Input bind:value={tuningTimeout} />
+        </label>
+        <div class="flex items-center gap-2">
+          <Button onclick={saveTuning}>Save tuning</Button>
+          <Button variant="secondary" onclick={resetTuning}>Reset to defaults</Button>
+        </div>
+        {#if tuningSaved}
+          <p class="text-muted-foreground text-sm">{tuningSaved}</p>
+        {/if}
+      </div>
+
+      <div class="bg-border my-4 h-px"></div>
+
+      <div class="flex items-center justify-between">
+        <h3 class="text-lg font-semibold">Existing Stamps (Bee Node)</h3>
+        <Button variant="secondary" onclick={loadBeeStamps} disabled={beeStampsLoading}>
+          {beeStampsLoading ? 'Refreshing...' : 'Refresh'}
+        </Button>
+      </div>
+      {#if beeStampsError}
+        <p class="text-destructive text-sm">❌ {beeStampsError}</p>
+      {/if}
+      {#if beeStamps.length === 0}
+        <p class="text-muted-foreground text-sm">No stamps found on the Bee node.</p>
+      {:else}
+        <div class="flex flex-col gap-2">
+          {#each beeStamps as stamp (stamp.batchID)}
+            {@const assignment = stampAssignments.get(stamp.batchID)}
+            <div class="flex flex-col gap-2 rounded-lg border bg-card p-4">
+              <div class="flex items-center justify-between">
+                <p class="font-mono text-sm">{stamp.batchID}</p>
+                <CopyButton text={stamp.batchID} />
+              </div>
+              <div class="text-muted-foreground flex flex-wrap gap-2 text-sm">
+                <span>Depth: {stamp.depth}</span>
+                <span>Utilization: {stamp.utilization}</span>
+                <span>Expires: {formatStampExpiry(stamp.batchTTL)}</span>
+                <span>Account: {assignment?.account ?? '—'}</span>
+              </div>
+            </div>
+          {/each}
+        </div>
+      {/if}
+
+      <div class="bg-border my-4 h-px"></div>
+
+      <h3 class="text-lg font-semibold">Assign stamp to account</h3>
+      <div class="flex flex-col gap-2">
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Stamp</span>
+          <Select options={stampOptions} bind:value={selectedStampId} />
+        </label>
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Account</span>
+          <Select options={accountOptions} bind:value={selectedAccountId} />
+        </label>
+
+        <label class="flex cursor-pointer items-center gap-2 text-sm">
+          <input type="checkbox" bind:checked={useCustomSigner} />
+          Use custom signer key
+        </label>
+
+        {#if useCustomSigner}
+          <label class={LABEL_CLASS}>
+            <span class={LABEL_TEXT_CLASS}>Custom Signer Key</span>
+            <Input bind:value={customSignerKey} aria-invalid={!!customSignerError} />
+            {#if customSignerError}
+              <span class="text-destructive text-xs">{customSignerError}</span>
+            {/if}
+          </label>
+        {/if}
+      </div>
+
+      <div class="flex items-center gap-2">
+        <Button onclick={assignAccountStamp} disabled={!selectedStampId || !selectedAccountId}>
+          Set account stamp
+        </Button>
+        <Button
+          variant="destructive"
+          onclick={clearDefaultStamp}
+          disabled={!accountHasDefaultStamp}
+        >
+          Clear default stamp
+        </Button>
+      </div>
+
+      {#if assignMessage}
+        <p class="text-success text-sm">{assignMessage}</p>
+      {/if}
+      {#if assignError}
+        <p class="text-destructive text-sm">{assignError}</p>
+      {/if}
+
+      <div class="bg-border my-4 h-px"></div>
+
+      <h3 class="text-lg font-semibold">Signer Key / Owner Address</h3>
+      <p class="text-muted-foreground text-sm">
+        Buy a stamp online under the owner address, then paste the private key as the signer key in
+        the "Use existing one" screen. Reflects the account selected above.
+      </p>
+
+      {#if !selectedAccountId}
+        <p class="text-muted-foreground text-sm">Select an account above to view its signer key.</p>
+      {:else if accountSigner}
+        <div class="flex flex-col gap-2">
+          {@render signerCard('Account-level signer', accountSigner)}
+        </div>
+      {/if}
+    </div>
+  {/if}
+
+  <!-- Sync Tab -->
+  {#if activeTab === 'sync'}
+    <div class="flex flex-col gap-4">
+      <h3 class="text-lg font-semibold">Manual Sync Testing</h3>
+      <p class="text-sm">
+        Trigger a manual sync for ALL accounts to test postage stamp utilization tracking.
+      </p>
+      <div class="flex gap-4">
+        <Button onclick={triggerManualSync}>Sync All Accounts</Button>
+      </div>
+
+      {#if syncMessage}
+        <div class="flex flex-col gap-4 rounded-lg border bg-card p-4 whitespace-pre-wrap">
+          <p class="font-mono text-sm">{syncMessage}</p>
+        </div>
+      {/if}
+
+      <div class="flex flex-col gap-2">
+        <p class="text-muted-foreground text-sm">Requirements for sync:</p>
+        <p class="text-muted-foreground font-mono text-sm">
+          • At least one account with a default postage stamp
+        </p>
+        <p class="text-muted-foreground font-mono text-sm">
+          • Open browser console to see detailed logs
+        </p>
+      </div>
+    </div>
+  {/if}
+
+  <!-- Devices Tab -->
+  {#if activeTab === 'devices'}
+    <div class="flex flex-col gap-4">
+      <h3 class="text-lg font-semibold">Account Devices</h3>
+      <p class="text-sm">
+        Inspect the devices registered to an account and which partitions they currently hold.
+      </p>
+      <label class={LABEL_CLASS}>
+        <span class={LABEL_TEXT_CLASS}>Account</span>
+        <Select options={accountOptions} bind:value={selectedAccountId} />
+      </label>
+      {#if selectedAccount}
+        {#key selectedAccountId}
+          <DeviceList account={selectedAccount} />
+        {/key}
+      {:else}
+        <p class="text-muted-foreground text-sm">No accounts found.</p>
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/ui/src/routes/dev/+page.svelte
+++ b/ui/src/routes/dev/+page.svelte
@@ -105,8 +105,11 @@
   // Sync state
   let syncMessage = $state('')
 
-  // Stamp buying state
-  let beeUrl = $state('http://localhost:1633')
+  // Stamp buying state. The Bee node URL is NOT page-local: every dev
+  // subsystem (stamp buying/listing here, sync, account refresh, the
+  // retrievability checks) reads the one persisted network setting, so a URL
+  // change applies everywhere at once — buying a stamp against one node while
+  // sync silently targets another was a debugging trap.
   // Amount starts empty — autofilled from chain price on first chainstate
   // load (see loadChainState). Hardcoding a default is fragile across chain
   // configs: bee-compose's PriceOracle floor (24_000 PLUR/chunk/block) needs
@@ -136,7 +139,7 @@
       accountSigner = undefined
       return
     }
-    // ponytail: fire-and-forget derive; effect re-runs when the selection changes
+    // Fire-and-forget derive; effect re-runs when the selection changes.
     void (async () => {
       const k = await derivePostageSignerKey(acct.derivationKey)
       accountSigner = { privateKey: k, owner: new PrivateKey(k).publicKey().address().toHex() }
@@ -247,8 +250,6 @@
         push('❌ Select a stored stamp to pay for the test chunk.')
         return
       }
-      // Test the node the proxy/app actually uses (network settings), not the
-      // dev-page stamp-buying URL which defaults to localhost.
       const nodeUrl = networkSettingsStore.beeNodeUrl
       const bee = new Bee(nodeUrl)
       // Throwaway, fresh-per-run SOC: random owner key + identifier + encryption
@@ -552,10 +553,13 @@ Check console logs for details:
       // multi-device partition scheme rewrites the partition-lock SOC on every
       // lease refresh, which an immutable batch forbids. Request mutable
       // explicitly so /dev-bought stamps work with partitioning.
-      const response = await fetch(`${beeUrl}/stamps/${stampAmount}/${stampDepth}`, {
-        method: 'POST',
-        headers: { immutable: 'false' },
-      })
+      const response = await fetch(
+        `${networkSettingsStore.beeNodeUrl}/stamps/${stampAmount}/${stampDepth}`,
+        {
+          method: 'POST',
+          headers: { immutable: 'false' },
+        },
+      )
       if (!response.ok) {
         const errorText = await response.text()
         throw new Error(errorText || `HTTP ${response.status}`)
@@ -590,17 +594,18 @@ Check console logs for details:
   }
 
   async function loadBeeStamps() {
+    const url = networkSettingsStore.beeNodeUrl
     beeStampsLoading = true
     beeStampsError = ''
     try {
-      const response = await fetch(`${beeUrl}/stamps`)
+      const response = await fetch(`${url}/stamps`)
       if (!response.ok) {
         const errorText = await response.text()
         throw new Error(errorText || `HTTP ${response.status}`)
       }
       const data = await response.json()
       beeStamps = data.stamps ?? []
-      lastBeeUrl = beeUrl
+      lastBeeUrl = url
     } catch (error) {
       beeStampsError = error instanceof Error ? error.message : String(error)
       beeStamps = []
@@ -612,7 +617,7 @@ Check console logs for details:
   async function loadChainState() {
     chainStateError = ''
     try {
-      const state = await fetchChainState(beeUrl)
+      const state = await fetchChainState(networkSettingsStore.beeNodeUrl)
       currentPrice = state.currentPrice
       // Only autofill if the user hasn't typed (or pre-typed) a value yet.
       // After the first fill, the user owns this field — switching bee URLs
@@ -627,7 +632,8 @@ Check console logs for details:
   }
 
   $effect(() => {
-    if (activeTab === 'stamps' && beeUrl && beeUrl !== lastBeeUrl && !beeStampsLoading) {
+    const url = networkSettingsStore.beeNodeUrl
+    if (activeTab === 'stamps' && url && url !== lastBeeUrl && !beeStampsLoading) {
       loadBeeStamps()
       loadChainState()
     }
@@ -832,9 +838,17 @@ Check console logs for details:
 
       <div class="flex flex-col gap-2">
         <label class={LABEL_CLASS}>
-          <span class={LABEL_TEXT_CLASS}>Bee Node URL</span>
-          <Input bind:value={beeUrl} />
+          <span class={LABEL_TEXT_CLASS}>Bee Node URL (network settings)</span>
+          <div class="flex gap-2">
+            <Input bind:value={networkSettingsStore.beeNodeUrl} />
+            <Button variant="secondary" onclick={networkSettingsStore.reset}>Reset</Button>
+          </div>
         </label>
+        <p class="text-muted-foreground text-sm">
+          One URL for all dev tooling — stamp buying/listing here, plus sync, account refresh and
+          the retrievability checks below. Persisted across reloads; point it at
+          http://localhost:1633 for the local cluster.
+        </p>
         <div class="flex gap-4">
           <label class={`${LABEL_CLASS} flex-1`}>
             <span class={LABEL_TEXT_CLASS}>Amount</span>
@@ -931,7 +945,7 @@ Check console logs for details:
 
       <h3 class="text-lg font-semibold">Retrievability self-check</h3>
       <p class="text-muted-foreground text-sm">
-        Writes a throwaway single-owner chunk to the Bee node from network settings ({networkSettingsStore.beeNodeUrl})
+        Writes a throwaway single-owner chunk to the configured Bee node ({networkSettingsStore.beeNodeUrl})
         and reads it back, to confirm the node actually serves back what you write. Multi-device
         coordination (and reliable sync/download) only works when this succeeds.
       </p>

--- a/ui/src/routes/dev/+page.svelte
+++ b/ui/src/routes/dev/+page.svelte
@@ -139,9 +139,13 @@
       accountSigner = undefined
       return
     }
-    // Fire-and-forget derive; effect re-runs when the selection changes.
+    // Fire-and-forget derive with a staleness guard: two quick account
+    // switches can resolve out of order, and this card renders key material —
+    // never label one account's private key with another account selected.
+    const requestedId = selectedAccountId
     void (async () => {
       const k = await derivePostageSignerKey(acct.derivationKey)
+      if (selectedAccountId !== requestedId) return
       accountSigner = { privateKey: k, owner: new PrivateKey(k).publicKey().address().toHex() }
     })()
   })

--- a/ui/src/routes/dev/+page.ts
+++ b/ui/src/routes/dev/+page.ts
@@ -1,0 +1,9 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Developer-tools page: local-only. The root layout prerenders every static
+// route (`prerender = true`), which would otherwise emit `dev.html` into the
+// static build and ship the dev tooling to the GitHub Pages previews/production
+// site. Opt this route out so it is never deployed — it still works on the dev
+// server (`pnpm dev:ui:new`), which ignores prerendering.
+export const prerender = false

--- a/ui/src/routes/dev/device-list.svelte
+++ b/ui/src/routes/dev/device-list.svelte
@@ -1,0 +1,354 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<script lang="ts">
+  import { onMount } from 'svelte'
+
+  import { Bee } from '@ethersphere/bee-js'
+  import CircleCheckBig from '@lucide/svelte/icons/circle-check-big'
+  import Laptop from '@lucide/svelte/icons/laptop'
+  import RefreshCw from '@lucide/svelte/icons/refresh-cw'
+  import {
+    type Account,
+    PartitionLease,
+    type PartitionLeaseStateSnapshot,
+    deriveSwarmEncryptionKey,
+    getOrCreateDeviceId,
+    hexToUint8Array,
+    leaseCacheStorageKey,
+  } from '@snaha/swarm-id'
+
+  import { browser } from '$app/environment'
+
+  import CopyButton from '$lib/components/copy-button.svelte'
+  import { Button } from '$lib/components/ui/button'
+  import { networkSettingsStore } from '$lib/dev/network-settings.svelte'
+  import { refreshAccountFromSwarm } from '$lib/dev/refresh-account-from-swarm'
+  import { syncStore } from '$lib/dev/sync.svelte'
+
+  const { account }: { account: Account } = $props()
+
+  // Re-read the shared lease cache this often so the self row picks up the
+  // proxy's per-tick `leasedUntil` advances even when `storage` events don't
+  // cross the iframe/tab boundary.
+  const LEASE_CACHE_POLL_MS = 3_000
+
+  const thisDeviceId = browser ? getOrCreateDeviceId() : undefined
+
+  const hasPostageBatch = $derived(!!account.defaultPostageStampBatchID)
+
+  // Refresh state — pull the snapshot from Swarm so peers added on other
+  // browsers show up here.
+  let refreshing = $state(false)
+  let refreshedAt = $state<number | undefined>(undefined)
+  let refreshError = $state<string | undefined>(undefined)
+  // True when the backup feed has no reachable entry yet (e.g. the prior
+  // backup expired with an old batch and the republish hasn't landed). Not
+  // an error — drives an informative note + "Publish backup now" action.
+  let noBackup = $state(false)
+  let publishing = $state(false)
+  // PEER active state, read through the PartitionLease model (lock SOCs on
+  // Swarm — the cross-device source of truth). Other machines don't share
+  // this tab's localStorage, so peers can only be observed via Swarm.
+  // Best-effort: empty when the Bee node can't serve the lock SOC chunk.
+  let holders = $state<{ partition: number; deviceId: string; leasedUntil: number }[]>([])
+
+  // SELF active state, read from the proxy-written localStorage lease cache
+  // (`swarm-id-lease-v2:<accountId>`). Shared across same-origin tabs, so it
+  // reflects the demo iframe's held partition without a Swarm read (which is
+  // currently 500ing). The proxy is the sole writer; refreshed ~every 10 s.
+  let leaseCache = $state<PartitionLeaseStateSnapshot | undefined>(undefined)
+
+  $effect(() => {
+    if (!browser) return
+    const key = leaseCacheStorageKey(account.id.toHex())
+    const read = () => {
+      const raw = localStorage.getItem(key)
+      leaseCache = raw ? (JSON.parse(raw) as PartitionLeaseStateSnapshot) : undefined
+    }
+    read()
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === key) read()
+    }
+    window.addEventListener('storage', onStorage)
+    // `storage` events don't reliably cross the iframe/tab boundary, so also
+    // poll the cache to pick up the proxy's per-tick `leasedUntil` advances.
+    const poll = setInterval(read, LEASE_CACHE_POLL_MS)
+    return () => {
+      window.removeEventListener('storage', onStorage)
+      clearInterval(poll)
+    }
+  })
+
+  async function doRefresh() {
+    if (refreshing) return
+    refreshing = true
+    refreshError = undefined
+    noBackup = false
+    try {
+      const result = await refreshAccountFromSwarm(account.id.toHex())
+      if (result.ok) {
+        refreshedAt = result.refreshedAt
+      } else if (result.kind === 'no-backup') {
+        noBackup = true
+      } else {
+        refreshError = result.error
+      }
+      // Always probe the lock SOCs even if the snapshot refresh failed —
+      // they're an independent source of truth for the active-state badge.
+      // Build a read-only PartitionLease and read its holders — the single
+      // in-code lease model (no parallel holder variable).
+      const partitionCount = account.partitionCount ?? 1
+      if (partitionCount > 1 && account.derivationKey) {
+        try {
+          const bee = new Bee(networkSettingsStore.beeNodeUrl)
+          const swarmKeyHex = await deriveSwarmEncryptionKey(account.derivationKey)
+          const lease = await PartitionLease.fromSwarmEncryptionKey({
+            bee,
+            deviceId: thisDeviceId ?? '',
+            swarmEncryptionKey: hexToUint8Array(swarmKeyHex),
+          })
+          await lease.refreshFromSwarm(partitionCount)
+          holders = lease.getHolders()
+        } catch (err) {
+          console.warn('[devices] reading lock SOCs failed:', err)
+        }
+      } else {
+        holders = []
+      }
+    } finally {
+      refreshing = false
+    }
+  }
+
+  // Republish the account snapshot to Swarm with the current default
+  // stamp, then re-read. Used when the backup is missing (e.g. after a
+  // batch swap). Best-effort: if the account isn't active, syncAccount
+  // refuses and we stay in the no-backup state — no worse than before.
+  async function doPublish() {
+    if (publishing) return
+    publishing = true
+    try {
+      await syncStore.syncAccount(account.id.toHex())
+    } catch (err) {
+      console.warn('[devices] publish backup failed:', err)
+    } finally {
+      publishing = false
+    }
+    await doRefresh()
+  }
+
+  // Refresh exactly once when the component mounts. No $effect — that
+  // re-fires whenever any tracked dependency changes (which happens every
+  // time `applyRefreshed` mutates the account), producing a loop.
+  // onMount runs after initial render with no reactive subscriptions, so
+  // it fires once per fresh mount and never again. Re-mounting the panel
+  // (e.g. switching the selected account via {#key}) re-fires onMount —
+  // that's how "re-visit to refresh" still works.
+  onMount(() => {
+    if (browser) void doRefresh()
+  })
+
+  let tick = $state(0)
+  $effect(() => {
+    if (!browser) return
+    // Re-render the relative timestamp every 30 s.
+    const timer = setInterval(() => (tick = tick + 1), 30_000)
+    return () => clearInterval(timer)
+  })
+
+  function formatRelative(ms: number): string {
+    void tick // depend on tick so the formatted string stays fresh
+    const ago = Date.now() - ms
+    if (ago < 5_000) return 'just now'
+    if (ago < 60_000) return `${Math.floor(ago / 1_000)}s ago`
+    if (ago < 3_600_000) return `${Math.floor(ago / 60_000)}m ago`
+    return `${Math.floor(ago / 3_600_000)}h ago`
+  }
+
+  // Debug helper: is a lease still live, relative to now?
+  function leaseLiveness(leasedUntil: number): string {
+    void tick // re-evaluate as time passes
+    const now = Date.now()
+    return leasedUntil > now
+      ? `LIVE (now ${formatDateTime(now)})`
+      : `EXPIRED ${Math.floor((now - leasedUntil) / 1000)}s ago (now ${formatDateTime(now)})`
+  }
+
+  const deviceRows = $derived.by(() => {
+    // `tick` so the self lease-expiry check re-evaluates over time.
+    void tick
+    const now = Date.now()
+    return (account.devices ?? []).map((d) => {
+      const isThis = d.deviceId === thisDeviceId
+      if (isThis) {
+        // Self: read from the shared localStorage lease cache (proxy is the
+        // sole writer). The cache key is per-account and machine-local, so a
+        // live `self` lease in it means THIS machine holds that partition —
+        // independent of the device-id string stored inside (the proxy's
+        // captured id can differ from this tab's id even when the value is
+        // shared). So don't gate on the inner deviceId; just check liveness.
+        const self = leaseCache?.self
+        const active = self !== undefined && self.leasedUntil > now
+        return {
+          ...d,
+          isThis: true,
+          isActive: active,
+          partition: active ? self!.partition : undefined,
+        }
+      }
+      // Peers: cross-device, only observable via the lock SOC (Swarm).
+      const holderEntry = holders.find((h) => h.deviceId === d.deviceId)
+      return {
+        ...d,
+        isThis: false,
+        isActive: holderEntry !== undefined,
+        partition: holderEntry?.partition,
+      }
+    })
+  })
+
+  function formatDateTime(ms: number): string {
+    return new Date(ms).toLocaleString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    })
+  }
+
+  function truncate(id: string): string {
+    if (id.length <= 16) return id
+    return `${id.slice(0, 8)}…${id.slice(-6)}`
+  }
+
+  const BADGE_CLASS =
+    'inline-flex items-center gap-1 rounded px-2 py-0.5 text-xs font-semibold whitespace-nowrap'
+</script>
+
+<div class="flex flex-col gap-4 pt-8">
+  {#if !hasPostageBatch}
+    <div class="flex flex-col gap-2">
+      <p class="text-center font-bold">No synced account yet.</p>
+      <p class="text-center text-sm">
+        Multi-device sync requires a postage stamp. Assign one in the Stamps tab to enable uploading
+        and see all registered devices here.
+      </p>
+    </div>
+  {:else}
+    <div class="flex flex-col gap-2">
+      <div class="flex items-center justify-between gap-2">
+        <p class="font-medium">Devices</p>
+        <Button variant="ghost" size="xs" onclick={() => doRefresh()} disabled={refreshing}>
+          <RefreshCw />
+          {refreshing ? 'Refreshing…' : 'Refresh'}
+        </Button>
+      </div>
+      <p class="text-muted-foreground text-sm">
+        Devices registered to this account. At most {account.partitionCount ?? 1} can upload simultaneously.
+      </p>
+      {#if refreshError}
+        <p class="text-destructive text-sm">Refresh failed: {refreshError}</p>
+      {:else if noBackup}
+        <div class="flex flex-col items-start gap-2">
+          <p class="text-sm">
+            No backup found on this node yet. If you recently replaced your postage stamp, your
+            account republishes automatically — this can take a minute. Publish it now or refresh
+            again shortly.
+          </p>
+          <Button size="sm" onclick={() => doPublish()} disabled={publishing || refreshing}>
+            {publishing ? 'Publishing…' : 'Publish backup now'}
+          </Button>
+        </div>
+      {:else if refreshedAt}
+        <p class="text-muted-foreground text-sm">Last refreshed {formatRelative(refreshedAt)}</p>
+      {/if}
+    </div>
+
+    {#if deviceRows.length === 0}
+      <div class="flex flex-col gap-2">
+        <p class="text-center font-bold">No devices registered yet.</p>
+        <p class="text-center text-sm">Sign in on another device to register it here.</p>
+      </div>
+    {:else}
+      <div class="flex flex-col gap-4">
+        {#each deviceRows as row (row.deviceId)}
+          <div class="flex flex-col gap-2">
+            <div class="flex items-center gap-2">
+              <Laptop class="size-4 shrink-0" />
+              {#if row.name}
+                <div class="flex flex-col items-start">
+                  <p class="text-sm">{row.name}</p>
+                  <p class="text-muted-foreground font-mono text-xs">{truncate(row.deviceId)}</p>
+                </div>
+              {:else}
+                <p class="font-mono text-sm">{truncate(row.deviceId)}</p>
+              {/if}
+              <CopyButton text={row.deviceId} />
+            </div>
+
+            <div class="flex gap-2 pl-6">
+              {#if row.isThis}
+                <span class={`${BADGE_CLASS} bg-primary text-primary-foreground`}>This device</span>
+              {/if}
+              {#if row.isActive}
+                <span class={`${BADGE_CLASS} bg-success text-success-foreground`}>
+                  <CircleCheckBig class="size-3" />
+                  Active · partition {row.partition}
+                </span>
+              {:else}
+                <span class={`${BADGE_CLASS} bg-muted text-muted-foreground`}>Inactive</span>
+              {/if}
+            </div>
+
+            <div class="text-muted-foreground flex gap-4 pl-6 text-sm">
+              {#if row.createdAt}
+                <span>Added {formatDateTime(row.createdAt)}</span>
+              {/if}
+              {#if row.lastSignedInAt}
+                <span>Last seen {formatDateTime(row.lastSignedInAt)}</span>
+              {/if}
+            </div>
+          </div>
+          <div class="bg-border h-px"></div>
+        {/each}
+      </div>
+    {/if}
+
+    <!-- Debug: the self lease (shared localStorage cache) and the peer
+         holders (lock SOCs on Swarm), vs this device's id. -->
+    <div class="flex flex-col items-start gap-0.5">
+      <div class="bg-border h-px w-full"></div>
+      <p class="text-sm font-bold">Debug · lease state</p>
+      <p class="font-mono text-sm">this device: {thisDeviceId ?? '—'}</p>
+      {#if leaseCache?.self}
+        <p class="font-mono text-sm">
+          self (localStorage): partition {leaseCache.self.partition} — {leaseLiveness(
+            leaseCache.self.leasedUntil,
+          )}
+        </p>
+        <p class="font-mono text-sm">
+          self deviceId: {leaseCache.deviceId} (matches this device: {leaseCache.deviceId ===
+          thisDeviceId
+            ? 'yes'
+            : 'no'})
+        </p>
+      {:else}
+        <p class="font-mono text-sm">self (localStorage): none</p>
+      {/if}
+      {#if holders.length === 0}
+        <p class="text-sm">peers (lock SOCs): none observed</p>
+      {:else}
+        {#each holders as h (h.partition)}
+          <p class="font-mono text-sm">
+            peer partition {h.partition} → {h.deviceId} (until {formatDateTime(h.leasedUntil)})
+          </p>
+        {/each}
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/ui/src/routes/dev/status-dot.svelte
+++ b/ui/src/routes/dev/status-dot.svelte
@@ -1,0 +1,54 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<script lang="ts">
+  import { onMount } from 'svelte'
+
+  import { cn } from '$lib/utils'
+
+  const CHECK_INTERVAL_MS = 10000
+
+  type Status = 'online' | 'offline' | 'checking'
+  type CheckMethod = 'head' | 'json-rpc'
+
+  let { endpoint, method = 'head' }: { endpoint: string; method?: CheckMethod } = $props()
+
+  let status = $state<Status>('checking')
+
+  const dotClass: Record<Status, string> = {
+    online: 'bg-success',
+    offline: 'bg-destructive',
+    checking: 'bg-muted-foreground animate-pulse',
+  }
+
+  async function checkEndpoint() {
+    try {
+      if (method === 'json-rpc') {
+        // Use eth_blockNumber for JSON-RPC endpoints
+        const response = await fetch(endpoint, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ jsonrpc: '2.0', method: 'eth_blockNumber', params: [], id: 1 }),
+        })
+        status = response.ok ? 'online' : 'offline'
+      } else {
+        // Use no-cors HEAD for regular HTTP endpoints
+        await fetch(endpoint, { method: 'HEAD', mode: 'no-cors' })
+        status = 'online'
+      }
+    } catch {
+      status = 'offline'
+    }
+  }
+
+  onMount(() => {
+    checkEndpoint()
+    const interval = setInterval(checkEndpoint, CHECK_INTERVAL_MS)
+    return () => clearInterval(interval)
+  })
+</script>
+
+<span class={cn('inline-block size-2 shrink-0 rounded-full', dotClass[status])} title={status}
+></span>


### PR DESCRIPTION
Split out of #379 (unified account store) to keep that PR focused.

Adds the local-only developer tools page (`/dev`) and its supporting dev subsystem — sync, postage-stamp, and network-settings helpers — plus the shared `copy-button` component it uses. The route opts out of prerendering (`prerender = false`), so it never ships to the static build.

**Stacked on #379** — review/merge that first. GitHub will auto-retarget this PR to `main` once #379 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)