### PR TITLE
fix(ui): record extend outcome before the attempt guard

### DIFF
--- a/ui/src/lib/components/drive-extend-dialog.svelte
+++ b/ui/src/lib/components/drive-extend-dialog.svelte
@@ -96,13 +96,13 @@
         throw new Error('This drive was removed in the meantime.')
       }
       await topUpStamp(drive.batchID.toHex(), topUpAmount)
-      if (myAttempt !== attempt) {
-        return
-      }
       account.updateStamp(
         drive.batchID,
         extendedStamp(drive, addedSeconds, topUpAmount, remainingLifespanSeconds(drive)),
       )
+      if (myAttempt !== attempt) {
+        return
+      }
       onUpdated?.('Lifespan extended')
       close()
     } catch (caught) {


### PR DESCRIPTION
In `drive-extend-dialog.svelte`, `account.updateStamp(...)` ran after the `myAttempt !== attempt` guard, so a superseded attempt could drop a landed top-up from the local record. Move it before the guard, mirroring `drive-resize-dialog.svelte`. Currently unreachable (the pending dialog is not dismissable), but this keeps the two dialogs consistent and future-proofs a Cancel in the pending state.

Closes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)