### PR TITLE
fix(ui): derive unnamed drive fallback name from batch id

### DIFF
--- a/lib/src/schemas.ts
+++ b/lib/src/schemas.ts
@@ -154,7 +154,7 @@ export const PostageStampSchemaV1 = z.object({
   signerKey: StoredPrivateKey,
   // User-given label shown in the UI (a "drive"). Optional: stamps created before
   // naming existed — and those bought outside the app — have none, and callers
-  // fall back to a positional `Drive N` label.
+  // fall back to a batch-ID-derived label.
   name: z.string().optional(),
   // Rename clock. The name merges on its own last-writer-wins clock, separate
   // from the node-state clock below: a rename made over a stale copy must not

--- a/ui/src/lib/components/drive-add-dialog.svelte
+++ b/ui/src/lib/components/drive-add-dialog.svelte
@@ -53,11 +53,6 @@
   type Storage = 'new' | 'existing'
   type Phase = 'form' | 'unlock' | 'pending' | 'error' | 'unconfirmed'
 
-  /** Positional default shown as the name placeholder and used when left blank. */
-  function suggestedName() {
-    return `Drive ${account.stamps.length + 1}`
-  }
-
   let storage = $state<Storage>('new')
   let name = $state('')
   let depthValue = $state('')
@@ -197,9 +192,9 @@
       devSettingsStore.data.mockStampEnabled && !devSettingsStore.data.mockStampPopup
         ? 'Simulating the purchase…'
         : 'Complete the purchase in the popup window.'
-    // Capture the fallback now: computed at settlement it could differ from the
-    // placeholder the user saw (a sync pull / another tab adding a stamp meanwhile).
-    const driveName = name.trim() || suggestedName()
+    // Left blank, the drive stays unnamed and the UI falls back to its stable
+    // batch-ID-derived label.
+    const driveName = name.trim() || undefined
     try {
       const { signerKey, destination } = await derivePostageSigner(seed)
       // The user may have cancelled during the derivation — bail before the
@@ -260,7 +255,7 @@
     const myAttempt = ++attempt
     phase = 'pending'
     pendingLabel = 'Looking up the batch…'
-    const driveName = name.trim() || suggestedName()
+    const driveName = name.trim() || undefined
     try {
       const { signerKey } = await derivePostageSigner(seed)
       const stamp = await fetchExistingStamp(batchIdInput.trim(), signerKey, driveName)
@@ -328,7 +323,7 @@
   <Dialog onclose={close} title="Add drive">
     <div class="flex w-full flex-col gap-2">
       <label for="drive-name" class="text-sm font-medium">Name</label>
-      <Input id="drive-name" bind:value={name} placeholder={suggestedName()} />
+      <Input id="drive-name" bind:value={name} placeholder="Optional" />
     </div>
 
     <div class="flex w-full flex-col gap-2">

--- a/ui/src/lib/components/home-drives.svelte
+++ b/ui/src/lib/components/home-drives.svelte
@@ -124,9 +124,9 @@
     <p class="text-muted-foreground py-8 text-center text-sm">No drives yet.</p>
   {:else}
     <div class="flex w-full flex-col gap-2">
-      {#each account.stamps as drive, index (drive.batchID.toHex())}
+      {#each account.stamps as drive (drive.batchID.toHex())}
         {@const batchKey = drive.batchID.toHex()}
-        {@const d = describeDrive(drive, index)}
+        {@const d = describeDrive(drive)}
         {@const isDefault = account.defaultPostageStampBatchID?.equals(drive.batchID) ?? false}
         {@const isOpen = expandedId === batchKey}
         {@const lifespanAlarm = d.status === 'expires-soon' || d.status === 'expired'}

--- a/ui/src/lib/drives.test.ts
+++ b/ui/src/lib/drives.test.ts
@@ -91,7 +91,7 @@ describe('describeDrive', () => {
   const measuredAt = Date.UTC(2026, 8, 21)
 
   it('describes an active drive', () => {
-    const display = describeDrive(makeDrive({ batchTTL: 90 * DAY }), 0, measuredAt)
+    const display = describeDrive(makeDrive({ batchTTL: 90 * DAY }), measuredAt)
     expect(display.status).toBe('active')
     expect(display.timeLeftLabel).toBe('3 months left')
     expect(display.expiryDate).toBe('2026-12-20')
@@ -102,53 +102,55 @@ describe('describeDrive', () => {
 
   it('ages the countdown as time passes without any node refresh', () => {
     const drive = makeDrive({ batchTTL: 90 * DAY })
-    const later = describeDrive(drive, 0, measuredAt + 89 * DAY * 1000)
+    const later = describeDrive(drive, measuredAt + 89 * DAY * 1000)
     expect(later.status).toBe('expires-soon')
     expect(later.timeLeftLabel).toBe('1 day left')
     // The expiry date stays anchored instead of sliding forward every render.
     expect(later.expiryDate).toBe('2026-12-20')
-    expect(describeDrive(drive, 0, measuredAt + 91 * DAY * 1000).status).toBe('expired')
+    expect(describeDrive(drive, measuredAt + 91 * DAY * 1000).status).toBe('expired')
   })
 
   it('flags drives close to expiry', () => {
-    const display = describeDrive(makeDrive({ batchTTL: 6 * DAY }), 0, measuredAt)
+    const display = describeDrive(makeDrive({ batchTTL: 6 * DAY }), measuredAt)
     expect(display.status).toBe('expires-soon')
     expect(display.timeLeftLabel).not.toBe('')
   })
 
   it('flags expired drives and hides the lifespan', () => {
-    const display = describeDrive(makeDrive({ batchTTL: 0 }), 0, measuredAt)
+    const display = describeDrive(makeDrive({ batchTTL: 0 }), measuredAt)
     expect(display.status).toBe('expired')
     expect(display.timeLeftLabel).toBe('')
     expect(display.expiryDate).toBeUndefined()
   })
 
   it('flags a full drive', () => {
-    expect(describeDrive(makeDrive({ utilization: 1 }), 0, measuredAt).storageFull).toBe(true)
+    expect(describeDrive(makeDrive({ utilization: 1 }), measuredAt).storageFull).toBe(true)
   })
 
   it('clamps utilization to the 0–100 range', () => {
-    expect(describeDrive(makeDrive({ utilization: 1.2 }), 0, measuredAt).usedPercent).toBe(100)
-    expect(describeDrive(makeDrive({ utilization: -0.1 }), 0, measuredAt).usedPercent).toBe(0)
+    expect(describeDrive(makeDrive({ utilization: 1.2 }), measuredAt).usedPercent).toBe(100)
+    expect(describeDrive(makeDrive({ utilization: -0.1 }), measuredAt).usedPercent).toBe(0)
   })
 
   it('reserves 100% for an actually-full drive', () => {
-    const almostFull = describeDrive(makeDrive({ utilization: 0.996 }), 0, measuredAt)
+    const almostFull = describeDrive(makeDrive({ utilization: 0.996 }), measuredAt)
     expect(almostFull.usedPercent).toBe(99)
     expect(almostFull.storageFull).toBe(false)
-    const full = describeDrive(makeDrive({ utilization: 1 }), 0, measuredAt)
+    const full = describeDrive(makeDrive({ utilization: 1 }), measuredAt)
     expect(full.usedPercent).toBe(100)
     expect(full.storageFull).toBe(true)
   })
 
-  it('names drives, falling back to a positional label', () => {
-    expect(describeDrive(makeDrive({ name: 'Photos' }), 3, measuredAt).name).toBe('Photos')
-    expect(describeDrive(makeDrive({ name: undefined }), 0, measuredAt).name).toBe('Drive 1')
-    expect(describeDrive(makeDrive({ name: '   ' }), 2, measuredAt).name).toBe('Drive 3')
+  it('names drives, falling back to a stable batch-ID-derived label', () => {
+    expect(describeDrive(makeDrive({ name: 'Photos' }), measuredAt).name).toBe('Photos')
+    expect(describeDrive(makeDrive({ name: undefined }), measuredAt).name).toBe('Drive aaaa')
+    expect(describeDrive(makeDrive({ name: '   ' }), measuredAt).name).toBe('Drive aaaa')
+    const other = makeDrive({ name: undefined, batchID: new BatchId('7cf2'.padEnd(64, '0')) })
+    expect(describeDrive(other, measuredAt).name).toBe('Drive 7cf2')
   })
 
   it('treats unknown TTL as active with no lifespan labels', () => {
-    const display = describeDrive(makeDrive({ batchTTL: undefined }), 0, measuredAt)
+    const display = describeDrive(makeDrive({ batchTTL: undefined }), measuredAt)
     expect(display.status).toBe('active')
     expect(display.timeLeftLabel).toBe('')
     expect(display.expiryDate).toBeUndefined()

--- a/ui/src/lib/drives.ts
+++ b/ui/src/lib/drives.ts
@@ -130,9 +130,16 @@ function driveUsedPercent(drive: PostageStamp): number {
     : percent
 }
 
-/** The drive's label, falling back to a positional `Drive N` when unnamed. */
-function driveDisplayName(drive: PostageStamp, index: number): string {
-  return drive.name?.trim() || `Drive ${index + 1}`
+/** Hex chars of the batch ID used in an unnamed drive's fallback label. */
+const FALLBACK_NAME_HEX_CHARS = 4
+
+/**
+ * The drive's label, falling back to `Drive <batch-ID prefix>` when unnamed.
+ * Deriving the fallback from the batch ID (not the list position) keeps it
+ * stable when drives are added/removed and identical on every device.
+ */
+function driveDisplayName(drive: PostageStamp): string {
+  return drive.name?.trim() || `Drive ${drive.batchID.toHex().slice(0, FALLBACK_NAME_HEX_CHARS)}`
 }
 
 /**
@@ -164,7 +171,7 @@ export function formatYmd(epochMs: number): string {
 }
 
 /** One-pass derivation of every display value for a drive row + detail. */
-export function describeDrive(drive: PostageStamp, index: number, now = Date.now()): DriveDisplay {
+export function describeDrive(drive: PostageStamp, now = Date.now()): DriveDisplay {
   const ttl = remainingLifespanSeconds(drive, now)
   const known = ttl !== undefined
   const expired = known && ttl <= 0
@@ -172,7 +179,7 @@ export function describeDrive(drive: PostageStamp, index: number, now = Date.now
   const hasLifespan = known && ttl > 0
 
   return {
-    name: driveDisplayName(drive, index),
+    name: driveDisplayName(drive),
     sizeLabel: driveSizeLabel(drive),
     usedPercent: driveUsedPercent(drive),
     storageFull: drive.utilization >= STORAGE_FULL_FRACTION,

--- a/ui/src/lib/payment/bee.ts
+++ b/ui/src/lib/payment/bee.ts
@@ -22,7 +22,7 @@ import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
 export async function fetchExistingStamp(
   batchId: string,
   signerKey: PrivateKey,
-  name: string,
+  name: string | undefined,
   beeUrl: string = networkSettingsStore.beeNodeUrl,
 ): Promise<NewStamp | undefined> {
   try {

--- a/ui/src/lib/payment/purchase.ts
+++ b/ui/src/lib/payment/purchase.ts
@@ -101,7 +101,7 @@ export function parseBlockNumber(value: string): number {
 export function stampFromBatch(
   batch: BatchEvent,
   signerKey: PrivateKey,
-  name: string,
+  name: string | undefined,
   batchTTL?: number,
 ): NewStamp {
   return {


### PR DESCRIPTION
Closes #393

Unnamed drives fell back to a positional `Drive N` label (filtered `index + 1` in `driveDisplayName`, `stamps.length + 1` in the add dialog's `suggestedName()`), so removing a drive renumbered the rest and the label could differ per device.

- **Naming scheme**: the fallback is now `Drive ` + the first 4 hex chars of the batch ID, lowercase (e.g. `Drive 7cf2`) — derived from the drive itself, so it's stable across list changes and identical on every device.
- `describeDrive` no longer takes an `index` parameter.
- **Add dialog**: `suggestedName()` is removed — the batch doesn't exist yet at that point, so any positional suggestion is equally unstable. A blank name now stores the stamp unnamed (`name: undefined`, already a supported schema state), letting the stable batch-ID fallback apply after creation; the name input placeholder is simply "Optional".

🤖 Generated with [Claude Code](https://claude.com/claude-code)