### PR TITLE
feat(ui): confirm before removing a drive

### DIFF
--- a/ui/src/lib/components/drive-remove-dialog.svelte
+++ b/ui/src/lib/components/drive-remove-dialog.svelte
@@ -1,0 +1,42 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<script lang="ts">
+  import Trash2 from '@lucide/svelte/icons/trash-2'
+  import type { PostageStamp } from '@snaha/swarm-id'
+
+  import { Button } from '$lib/components/ui/button'
+  import { Dialog } from '$lib/components/ui/dialog'
+  import type { Account } from '$lib/types'
+
+  interface Props {
+    account: Account
+    drive: PostageStamp
+    onClose: () => void
+    onRemoved?: (message: string) => void
+  }
+
+  let { account, drive, onClose, onRemoved }: Props = $props()
+
+  function remove() {
+    account.removeStamp(drive.batchID)
+    onRemoved?.('Drive removed')
+    onClose()
+  }
+</script>
+
+<Dialog onclose={onClose} title={drive.name || 'Drive'}>
+  <p class="text-sm">
+    This removes the drive from your account on all your devices. The storage itself stays on the
+    Swarm network — you can re-attach it later with its Batch ID.
+  </p>
+  <div class="flex w-full flex-col gap-2">
+    <Button variant="destructive" class="w-full" onclick={remove}>
+      <Trash2 />
+      Remove drive
+    </Button>
+    <Button variant="outline" class="w-full" onclick={onClose}>Cancel</Button>
+  </div>
+</Dialog>

--- a/ui/src/lib/components/drive-remove-dialog.svelte
+++ b/ui/src/lib/components/drive-remove-dialog.svelte
@@ -30,7 +30,7 @@
 <Dialog onclose={onClose} title={drive.name || 'Drive'}>
   <p class="text-sm">
     This removes the drive from your account on all your devices. The storage itself stays on the
-    Swarm network — you can re-attach it later with its Batch ID.
+    Swarm network — this account can re-attach it later with its Batch ID.
   </p>
   <div class="flex w-full flex-col gap-2">
     <Button variant="destructive" class="w-full" onclick={remove}>

--- a/ui/src/lib/components/home-drives.svelte
+++ b/ui/src/lib/components/home-drives.svelte
@@ -15,6 +15,7 @@
   import AppIcon from '$lib/components/app-icon.svelte'
   import DriveAddDialog from '$lib/components/drive-add-dialog.svelte'
   import DriveExtendDialog from '$lib/components/drive-extend-dialog.svelte'
+  import DriveRemoveDialog from '$lib/components/drive-remove-dialog.svelte'
   import DriveResizeDialog from '$lib/components/drive-resize-dialog.svelte'
   import { Badge } from '$lib/components/ui/badge'
   import { Button } from '$lib/components/ui/button'
@@ -40,6 +41,7 @@
   let addOpen = $state(false)
   let resizeDrive = $state<PostageStamp | undefined>(undefined)
   let extendDrive = $state<PostageStamp | undefined>(undefined)
+  let removeDrive = $state<PostageStamp | undefined>(undefined)
 
   function toggle(batchId: string, currentName: string) {
     if (expandedId === batchId) {
@@ -66,12 +68,15 @@
   }
 
   function remove(drive: PostageStamp) {
-    account.removeStamp(drive.batchID)
+    removeDrive = drive
     openMenuId = undefined
-    if (expandedId === drive.batchID.toHex()) {
+  }
+
+  function onDriveRemoved(message: string) {
+    if (expandedId === removeDrive?.batchID.toHex()) {
       expandedId = undefined
     }
-    toastStore.show('Drive removed')
+    toastStore.show(message)
   }
 
   function onWindowPointerDown(event: PointerEvent) {
@@ -334,5 +339,14 @@
     drive={extendDrive}
     onClose={() => (extendDrive = undefined)}
     onUpdated={toastStore.show}
+  />
+{/if}
+
+{#if removeDrive}
+  <DriveRemoveDialog
+    {account}
+    drive={removeDrive}
+    onClose={() => (removeDrive = undefined)}
+    onRemoved={onDriveRemoved}
   />
 {/if}


### PR DESCRIPTION
The Storage tab's **Remove** action detached a drive immediately with no confirmation, even though removal looks destructive and the tombstone syncs to other devices.

This adds `drive-remove-dialog.svelte` (following the sibling drive-dialog pattern): the menu action now opens a confirmation dialog titled with the drive's name, explaining that removal only detaches the drive from the account — the batch stays on the Swarm network and can be re-attached later via its Batch ID. A destructive **Remove drive** button confirms; **Cancel** (or Escape/X) closes without action.

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)