### PR TITLE
fix(lib): migrate remaining rejectAfter races to withTimeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,11 @@ Authentication uses storage events: popup writes to localStorage → storage eve
 - **kebab-case** for all file and directory names
 - **Conventional commits**: `feat:`, `fix:`, `docs:`, etc.
 - **TypeScript execution**: Use `pnpx tsx` (not `npx ts-node`)
+- **Timeouts: use `withTimeout`** (`lib/src/utils/promise.ts`) — never `Promise.race` work against
+  `rejectAfter` or an inline `setTimeout` rejection: when the work wins, the losing timer stays
+  armed and leaks its handle. `withTimeout(work, ms, message)` clears the timer and rejects with
+  `TimeoutError`, so discriminate timeouts with `instanceof TimeoutError`, not by message.
+  `rejectAfter` is deprecated and kept only for the public API.
 
 ## Testing
 

--- a/lib/src/swarm-id-client.ts
+++ b/lib/src/swarm-id-client.ts
@@ -85,7 +85,7 @@ import { EthAddress, Identifier, PrivateKey, Topic } from "@ethersphere/bee-js"
 import { uint8ArrayToHex } from "./utils/hex"
 import { buildAuthUrl } from "./utils/url"
 import { isWebKit } from "./utils/browser"
-import { rejectAfter } from "./utils/promise"
+import { withTimeout } from "./utils/promise"
 
 const DEFAULT_TIMEOUT_MS = 30000
 const DEFAULT_INITIALIZATION_TIMEOUT_MS = 30000
@@ -280,15 +280,13 @@ export class SwarmIdClient {
     // `handleIframeMessage` when the `connectionInfoChanged` arrives — not
     // from this executor. ES2024's `Promise.withResolvers()` would express
     // the same shape more directly.
-    this.firstConnectionInfoPromise = Promise.race([
+    this.firstConnectionInfoPromise = withTimeout(
       new Promise<void>((resolve) => {
         this.firstConnectionInfoResolve = resolve
       }),
-      rejectAfter(
-        this.initializationTimeout,
-        `Proxy initialization timeout - proxy did not send initial connectionInfoChanged within ${this.initializationTimeout}ms`,
-      ),
-    ])
+      this.initializationTimeout,
+      `Proxy initialization timeout - proxy did not send initial connectionInfoChanged within ${this.initializationTimeout}ms`,
+    )
     // Attach a no-op handler so the rejection isn't surfaced as
     // "unhandled" if the timeout fires before we reach the awaiting line
     // below (e.g. because an earlier `await` in this method hung first).

--- a/lib/src/sync/batch-write-coordinator.ts
+++ b/lib/src/sync/batch-write-coordinator.ts
@@ -46,6 +46,7 @@ import {
   UtilizationAwareStamper,
 } from "../utils/batch-utilization"
 import { withBatchWriteLock } from "../utils/batch-write-lock"
+import { withTimeout } from "../utils/promise"
 import { PartitionLease } from "./partition-lease"
 import type {
   LeaseRefreshOutcome,
@@ -417,19 +418,12 @@ export class BatchWriteCoordinator {
           }
           return
         }
-        const timeout = new Promise<void>((_, reject) =>
-          setTimeout(
-            () =>
-              reject(
-                new Error(
-                  `Partition lease timed out after ${PARTITION_LEASE_ACQUIRE_TIMEOUT_MS}ms`,
-                ),
-              ),
-            PARTITION_LEASE_ACQUIRE_TIMEOUT_MS,
-          ),
-        )
         try {
-          await Promise.race([this.acquireWithSlotWait(), timeout])
+          await withTimeout(
+            this.acquireWithSlotWait(),
+            PARTITION_LEASE_ACQUIRE_TIMEOUT_MS,
+            `Partition lease timed out after ${PARTITION_LEASE_ACQUIRE_TIMEOUT_MS}ms`,
+          )
         } catch (error) {
           console.warn(
             "[BatchWriteCoordinator] Partition lease acquisition failed, pausing background work:",
@@ -621,8 +615,8 @@ export class BatchWriteCoordinator {
    */
   private async acquireWithSlotWait(): Promise<void> {
     const deadline = Date.now() + SLOT_WAIT_TIMEOUT_MS
-    // Epoch capture: when the Promise.race timeout in `ensureLease` fires,
-    // this loop keeps running detached (race can't cancel it) and would
+    // Epoch capture: when the `withTimeout` in `ensureLease` fires, this
+    // loop keeps running detached (the race can't cancel it) and would
     // otherwise wake from its poll sleep and claim the lock SOC one more
     // time, only for `acquire()` to discard the claim — a pointless ghost
     // claim peers must wait out via the TTL.

--- a/lib/src/sync/sync-account.ts
+++ b/lib/src/sync/sync-account.ts
@@ -35,7 +35,7 @@ import type {
 } from "./store-interfaces"
 import type { SyncResult } from "./types"
 import type { AccountStateSnapshot } from "../utils/account-state-snapshot"
-import { rejectAfter } from "../utils/promise"
+import { withTimeout } from "../utils/promise"
 import type { PostageStamp } from "../schemas"
 import {
   BatchWriteCoordinator,
@@ -217,13 +217,11 @@ export function createSyncAccount(
         },
       )
 
-      return Promise.race([
+      return withTimeout(
         uploadPromise,
-        rejectAfter(
-          UTILIZATION_UPLOAD_TIMEOUT_MS,
-          `Utilization upload timeout (${UTILIZATION_UPLOAD_TIMEOUT_MS}ms)`,
-        ),
-      ])
+        UTILIZATION_UPLOAD_TIMEOUT_MS,
+        `Utilization upload timeout (${UTILIZATION_UPLOAD_TIMEOUT_MS}ms)`,
+      )
     }
   }
 

--- a/lib/src/utils/promise.ts
+++ b/lib/src/utils/promise.ts
@@ -9,6 +9,10 @@
  * ```ts
  * await Promise.race([work, rejectAfter(5000, "work timed out")])
  * ```
+ *
+ * @deprecated Use {@link withTimeout} instead. `rejectAfter` never clears its
+ * `setTimeout`, so when the raced work wins the timer stays alive until it
+ * fires, holding its closure and an event-loop reference.
  */
 export function rejectAfter(ms: number, message: string): Promise<never> {
   return new Promise((_, reject) => {


### PR DESCRIPTION
## Summary

`rejectAfter` never clears its `setTimeout`, so every race the work wins leaves a stray timer holding its closure until it fires. This migrates the remaining internal timeout races to `withTimeout` (introduced in #382, clears the timer once the race settles):

- `lib/src/sync/sync-account.ts` — 30s utilization-upload timeout
- `lib/src/swarm-id-client.ts` — proxy-init timeout (`firstConnectionInfoPromise`)
- `lib/src/sync/batch-write-coordinator.ts` — inline setTimeout-reject race for the 45s partition-lease-acquire timeout

`lib/src/sync/partition-intent.ts` (listed in the issue) was already migrated on main. `rejectAfter` stays exported as public API, now tagged `@deprecated` pointing to `withTimeout` with the uncancelled-timer caveat.

No behaviour change: `withTimeout` rejects with the same message (`TimeoutError extends Error`), and no call site keys on the plain-`Error` constructor or these message strings. Timer cleanup is already covered by the `withTimeout` fast-path test in `lib/src/utils/promise.test.ts`.

Closes #383

🤖 Generated with [Claude Code](https://claude.com/claude-code)