### PR TITLE
feat(ui): sign-in recovery, product account sync (publish + fold), existing-batch attach

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -28,6 +28,9 @@ export {
 // Hex address utility
 export { hexAddress } from "./utils/hex"
 
+// Cross-tab coalescing: run a task at most once per window across same-origin tabs
+export { runCoalescedAcrossTabs } from "./utils/coalesced-task"
+
 // Stamp worker pool for parallel ECDSA signing
 export { StampWorkerPool } from "./proxy/stamp-worker-pool"
 

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -231,6 +231,7 @@ export {
   ensureInRoster,
   ROSTER_TOPIC_PREFIX,
   foldAccountFromSwarm,
+  foldedToAccountData,
 } from "./sync"
 
 // State sync types
@@ -457,6 +458,7 @@ export { downloadDataWithChunkAPI } from "./proxy/download-data"
 export { downloadEncryptedSOC } from "./proxy/download-data"
 export {
   uploadSOC,
+  SocUploadError,
   type UploadTarget,
   type UploadSOCOptions,
 } from "./proxy/upload"
@@ -480,7 +482,7 @@ export type { ActEntry } from "./proxy/act"
 export { SWARM_SECRET_PREFIX, STORAGE_CHALLENGE_KEY } from "./types"
 
 // URL building utilities
-export { buildAuthUrl } from "./utils/url"
+export { buildAuthUrl, isHttpUrl } from "./utils/url"
 
 // Browser detection utilities
 export { isWebKit } from "./utils/browser"

--- a/lib/src/proxy/upload.ts
+++ b/lib/src/proxy/upload.ts
@@ -43,6 +43,26 @@ import { uint8ArrayToHex } from "../utils/hex"
 import { normalizeUrl } from "../utils/url"
 
 // ============================================================================
+// Errors
+// ============================================================================
+
+/**
+ * Thrown when a SOC upload gets a non-OK HTTP response. Carries the numeric
+ * `status` so callers can distinguish a definitive stamp rejection (400) from a
+ * transient / not-yet-synced condition (404 "batch not found", 422 "not usable
+ * yet") without regex-matching the message — see `verifyBatchStampable`.
+ */
+export class SocUploadError extends Error {
+  readonly status: number
+
+  constructor(status: number, statusText: string, body: string) {
+    super(`SOC upload failed: ${status} ${statusText} - ${body}`)
+    this.name = "SocUploadError"
+    this.status = status
+  }
+}
+
+// ============================================================================
 // Types
 // ============================================================================
 
@@ -910,8 +930,10 @@ export async function uploadSOC(
 
     if (!response.ok) {
       const errorText = await response.text()
-      throw new Error(
-        `Subsidised SOC upload failed: ${response.status} ${response.statusText} - ${errorText}`,
+      throw new SocUploadError(
+        response.status,
+        `${response.statusText} (subsidised)`,
+        errorText,
       )
     }
 
@@ -955,9 +977,7 @@ export async function uploadSOC(
 
     if (!response.ok) {
       const errorText = await response.text()
-      throw new Error(
-        `SOC upload failed: ${response.status} ${response.statusText} - ${errorText}`,
-      )
+      throw new SocUploadError(response.status, response.statusText, errorText)
     }
 
     return {

--- a/lib/src/schemas.ts
+++ b/lib/src/schemas.ts
@@ -15,6 +15,7 @@ import {
   BatchId as BeeBatchId,
   PrivateKey as BeePrivateKey,
 } from "@ethersphere/bee-js"
+import { isHttpUrl } from "./utils/url"
 
 // ============================================================================
 // Network Settings Constants
@@ -448,8 +449,11 @@ export type PartitionIntentPayload = z.infer<
  * Stores user-configurable network endpoints (Bee node and Gnosis RPC)
  */
 export const NetworkSettingsSchemaV1 = z.object({
-  beeNodeUrl: z.string().url(),
-  gnosisRpcUrl: z.string().url(),
+  // `.refine(isHttpUrl)` (not `.url()`) so a scheme-less paste like `localhost:1633`
+  // — which `new URL`/zod `.url()` accept as protocol `localhost:` — can't persist
+  // as a broken endpoint. Same validator the settings dialog uses.
+  beeNodeUrl: z.string().refine(isHttpUrl, "Must be an http(s) URL"),
+  gnosisRpcUrl: z.string().refine(isHttpUrl, "Must be an http(s) URL"),
 })
 
 export type NetworkSettings = z.infer<typeof NetworkSettingsSchemaV1>

--- a/lib/src/sync/fold-account-from-swarm.ts
+++ b/lib/src/sync/fold-account-from-swarm.ts
@@ -8,7 +8,7 @@
  * / refresh / the proxy.
  */
 
-import { Bee, PrivateKey } from "@ethersphere/bee-js"
+import { Bee, EthAddress, PrivateKey } from "@ethersphere/bee-js"
 import { deriveSwarmEncryptionKey, deriveSecret } from "../utils/key-derivation"
 import { readRoster } from "./device-roster"
 import {
@@ -17,11 +17,48 @@ import {
   type DeviceStateSnapshot,
   type FoldedAccount,
 } from "./device-state"
-import type { Device } from "../schemas"
+import type { AccountData, Device } from "../schemas"
 
 export interface FoldAccountResult {
   account: FoldedAccount
   devices: Device[]
+}
+
+/**
+ * Project a folded account onto the local `AccountData` record — the single
+ * place the field list lives so a new `AccountData`/`FoldedAccount` field can't
+ * be silently dropped by a hand-written copy on the sign-in path. `id` and
+ * `derivationKey` aren't in the fold (they come from the recovering wallet), so
+ * the caller supplies them.
+ *
+ * `foldAccountFromSwarm` shallow-FREEZES its result arrays so coalesced callers
+ * can't corrupt each other's shared view; a persisted `AccountData` outlives that
+ * window and is mutated in place downstream, so the arrays are COPIED here.
+ */
+export function foldedToAccountData(opts: {
+  id: EthAddress
+  derivationKey: string
+  account: FoldedAccount
+  lastModified?: number
+}): AccountData {
+  const { id, derivationKey, account } = opts
+  return {
+    id,
+    name: account.accountName,
+    publicKey: account.publicKey,
+    createdAt: account.createdAt,
+    derivationKey,
+    defaultPostageStampBatchID: account.defaultPostageStampBatchID,
+    settings: account.settings,
+    accountNameAt: account.accountNameAt,
+    defaultStampAt: account.defaultStampAt,
+    settingsAt: account.settingsAt,
+    lastModified: opts.lastModified ?? Date.now(),
+    devices: [...account.devices],
+    connectedApps: [...account.connectedApps],
+    postageStamps: [...account.postageStamps],
+    partitionCount: account.partitionCount,
+  }
 }
 
 /**

--- a/lib/src/sync/index.ts
+++ b/lib/src/sync/index.ts
@@ -57,7 +57,10 @@ export {
   ensureInRoster,
   ROSTER_TOPIC_PREFIX,
 } from "./device-roster"
-export { foldAccountFromSwarm } from "./fold-account-from-swarm"
+export {
+  foldAccountFromSwarm,
+  foldedToAccountData,
+} from "./fold-account-from-swarm"
 export type { FoldAccountResult } from "./fold-account-from-swarm"
 
 // Store interfaces

--- a/lib/src/utils/coalesced-task.test.ts
+++ b/lib/src/utils/coalesced-task.test.ts
@@ -1,0 +1,134 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { runCoalescedAcrossTabs } from "./coalesced-task"
+
+const LOCK = "test-lock"
+const KEY = "test-cooldown-key"
+const COOLDOWN_MS = 60_000
+
+function stubLocalStorage(
+  initial: Record<string, string> = {},
+): Map<string, string> {
+  const store = new Map<string, string>(Object.entries(initial))
+  vi.stubGlobal("window", {
+    localStorage: {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => void store.set(key, value),
+      removeItem: (key: string) => void store.delete(key),
+    },
+  })
+  return store
+}
+
+/** navigator.locks mock that immediately grants the lock (runs the callback). */
+function stubWebLocks(): void {
+  vi.stubGlobal("navigator", {
+    locks: {
+      request: (_name: string, _opts: unknown, cb: () => Promise<void>) => cb(),
+    },
+  })
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe("runCoalescedAcrossTabs", () => {
+  it("runs the task when there is no prior timestamp, then stamps it", async () => {
+    const store = stubLocalStorage()
+    stubWebLocks()
+    const task = vi.fn(async () => undefined)
+
+    await runCoalescedAcrossTabs({
+      lockName: LOCK,
+      cooldownKey: KEY,
+      cooldownMs: COOLDOWN_MS,
+      task,
+    })
+
+    expect(task).toHaveBeenCalledTimes(1)
+    expect(Number(store.get(KEY))).toBeGreaterThan(0)
+  })
+
+  it("skips the task when another tab ran within the cooldown window", async () => {
+    stubLocalStorage({ [KEY]: String(Date.now()) })
+    stubWebLocks()
+    const task = vi.fn(async () => undefined)
+
+    await runCoalescedAcrossTabs({
+      lockName: LOCK,
+      cooldownKey: KEY,
+      cooldownMs: COOLDOWN_MS,
+      task,
+    })
+
+    expect(task).not.toHaveBeenCalled()
+  })
+
+  it("runs when the last run is older than the cooldown window", async () => {
+    stubLocalStorage({ [KEY]: String(Date.now() - COOLDOWN_MS * 2) })
+    stubWebLocks()
+    const task = vi.fn(async () => undefined)
+
+    await runCoalescedAcrossTabs({
+      lockName: LOCK,
+      cooldownKey: KEY,
+      cooldownMs: COOLDOWN_MS,
+      task,
+    })
+
+    expect(task).toHaveBeenCalledTimes(1)
+  })
+
+  it("runs despite a recent timestamp when force is set", async () => {
+    stubLocalStorage({ [KEY]: String(Date.now()) })
+    stubWebLocks()
+    const task = vi.fn(async () => undefined)
+
+    await runCoalescedAcrossTabs({
+      lockName: LOCK,
+      cooldownKey: KEY,
+      cooldownMs: COOLDOWN_MS,
+      force: true,
+      task,
+    })
+
+    expect(task).toHaveBeenCalledTimes(1)
+  })
+
+  it("stamps the timestamp even if the task throws", async () => {
+    const store = stubLocalStorage()
+    stubWebLocks()
+    const task = vi.fn(async () => {
+      throw new Error("boom")
+    })
+
+    await expect(
+      runCoalescedAcrossTabs({
+        lockName: LOCK,
+        cooldownKey: KEY,
+        cooldownMs: COOLDOWN_MS,
+        task,
+      }),
+    ).rejects.toThrow("boom")
+    expect(Number(store.get(KEY))).toBeGreaterThan(0)
+  })
+
+  it("falls back to running directly when Web Locks are unavailable", async () => {
+    stubLocalStorage()
+    // no navigator stub → the `navigator.locks` branch is skipped
+    const task = vi.fn(async () => undefined)
+
+    await runCoalescedAcrossTabs({
+      lockName: LOCK,
+      cooldownKey: KEY,
+      cooldownMs: COOLDOWN_MS,
+      task,
+    })
+
+    expect(task).toHaveBeenCalledTimes(1)
+  })
+})

--- a/lib/src/utils/coalesced-task.test.ts
+++ b/lib/src/utils/coalesced-task.test.ts
@@ -99,6 +99,40 @@ describe("runCoalescedAcrossTabs", () => {
     expect(task).toHaveBeenCalledTimes(1)
   })
 
+  it("skips despite force when the last run is within the grace window", async () => {
+    stubLocalStorage({ [KEY]: String(Date.now()) })
+    stubWebLocks()
+    const task = vi.fn(async () => undefined)
+
+    await runCoalescedAcrossTabs({
+      lockName: LOCK,
+      cooldownKey: KEY,
+      cooldownMs: COOLDOWN_MS,
+      force: true,
+      graceMs: 5_000,
+      task,
+    })
+
+    expect(task).not.toHaveBeenCalled()
+  })
+
+  it("runs under force when the last run is older than the grace window", async () => {
+    stubLocalStorage({ [KEY]: String(Date.now() - 10_000) })
+    stubWebLocks()
+    const task = vi.fn(async () => undefined)
+
+    await runCoalescedAcrossTabs({
+      lockName: LOCK,
+      cooldownKey: KEY,
+      cooldownMs: COOLDOWN_MS,
+      force: true,
+      graceMs: 5_000,
+      task,
+    })
+
+    expect(task).toHaveBeenCalledTimes(1)
+  })
+
   it("stamps the timestamp even if the task throws", async () => {
     const store = stubLocalStorage()
     stubWebLocks()

--- a/lib/src/utils/coalesced-task.ts
+++ b/lib/src/utils/coalesced-task.ts
@@ -8,7 +8,9 @@
  * concurrent callers so two tabs can't run `task` at the same instant; a shared
  * `localStorage` timestamp (`cooldownKey`) then lets the second caller skip when
  * another tab already ran within the window. `force` bypasses the cooldown (e.g.
- * a page load / manual refresh).
+ * a page load / manual refresh) but still honours the optional short `graceMs`
+ * window, so a burst of forced runs (N tabs on load, or two back-to-back forced
+ * triggers) still collapses to one.
  *
  * Effect: with several tabs each scheduling the same task, only ONE actually runs
  * per window — the rest observe the fresh timestamp and return. Whatever the task
@@ -23,9 +25,18 @@ export async function runCoalescedAcrossTabs(opts: {
   cooldownKey: string
   cooldownMs: number
   force?: boolean
+  /** Short window honoured even under `force` — collapses back-to-back forced runs. */
+  graceMs?: number
   task: () => Promise<void>
 }): Promise<void> {
   const run = async () => {
+    // The grace window applies even under force; the long cooldown only when not forced.
+    if (
+      opts.graceMs !== undefined &&
+      ranWithin(opts.cooldownKey, opts.graceMs)
+    ) {
+      return
+    }
     if (!opts.force && ranWithin(opts.cooldownKey, opts.cooldownMs)) {
       return
     }

--- a/lib/src/utils/coalesced-task.ts
+++ b/lib/src/utils/coalesced-task.ts
@@ -1,0 +1,65 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Run `task` at most once per `cooldownMs` across all same-origin browser tabs.
+ *
+ * An exclusive Web Lock (`navigator.locks`, keyed on `lockName`) serialises
+ * concurrent callers so two tabs can't run `task` at the same instant; a shared
+ * `localStorage` timestamp (`cooldownKey`) then lets the second caller skip when
+ * another tab already ran within the window. `force` bypasses the cooldown (e.g.
+ * a page load / manual refresh).
+ *
+ * Effect: with several tabs each scheduling the same task, only ONE actually runs
+ * per window — the rest observe the fresh timestamp and return. Whatever the task
+ * persists (e.g. the account document) then propagates to the other tabs via their
+ * own `storage` listeners, so they never need to fetch themselves.
+ *
+ * Falls back to running `task` directly when the Web Locks API is unavailable
+ * (Node / test), still honouring the cooldown when `localStorage` is present.
+ */
+export async function runCoalescedAcrossTabs(opts: {
+  lockName: string
+  cooldownKey: string
+  cooldownMs: number
+  force?: boolean
+  task: () => Promise<void>
+}): Promise<void> {
+  const run = async () => {
+    if (!opts.force && ranWithin(opts.cooldownKey, opts.cooldownMs)) {
+      return
+    }
+    try {
+      await opts.task()
+    } finally {
+      stampNow(opts.cooldownKey)
+    }
+  }
+
+  if (typeof navigator !== "undefined" && navigator.locks) {
+    await navigator.locks.request(opts.lockName, { mode: "exclusive" }, run)
+  } else {
+    await run()
+  }
+}
+
+/** True when `key`'s stored epoch-ms timestamp is within `windowMs` of now. */
+function ranWithin(key: string, windowMs: number): boolean {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return false
+  }
+  const raw = window.localStorage.getItem(key)
+  if (!raw) {
+    return false
+  }
+  const last = Number(raw)
+  return Number.isFinite(last) && Date.now() - last < windowMs
+}
+
+/** Record "ran just now" so other tabs in the window skip. */
+function stampNow(key: string): void {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return
+  }
+  window.localStorage.setItem(key, String(Date.now()))
+}

--- a/lib/src/utils/url.ts
+++ b/lib/src/utils/url.ts
@@ -11,6 +11,22 @@ export function normalizeUrl(url: string): string {
 }
 
 /**
+ * True only for a well-formed `http:`/`https:` URL. Unlike a bare
+ * `new URL(value)` / zod `.url()` check, this rejects a scheme-less paste like
+ * `localhost:1633` (which `new URL` happily parses with protocol `localhost:`)
+ * — the single validator shared by the network-settings schema and its editor
+ * dialog so a broken Bee/RPC endpoint can't be saved or persisted.
+ */
+export function isHttpUrl(value: string): boolean {
+  try {
+    const { protocol } = new URL(value)
+    return protocol === "http:" || protocol === "https:"
+  } catch {
+    return false
+  }
+}
+
+/**
  * Configuration options for building the authentication URL.
  */
 export interface BuildAuthUrlOptions {

--- a/ui/src/lib/components/drive-add-dialog.svelte
+++ b/ui/src/lib/components/drive-add-dialog.svelte
@@ -6,15 +6,17 @@
 <script lang="ts">
   import { onDestroy } from 'svelte'
 
-  import { Utils } from '@ethersphere/bee-js'
+  import { PrivateKey, Utils } from '@ethersphere/bee-js'
   import ArrowRight from '@lucide/svelte/icons/arrow-right'
   import TriangleAlert from '@lucide/svelte/icons/triangle-alert'
+  import { BatchIdSchema, PrivateKeySchema } from '@snaha/swarm-id'
 
   import DriveDialogStatus from '$lib/components/drive-dialog-status.svelte'
   import { Button } from '$lib/components/ui/button'
   import { Dialog } from '$lib/components/ui/dialog'
   import { Input } from '$lib/components/ui/input'
   import { Select } from '$lib/components/ui/select'
+  import { strip0x } from '$lib/crypto/hex'
   import { unlockAccount } from '$lib/crypto/unlock'
   import {
     LIFESPAN_UNIT_OPTIONS,
@@ -22,8 +24,9 @@
     formatBytes,
     lifespanToSeconds,
   } from '$lib/drives'
-  import { fetchExistingStamp } from '$lib/payment/bee'
+  import { verifyBatchStampable } from '$lib/payment/bee'
   import { currentChainPrice } from '$lib/payment/chain-price'
+  import { fetchExistingBatchFromChain } from '$lib/payment/contract'
   import { type StampPurchaseHandle, openStampPurchaseWidget } from '$lib/payment/multichain-widget'
   import {
     derivePostageSigner,
@@ -34,8 +37,6 @@
   } from '$lib/payment/purchase'
   import { devSettingsStore } from '$lib/stores/dev-settings.svelte'
   import type { Account } from '$lib/types'
-
-  const BATCH_ID_PATTERN = /^(0x)?[0-9a-fA-F]{64}$/
 
   const STORAGE_OPTIONS = [
     { value: 'new', label: 'Purchase new batch' },
@@ -59,6 +60,7 @@
   let lifespanValue = $state('1')
   let lifespanUnit = $state<LifespanUnit>('years')
   let batchIdInput = $state('')
+  let signerKeyInput = $state('')
 
   let phase = $state<Phase>('form')
   let pendingLabel = $state('')
@@ -94,9 +96,17 @@
     return stampCostBzz(Number(depthValue), stampAmountForSeconds(currentPrice, lifespanSeconds))
   })
 
-  const batchIdValid = $derived(BATCH_ID_PATTERN.test(batchIdInput.trim()))
+  // Validate through the lib's canonical schemas (bare 64-hex), tolerating a
+  // `0x` prefix by stripping first.
+  const batchIdValid = $derived(BatchIdSchema.safeParse(strip0x(batchIdInput.trim())).success)
+  // Optional: blank keeps the derive-from-account behaviour; a pasted key lets
+  // the user attach a batch owned by an external signer.
+  const signerKeyValid = $derived(
+    signerKeyInput.trim() === '' ||
+      PrivateKeySchema.safeParse(strip0x(signerKeyInput.trim())).success,
+  )
   const canProceed = $derived(
-    storage === 'new' ? depthValue !== '' && lifespanSeconds > 0 : batchIdValid,
+    storage === 'new' ? depthValue !== '' && lifespanSeconds > 0 : batchIdValid && signerKeyValid,
   )
 
   const infoText = $derived.by(() => {
@@ -140,6 +150,12 @@
 
   function proceed() {
     errorMessage = ''
+    // A user-supplied signer needs no account secret — attach the external
+    // batch directly, skipping the unlock ceremony.
+    if (storage === 'existing' && signerKeyInput.trim() !== '') {
+      void attachExisting()
+      return
+    }
     if (entropy) {
       void runWithEntropy(entropy)
       return
@@ -251,19 +267,42 @@
     }
   }
 
-  async function attachExisting(seed: Uint8Array) {
+  async function attachExisting(seed?: Uint8Array) {
     const myAttempt = ++attempt
     phase = 'pending'
     pendingLabel = 'Looking up the batch…'
     const driveName = name.trim() || undefined
     try {
-      const { signerKey } = await derivePostageSigner(seed)
-      const stamp = await fetchExistingStamp(batchIdInput.trim(), signerKey, driveName)
+      // A pasted signer key attaches an externally-owned batch; otherwise derive
+      // this account's signer (the `seed` path is only reached via unlock).
+      const pasted = signerKeyInput.trim()
+      const signerKey = pasted
+        ? new PrivateKey(strip0x(pasted))
+        : (await derivePostageSigner(seed as Uint8Array)).signerKey
+      // Read the batch straight from the PostageStamp contract on-chain, not the
+      // Bee node — a public gateway has no /stamps and won't know a batch bought
+      // independently of it.
+      const lookup = await fetchExistingBatchFromChain(batchIdInput.trim(), signerKey, driveName)
       if (myAttempt !== attempt) {
         return
       }
-      if (!stamp) {
-        errorMessage = 'Couldn’t load that batch from the node. Check the Batch ID and try again.'
+      if (lookup.status !== 'found') {
+        errorMessage =
+          'Couldn’t find that batch on chain. Check the Batch ID, or the Gnosis RPC endpoint in Network settings.'
+        phase = 'error'
+        return
+      }
+      const stamp = lookup.stamp
+      // Existence isn't enough — upload one stamped test chunk to prove the
+      // signer key can actually stamp uploads for this batch before attaching.
+      pendingLabel = 'Verifying the batch…'
+      const stampable = await verifyBatchStampable(stamp.batchID, signerKey, stamp.depth)
+      if (myAttempt !== attempt) {
+        return
+      }
+      if (!stampable) {
+        errorMessage =
+          'That batch exists, but this signer key can’t stamp uploads for it. Check the signer key.'
         phase = 'error'
         return
       }
@@ -347,8 +386,27 @@
     {:else}
       <div class="flex w-full flex-col gap-2">
         <label for="drive-batch" class="text-sm font-medium">Batch ID</label>
-        <Input id="drive-batch" bind:value={batchIdInput} placeholder="0x…" class="font-mono" />
+        <Input
+          id="drive-batch"
+          bind:value={batchIdInput}
+          placeholder="64-character hex"
+          class="font-mono"
+        />
         <p class="text-muted-foreground text-xs">Don't reuse batches across accounts.</p>
+      </div>
+
+      <div class="flex w-full flex-col gap-2">
+        <label for="drive-signer" class="text-sm font-medium">Signer key (optional)</label>
+        <Input
+          id="drive-signer"
+          bind:value={signerKeyInput}
+          placeholder="64-character hex"
+          class="font-mono"
+        />
+        <p class="text-muted-foreground text-xs">
+          Leave blank to use this account's key. Paste the batch's private signer key to attach a
+          batch owned by another key.
+        </p>
       </div>
     {/if}
 

--- a/ui/src/lib/components/drive-add-dialog.svelte
+++ b/ui/src/lib/components/drive-add-dialog.svelte
@@ -100,10 +100,12 @@
   // `0x` prefix by stripping first.
   const batchIdValid = $derived(BatchIdSchema.safeParse(strip0x(batchIdInput.trim())).success)
   // Optional: blank keeps the derive-from-account behaviour; a pasted key lets
-  // the user attach a batch owned by an external signer.
+  // the user attach a batch owned by an external signer. `pastedSignerKey` is the
+  // trimmed non-empty key (undefined when blank) — the single source both the
+  // attach guard and the derive/paste branch read, so no `seed as` cast is needed.
+  const pastedSignerKey = $derived(signerKeyInput.trim() === '' ? undefined : signerKeyInput.trim())
   const signerKeyValid = $derived(
-    signerKeyInput.trim() === '' ||
-      PrivateKeySchema.safeParse(strip0x(signerKeyInput.trim())).success,
+    pastedSignerKey === undefined || PrivateKeySchema.safeParse(strip0x(pastedSignerKey)).success,
   )
   const canProceed = $derived(
     storage === 'new' ? depthValue !== '' && lifespanSeconds > 0 : batchIdValid && signerKeyValid,
@@ -111,7 +113,13 @@
 
   const infoText = $derived.by(() => {
     if (storage === 'existing') {
-      return batchIdValid ? "Don't reuse batches across accounts." : 'Enter a batch ID to proceed.'
+      if (!batchIdValid) {
+        return 'Enter a batch ID to proceed.'
+      }
+      if (!signerKeyValid) {
+        return "Enter a valid signer key, or leave it blank to use this account's key."
+      }
+      return "Don't reuse batches across accounts."
     }
     if (!canProceed) {
       return 'Set storage options to proceed.'
@@ -152,7 +160,7 @@
     errorMessage = ''
     // A user-supplied signer needs no account secret — attach the external
     // batch directly, skipping the unlock ceremony.
-    if (storage === 'existing' && signerKeyInput.trim() !== '') {
+    if (storage === 'existing' && pastedSignerKey) {
       void attachExisting()
       return
     }
@@ -274,25 +282,32 @@
     const driveName = name.trim() || undefined
     try {
       // A pasted signer key attaches an externally-owned batch; otherwise derive
-      // this account's signer (the `seed` path is only reached via unlock).
-      const pasted = signerKeyInput.trim()
-      const signerKey = pasted
-        ? new PrivateKey(strip0x(pasted))
-        : (await derivePostageSigner(seed as Uint8Array)).signerKey
+      // this account's signer. Without a pasted key the `seed` (from unlock) is
+      // required — guard it so no `as` cast is needed.
+      let signerKey: PrivateKey
+      if (pastedSignerKey) {
+        signerKey = new PrivateKey(strip0x(pastedSignerKey))
+      } else {
+        if (!seed) {
+          errorMessage = 'Unlock is required to derive the signer key.'
+          phase = 'error'
+          return
+        }
+        signerKey = (await derivePostageSigner(seed)).signerKey
+      }
       // Read the batch straight from the PostageStamp contract on-chain, not the
       // Bee node — a public gateway has no /stamps and won't know a batch bought
       // independently of it.
-      const lookup = await fetchExistingBatchFromChain(batchIdInput.trim(), signerKey, driveName)
+      const stamp = await fetchExistingBatchFromChain(batchIdInput.trim(), signerKey, driveName)
       if (myAttempt !== attempt) {
         return
       }
-      if (lookup.status !== 'found') {
+      if (!stamp) {
         errorMessage =
           'Couldn’t find that batch on chain. Check the Batch ID, or the Gnosis RPC endpoint in Network settings.'
         phase = 'error'
         return
       }
-      const stamp = lookup.stamp
       // Existence isn't enough — upload one stamped test chunk to prove the
       // signer key can actually stamp uploads for this batch before attaching.
       pendingLabel = 'Verifying the batch…'

--- a/ui/src/lib/components/network-settings-dialog.svelte
+++ b/ui/src/lib/components/network-settings-dialog.svelte
@@ -4,7 +4,7 @@
 -->
 
 <script lang="ts">
-  import { DEFAULT_BEE_NODE_URL, DEFAULT_GNOSIS_RPC_URL } from '@snaha/swarm-id'
+  import { DEFAULT_BEE_NODE_URL, DEFAULT_GNOSIS_RPC_URL, isHttpUrl } from '@snaha/swarm-id'
 
   import { Button } from '$lib/components/ui/button'
   import { Dialog } from '$lib/components/ui/dialog'
@@ -20,25 +20,18 @@
   let beeNodeUrl = $state(networkSettingsStore.beeNodeUrl)
   let gnosisRpcUrl = $state(networkSettingsStore.gnosisRpcUrl)
 
-  function isUrl(value: string): boolean {
-    try {
-      new URL(value)
-      return true
-    } catch {
-      return false
-    }
-  }
-
-  const beeNodeUrlValid = $derived(isUrl(beeNodeUrl.trim()))
-  const gnosisRpcUrlValid = $derived(isUrl(gnosisRpcUrl.trim()))
+  // Same http(s)-only validator the store's schema uses, so a value that saves
+  // here also survives the next load (a scheme-less `localhost:1633` fails both).
+  const beeNodeUrlValid = $derived(isHttpUrl(beeNodeUrl.trim()))
+  const gnosisRpcUrlValid = $derived(isHttpUrl(gnosisRpcUrl.trim()))
   const canSave = $derived(beeNodeUrlValid && gnosisRpcUrlValid)
+  const beeNodeUrlError = $derived(beeNodeUrl.trim().length > 0 && !beeNodeUrlValid)
+  const gnosisRpcUrlError = $derived(gnosisRpcUrl.trim().length > 0 && !gnosisRpcUrlValid)
 
   function save() {
     if (!canSave) {
       return
     }
-    // Persist trimmed values; the store's schema (z.string().url()) would reject
-    // a malformed value on the next load and silently revert to defaults.
     networkSettingsStore.updateSettings({
       beeNodeUrl: beeNodeUrl.trim(),
       gnosisRpcUrl: gnosisRpcUrl.trim(),
@@ -61,9 +54,9 @@
       bind:value={beeNodeUrl}
       placeholder={DEFAULT_BEE_NODE_URL}
       class="font-mono"
-      aria-invalid={beeNodeUrl.trim().length > 0 && !beeNodeUrlValid}
+      aria-invalid={beeNodeUrlError}
     />
-    {#if beeNodeUrl.trim().length > 0 && !beeNodeUrlValid}
+    {#if beeNodeUrlError}
       <p class="text-destructive text-xs">Please enter a valid URL</p>
     {/if}
   </div>
@@ -75,9 +68,9 @@
       bind:value={gnosisRpcUrl}
       placeholder={DEFAULT_GNOSIS_RPC_URL}
       class="font-mono"
-      aria-invalid={gnosisRpcUrl.trim().length > 0 && !gnosisRpcUrlValid}
+      aria-invalid={gnosisRpcUrlError}
     />
-    {#if gnosisRpcUrl.trim().length > 0 && !gnosisRpcUrlValid}
+    {#if gnosisRpcUrlError}
       <p class="text-destructive text-xs">Please enter a valid URL</p>
     {/if}
   </div>

--- a/ui/src/lib/components/network-settings-dialog.svelte
+++ b/ui/src/lib/components/network-settings-dialog.svelte
@@ -1,0 +1,89 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<script lang="ts">
+  import { DEFAULT_BEE_NODE_URL, DEFAULT_GNOSIS_RPC_URL } from '@snaha/swarm-id'
+
+  import { Button } from '$lib/components/ui/button'
+  import { Dialog } from '$lib/components/ui/dialog'
+  import { Input } from '$lib/components/ui/input'
+  import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
+
+  interface Props {
+    onclose: () => void
+  }
+
+  let { onclose }: Props = $props()
+
+  let beeNodeUrl = $state(networkSettingsStore.beeNodeUrl)
+  let gnosisRpcUrl = $state(networkSettingsStore.gnosisRpcUrl)
+
+  function isUrl(value: string): boolean {
+    try {
+      new URL(value)
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  const beeNodeUrlValid = $derived(isUrl(beeNodeUrl.trim()))
+  const gnosisRpcUrlValid = $derived(isUrl(gnosisRpcUrl.trim()))
+  const canSave = $derived(beeNodeUrlValid && gnosisRpcUrlValid)
+
+  function save() {
+    if (!canSave) {
+      return
+    }
+    // Persist trimmed values; the store's schema (z.string().url()) would reject
+    // a malformed value on the next load and silently revert to defaults.
+    networkSettingsStore.updateSettings({
+      beeNodeUrl: beeNodeUrl.trim(),
+      gnosisRpcUrl: gnosisRpcUrl.trim(),
+    })
+    onclose()
+  }
+
+  // Fill the fields with the defaults; only persisted once the user hits Save.
+  function resetToDefaults() {
+    beeNodeUrl = DEFAULT_BEE_NODE_URL
+    gnosisRpcUrl = DEFAULT_GNOSIS_RPC_URL
+  }
+</script>
+
+<Dialog title="Network settings" {onclose}>
+  <div class="flex w-full flex-col gap-2">
+    <label for="bee-node-url" class="text-sm font-medium">Bee node URL</label>
+    <Input
+      id="bee-node-url"
+      bind:value={beeNodeUrl}
+      placeholder={DEFAULT_BEE_NODE_URL}
+      class="font-mono"
+      aria-invalid={beeNodeUrl.trim().length > 0 && !beeNodeUrlValid}
+    />
+    {#if beeNodeUrl.trim().length > 0 && !beeNodeUrlValid}
+      <p class="text-destructive text-xs">Please enter a valid URL</p>
+    {/if}
+  </div>
+
+  <div class="flex w-full flex-col gap-2">
+    <label for="gnosis-rpc-url" class="text-sm font-medium">Gnosis RPC endpoint</label>
+    <Input
+      id="gnosis-rpc-url"
+      bind:value={gnosisRpcUrl}
+      placeholder={DEFAULT_GNOSIS_RPC_URL}
+      class="font-mono"
+      aria-invalid={gnosisRpcUrl.trim().length > 0 && !gnosisRpcUrlValid}
+    />
+    {#if gnosisRpcUrl.trim().length > 0 && !gnosisRpcUrlValid}
+      <p class="text-destructive text-xs">Please enter a valid URL</p>
+    {/if}
+  </div>
+
+  <div class="flex w-full items-center gap-2">
+    <Button class="flex-1" disabled={!canSave} onclick={save}>Save settings</Button>
+    <Button variant="outline" onclick={resetToDefaults}>Reset to defaults</Button>
+  </div>
+</Dialog>

--- a/ui/src/lib/components/settings-menu.svelte
+++ b/ui/src/lib/components/settings-menu.svelte
@@ -15,10 +15,10 @@
   import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'
 
+  import NetworkSettingsDialog from '$lib/components/network-settings-dialog.svelte'
   import { Button } from '$lib/components/ui/button'
   import routes from '$lib/routes'
   import { type ThemePreference, themeStore } from '$lib/stores/theme.svelte'
-  import { notImplemented } from '$lib/utils'
 
   const APPEARANCE_OPTIONS = [
     { value: 'auto', label: 'Automatic', icon: Contrast },
@@ -30,6 +30,7 @@
     'flex h-7 w-full cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-1 text-left text-sm outline-none hover:bg-muted focus-visible:bg-muted'
 
   let open = $state(false)
+  let dialogOpen = $state(false)
   let container = $state<HTMLDivElement>()
 
   function close() {
@@ -55,7 +56,7 @@
 
   function networkSettings() {
     close()
-    notImplemented()
+    dialogOpen = true
   }
 
   function selectAppearance(value: ThemePreference) {
@@ -115,3 +116,7 @@
     </div>
   {/if}
 </div>
+
+{#if dialogOpen}
+  <NetworkSettingsDialog onclose={() => (dialogOpen = false)} />
+{/if}

--- a/ui/src/lib/dev/account-refresh.ts
+++ b/ui/src/lib/dev/account-refresh.ts
@@ -1,0 +1,66 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Background fold-back for the signed-in account: pull peer/node state from Swarm
+ * into the local account (name, connected apps, stamps, and node truth like a
+ * batch's real utilization / TTL). The publish direction is wired app-wide in the
+ * root layout; this is the read direction.
+ *
+ * Only ONE tab actually fetches per window — `runCoalescedAcrossTabs` (Web Lock +
+ * shared cooldown timestamp) collapses concurrent folds across tabs, and the
+ * winner's persisted account document propagates to the others via the accounts
+ * store's `storage` listener. Folds apply with `skipSync: true`, so they never
+ * re-publish.
+ */
+import { runCoalescedAcrossTabs } from '@snaha/swarm-id'
+
+import { browser } from '$app/environment'
+
+import { refreshAccountFromSwarm } from '$lib/dev/refresh-account-from-swarm'
+import { sessionStore } from '$lib/stores/session.svelte'
+
+// "Every few minutes" — the cross-tab window doubles as the interval, so with N
+// tabs open only ~one fold runs per window.
+const FOLD_INTERVAL_MS = 3 * 60 * 1000
+const FOLD_LOCK_NAME = 'swarm-id-account-fold'
+const FOLD_COOLDOWN_KEY_PREFIX = 'swarm-id-account-folded-at-'
+
+// Per-tab guard so overlapping triggers (interval + account switch) don't stack.
+let inFlight = false
+
+/**
+ * Fold the currently-active account. `force` bypasses the cross-tab cooldown
+ * (page load / account switch); the periodic tick passes `false` so it coalesces.
+ */
+export async function foldCurrentAccount(force: boolean): Promise<void> {
+  const accountId = sessionStore.currentAccountId
+  if (!accountId || inFlight) {
+    return
+  }
+  inFlight = true
+  try {
+    await runCoalescedAcrossTabs({
+      lockName: FOLD_LOCK_NAME,
+      cooldownKey: `${FOLD_COOLDOWN_KEY_PREFIX}${accountId}`,
+      cooldownMs: FOLD_INTERVAL_MS,
+      force,
+      task: async () => {
+        const result = await refreshAccountFromSwarm(accountId)
+        if (!result.ok && result.kind === 'error') {
+          console.warn(`[account-fold] ${accountId} failed:`, result.error)
+        }
+      },
+    })
+  } finally {
+    inFlight = false
+  }
+}
+
+/** Start the periodic (coalesced) fold. Returns a teardown. */
+export function startFoldInterval(): () => void {
+  if (!browser) {
+    return () => undefined
+  }
+  const timer = setInterval(() => void foldCurrentAccount(false), FOLD_INTERVAL_MS)
+  return () => clearInterval(timer)
+}

--- a/ui/src/lib/dev/account-refresh.ts
+++ b/ui/src/lib/dev/account-refresh.ts
@@ -22,11 +22,18 @@ import { sessionStore } from '$lib/stores/session.svelte'
 // "Every few minutes" — the cross-tab window doubles as the interval, so with N
 // tabs open only ~one fold runs per window.
 const FOLD_INTERVAL_MS = 3 * 60 * 1000
+// Short window honoured even under `force`, so a burst of forced folds collapses:
+// N restored tabs each forcing on load, and the post-sign-in fold immediately
+// after the import page's own fold (which stamps via `noteAccountFolded`).
+const FOLD_GRACE_MS = 5 * 1000
 const FOLD_LOCK_NAME = 'swarm-id-account-fold'
 const FOLD_COOLDOWN_KEY_PREFIX = 'swarm-id-account-folded-at-'
 
-// Per-tab guard so overlapping triggers (interval + account switch) don't stack.
-let inFlight = false
+const foldCooldownKey = (accountId: string) => `${FOLD_COOLDOWN_KEY_PREFIX}${accountId}`
+
+// Per-tab, per-account guard so overlapping triggers (interval + account switch)
+// don't stack — keyed so an A→B switch while A's fold runs still folds B.
+const inFlight = new Set<string>()
 
 /**
  * Fold the currently-active account. `force` bypasses the cross-tab cooldown
@@ -34,15 +41,16 @@ let inFlight = false
  */
 export async function foldCurrentAccount(force: boolean): Promise<void> {
   const accountId = sessionStore.currentAccountId
-  if (!accountId || inFlight) {
+  if (!accountId || inFlight.has(accountId)) {
     return
   }
-  inFlight = true
+  inFlight.add(accountId)
   try {
     await runCoalescedAcrossTabs({
       lockName: FOLD_LOCK_NAME,
-      cooldownKey: `${FOLD_COOLDOWN_KEY_PREFIX}${accountId}`,
+      cooldownKey: foldCooldownKey(accountId),
       cooldownMs: FOLD_INTERVAL_MS,
+      graceMs: FOLD_GRACE_MS,
       force,
       task: async () => {
         const result = await refreshAccountFromSwarm(accountId)
@@ -52,8 +60,21 @@ export async function foldCurrentAccount(force: boolean): Promise<void> {
       },
     })
   } finally {
-    inFlight = false
+    inFlight.delete(accountId)
   }
+}
+
+/**
+ * Stamp the fold cooldown for `accountId` as "just folded". The import/sign-in
+ * flow folds directly (not via `foldCurrentAccount`); calling this after it lets
+ * the forced fold triggered right after finalize skip within the grace window
+ * instead of re-folding back-to-back.
+ */
+export function noteAccountFolded(accountId: string): void {
+  if (typeof localStorage === 'undefined') {
+    return
+  }
+  localStorage.setItem(foldCooldownKey(accountId), String(Date.now()))
 }
 
 /** Start the periodic (coalesced) fold. Returns a teardown. */

--- a/ui/src/lib/payment/bee.ts
+++ b/ui/src/lib/payment/bee.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 The Swarm Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { type BatchId, Bee, Identifier, PrivateKey, Stamper } from '@ethersphere/bee-js'
-import { type UploadTarget, rejectAfter, uploadSOC } from '@snaha/swarm-id'
+import { SocUploadError, type UploadTarget, rejectAfter, uploadSOC } from '@snaha/swarm-id'
 
 import { strip0x } from '$lib/crypto/hex'
 import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
@@ -30,20 +30,20 @@ function randomIdentifier(): Identifier {
  */
 
 // The node validates a postage stamp synchronously at ingestion (signature vs
-// batch owner, funds, depth) BEFORE the chunk enters pushsync, so a bad signer
-// is refused with a fast 4xx. A valid stamp is accepted and only then pushsynced
-// — which can be slow or (on a misconfigured node) never receipt. So a definitive
-// 4xx is the only reliable "can't stamp" signal; a timeout / 5xx / network error
-// means "accepted, receipt pending" and must NOT reject a valid batch.
-const NODE_REJECTED = /SOC upload failed: 4\d\d/
+// batch owner, funds, depth) BEFORE the chunk enters pushsync, and refuses a bad
+// stamp with 400. A 404 ("batch not found") or 422 ("batch not usable yet"),
+// though, just means the node hasn't synced/warmed this batch yet — the exact
+// case attach exists for — so it must NOT count as a rejection. Only a 400 is
+// definitive; every other status (404/422/timeout/5xx/network) is inconclusive
+// ("accepted or unknown, receipt pending") and must let a valid batch through.
+const STAMP_REJECTED_STATUS = 400
 
 /**
  * Prove a (batchID, signerKey) pair can actually stamp uploads by writing one
  * tiny stamped SOC. `getPostageBatch` only proves the batch exists; this proves
- * the signer owns/can-stamp it. Returns false ONLY when the node definitively
- * rejects the stamp (4xx); a timeout or other error is inconclusive (the caller
- * already reached the node for the metadata lookup) and returns true so a slow
- * pushsync can't turn a valid batch away.
+ * the signer owns/can-stamp it. Returns false ONLY on a definitive stamp
+ * rejection (HTTP 400); a 404/422/timeout/other error is inconclusive and
+ * returns true so a freshly-bought or not-yet-synced batch isn't turned away.
  */
 export async function verifyBatchStampable(
   batchId: BatchId,
@@ -61,7 +61,7 @@ export async function verifyBatchStampable(
     await Promise.race([upload, rejectAfter(VALIDATION_TIMEOUT_MS, 'batch validation timed out')])
     return true
   } catch (error) {
-    return !NODE_REJECTED.test(error instanceof Error ? error.message : '')
+    return !(error instanceof SocUploadError && error.status === STAMP_REJECTED_STATUS)
   } finally {
     // If the timeout won the race, the upload promise is still pending; swallow
     // its eventual (unhandled) rejection.

--- a/ui/src/lib/payment/bee.ts
+++ b/ui/src/lib/payment/bee.ts
@@ -1,10 +1,25 @@
 // Copyright 2026 The Swarm Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
-import { Bee, PrivateKey } from '@ethersphere/bee-js'
+import { type BatchId, Bee, Identifier, PrivateKey, Stamper } from '@ethersphere/bee-js'
+import { type UploadTarget, rejectAfter, uploadSOC } from '@snaha/swarm-id'
 
 import { strip0x } from '$lib/crypto/hex'
-import type { NewStamp } from '$lib/payment/purchase'
 import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
+
+const VALIDATION_PAYLOAD = new TextEncoder().encode('swarm-id batch validation')
+// A real gateway stamps + pushsyncs a valid chunk in a second or two; give it
+// headroom. A slower response is treated as "accepted, receipt pending" (see
+// verifyBatchStampable), so this bound only affects how long we wait before
+// letting a valid-looking batch through — it never turns a valid batch away.
+const VALIDATION_TIMEOUT_MS = 10000
+const IDENTIFIER_BYTES = 32
+
+// A random identifier each call → a fresh SOC address → a fresh postage bucket
+// slot, so re-validating the same batch doesn't reuse a stamp index (which the
+// node rejects as a double-spend). Costs one tiny chunk per validation.
+function randomIdentifier(): Identifier {
+  return new Identifier(crypto.getRandomValues(new Uint8Array(IDENTIFIER_BYTES)))
+}
 
 /**
  * The product UI's postage ("drive") operations against a Bee node, as a thin
@@ -14,38 +29,43 @@ import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
  * so pointing the app at a different Bee node redirects these calls too.
  */
 
+// The node validates a postage stamp synchronously at ingestion (signature vs
+// batch owner, funds, depth) BEFORE the chunk enters pushsync, so a bad signer
+// is refused with a fast 4xx. A valid stamp is accepted and only then pushsynced
+// — which can be slow or (on a misconfigured node) never receipt. So a definitive
+// 4xx is the only reliable "can't stamp" signal; a timeout / 5xx / network error
+// means "accepted, receipt pending" and must NOT reject a valid batch.
+const NODE_REJECTED = /SOC upload failed: 4\d\d/
+
 /**
- * Look up an existing batch on a Bee node and shape it into a stamp record.
- * Returns `undefined` when the node doesn't track the batch or is unreachable —
- * the caller surfaces that to the user rather than attaching a half-known drive.
+ * Prove a (batchID, signerKey) pair can actually stamp uploads by writing one
+ * tiny stamped SOC. `getPostageBatch` only proves the batch exists; this proves
+ * the signer owns/can-stamp it. Returns false ONLY when the node definitively
+ * rejects the stamp (4xx); a timeout or other error is inconclusive (the caller
+ * already reached the node for the metadata lookup) and returns true so a slow
+ * pushsync can't turn a valid batch away.
  */
-export async function fetchExistingStamp(
-  batchId: string,
+export async function verifyBatchStampable(
+  batchId: BatchId,
   signerKey: PrivateKey,
-  name: string | undefined,
+  depth: number,
   beeUrl: string = networkSettingsStore.beeNodeUrl,
-): Promise<NewStamp | undefined> {
+): Promise<boolean> {
+  const bee = new Bee(beeUrl)
+  const stamper = Stamper.fromBlank(signerKey, batchId, depth)
+  const target: UploadTarget = { mode: 'stamper', bee, stamper }
+  const upload = uploadSOC(target, signerKey, randomIdentifier(), VALIDATION_PAYLOAD, {
+    deferred: true,
+  })
   try {
-    const batch = await new Bee(beeUrl).getPostageBatch(strip0x(batchId))
-    return {
-      batchID: batch.batchID,
-      name,
-      signerKey,
-      depth: batch.depth,
-      amount: BigInt(batch.amount),
-      bucketDepth: batch.bucketDepth,
-      blockNumber: batch.blockNumber,
-      immutableFlag: batch.immutableFlag,
-      // bee-js precomputes `usage` as the 0–1 fraction the UI reads.
-      utilization: batch.usage,
-      usable: batch.usable,
-      // getPostageBatch throws when the node doesn't track the batch, so a
-      // batch that made it here exists by construction.
-      exists: true,
-      batchTTL: batch.duration.toSeconds(),
-    }
-  } catch {
-    return undefined
+    await Promise.race([upload, rejectAfter(VALIDATION_TIMEOUT_MS, 'batch validation timed out')])
+    return true
+  } catch (error) {
+    return !NODE_REJECTED.test(error instanceof Error ? error.message : '')
+  } finally {
+    // If the timeout won the race, the upload promise is still pending; swallow
+    // its eventual (unhandled) rejection.
+    upload.catch(() => undefined)
   }
 }
 

--- a/ui/src/lib/payment/contract.ts
+++ b/ui/src/lib/payment/contract.ts
@@ -14,14 +14,7 @@ import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
 // bee-compose anvil deploy of the PostageStamp contract; only used when the RPC
 // URL is local (resolvePostageStampContractAddress gates it — a remote RPC
 // resolves to Gnosis mainnet). Inert in production.
-const LOCAL_POSTAGE_STAMP_CONTRACT_ADDRESS = '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512'
-
-/**
- * Result of looking a batch up on the PostageStamp contract. `not-found` covers
- * both "no such batch on this chain" and "couldn't read the chain" — the lib's
- * `fetchOnChainBatchState` collapses those into one `undefined`.
- */
-export type ExistingBatchLookup = { status: 'found'; stamp: NewStamp } | { status: 'not-found' }
+export const LOCAL_POSTAGE_STAMP_CONTRACT_ADDRESS = '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512'
 
 /**
  * Read a batch's parameters straight from the PostageStamp contract ON-CHAIN
@@ -29,6 +22,9 @@ export type ExistingBatchLookup = { status: 'found'; stamp: NewStamp } | { statu
  * never saw it — e.g. a public gateway with no `/stamps`, or a batch bought
  * independently. The signer key is NOT on-chain, so the caller supplies it (it's
  * needed to sign uploads with the batch and is validated later by an upload probe).
+ *
+ * Returns `undefined` when the batch isn't found on chain — which the lib's
+ * `fetchOnChainBatchState` also collapses "couldn't read the chain" into.
  */
 export async function fetchExistingBatchFromChain(
   batchId: string,
@@ -36,7 +32,7 @@ export async function fetchExistingBatchFromChain(
   // Optional: an unnamed drive falls back to a batch-ID-derived label (drives.ts).
   name: string | undefined,
   opts?: { rpcUrl?: string; contractAddress?: string },
-): Promise<ExistingBatchLookup> {
+): Promise<NewStamp | undefined> {
   const rpcUrl = opts?.rpcUrl ?? networkSettingsStore.gnosisRpcUrl
   const contractAddress =
     opts?.contractAddress ??
@@ -44,29 +40,28 @@ export async function fetchExistingBatchFromChain(
 
   const state = await fetchOnChainBatchState(rpcUrl, strip0x(batchId), contractAddress)
   if (!state) {
-    return { status: 'not-found' }
+    return undefined
   }
 
   const { batch } = state
   const ttl = calculateContractTTLSeconds(state)
   return {
-    status: 'found',
-    stamp: {
-      batchID: new BatchId(strip0x(batchId)),
-      name,
-      signerKey,
-      depth: batch.depth,
-      bucketDepth: batch.bucketDepth,
-      // On-chain per-chunk balance level (record metadata only — the stamper
-      // doesn't read it); the original purchase amount isn't recoverable on-chain.
-      amount: batch.normalisedBalance,
-      blockNumber: Number(batch.lastUpdatedBlockNumber),
-      immutableFlag: batch.immutableFlag,
-      // On-chain has no per-bucket usage; the local stamper tracks it from here.
-      utilization: 0,
-      usable: ttl === undefined || ttl > 0,
-      exists: true,
-      batchTTL: ttl,
-    },
+    batchID: new BatchId(strip0x(batchId)),
+    name,
+    signerKey,
+    depth: batch.depth,
+    bucketDepth: batch.bucketDepth,
+    // Remaining per-chunk balance: `normalisedBalance` is the run-out watermark
+    // (cumulative outpayment since genesis), so subtract the global outpayment to
+    // get what dilute/extend read as `stamp.amount`. The original purchase amount
+    // isn't recoverable on-chain.
+    amount: batch.normalisedBalance - state.currentTotalOutPayment,
+    blockNumber: Number(batch.lastUpdatedBlockNumber),
+    immutableFlag: batch.immutableFlag,
+    // On-chain has no per-bucket usage; the local stamper tracks it from here.
+    utilization: 0,
+    usable: ttl === undefined || ttl > 0,
+    exists: true,
+    batchTTL: ttl,
   }
 }

--- a/ui/src/lib/payment/contract.ts
+++ b/ui/src/lib/payment/contract.ts
@@ -1,0 +1,72 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { BatchId, PrivateKey } from '@ethersphere/bee-js'
+import {
+  calculateContractTTLSeconds,
+  fetchOnChainBatchState,
+  resolvePostageStampContractAddress,
+} from '@snaha/swarm-id'
+
+import { strip0x } from '$lib/crypto/hex'
+import type { NewStamp } from '$lib/payment/purchase'
+import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
+
+// bee-compose anvil deploy of the PostageStamp contract; only used when the RPC
+// URL is local (resolvePostageStampContractAddress gates it — a remote RPC
+// resolves to Gnosis mainnet). Inert in production.
+const LOCAL_POSTAGE_STAMP_CONTRACT_ADDRESS = '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512'
+
+/**
+ * Result of looking a batch up on the PostageStamp contract. `not-found` covers
+ * both "no such batch on this chain" and "couldn't read the chain" — the lib's
+ * `fetchOnChainBatchState` collapses those into one `undefined`.
+ */
+export type ExistingBatchLookup = { status: 'found'; stamp: NewStamp } | { status: 'not-found' }
+
+/**
+ * Read a batch's parameters straight from the PostageStamp contract ON-CHAIN
+ * (not from a Bee node), so any batch id works even when the configured node
+ * never saw it — e.g. a public gateway with no `/stamps`, or a batch bought
+ * independently. The signer key is NOT on-chain, so the caller supplies it (it's
+ * needed to sign uploads with the batch and is validated later by an upload probe).
+ */
+export async function fetchExistingBatchFromChain(
+  batchId: string,
+  signerKey: PrivateKey,
+  // Optional: an unnamed drive falls back to a batch-ID-derived label (drives.ts).
+  name: string | undefined,
+  opts?: { rpcUrl?: string; contractAddress?: string },
+): Promise<ExistingBatchLookup> {
+  const rpcUrl = opts?.rpcUrl ?? networkSettingsStore.gnosisRpcUrl
+  const contractAddress =
+    opts?.contractAddress ??
+    resolvePostageStampContractAddress(rpcUrl, LOCAL_POSTAGE_STAMP_CONTRACT_ADDRESS)
+
+  const state = await fetchOnChainBatchState(rpcUrl, strip0x(batchId), contractAddress)
+  if (!state) {
+    return { status: 'not-found' }
+  }
+
+  const { batch } = state
+  const ttl = calculateContractTTLSeconds(state)
+  return {
+    status: 'found',
+    stamp: {
+      batchID: new BatchId(strip0x(batchId)),
+      name,
+      signerKey,
+      depth: batch.depth,
+      bucketDepth: batch.bucketDepth,
+      // On-chain per-chunk balance level (record metadata only — the stamper
+      // doesn't read it); the original purchase amount isn't recoverable on-chain.
+      amount: batch.normalisedBalance,
+      blockNumber: Number(batch.lastUpdatedBlockNumber),
+      immutableFlag: batch.immutableFlag,
+      // On-chain has no per-bucket usage; the local stamper tracks it from here.
+      utilization: 0,
+      usable: ttl === undefined || ttl > 0,
+      exists: true,
+      batchTTL: ttl,
+    },
+  }
+}

--- a/ui/src/lib/stores/session.svelte.ts
+++ b/ui/src/lib/stores/session.svelte.ts
@@ -47,8 +47,8 @@ function createSessionStore() {
       // back to rename does not silently swap in a new recovery phrase.
       draft = draft?.flow === 'create' ? { ...draft, name } : { flow: 'create', name }
     },
-    startSignIn(name: string, phrase: string) {
-      draft = { flow: 'sign-in', name, phrase }
+    startSignIn(name: string, phrase: string, restored?: AccountData) {
+      draft = { flow: 'sign-in', name, phrase, restored }
     },
     startRestore(restored: AccountData, phrase: string) {
       draft = { flow: 'restore', name: restored.name, phrase, restored }

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -7,6 +7,10 @@
   import { onMount } from 'svelte'
 
   import Toast from '$lib/components/toast.svelte'
+  // ponytail: the sync engine lives under `$lib/dev` but operates on real account
+  // data — #389 can relocate it out of `$lib/dev`; not worth the churn here.
+  import { triggerSync } from '$lib/dev/sync-hooks'
+  import { setAccountsSyncHook } from '$lib/stores/accounts.svelte'
   import { themeStore } from '$lib/stores/theme.svelte'
   import { toastStore } from '$lib/stores/toast.svelte'
 
@@ -16,6 +20,9 @@
 
   onMount(() => {
     themeStore.init()
+    // Publish account mutations to Swarm app-wide (debounced). Previously wired
+    // only in /dev, so the shipping app never synced (#389). Owned here now.
+    setAccountsSyncHook(triggerSync)
   })
 </script>
 

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -9,8 +9,10 @@
   import Toast from '$lib/components/toast.svelte'
   // ponytail: the sync engine lives under `$lib/dev` but operates on real account
   // data — #389 can relocate it out of `$lib/dev`; not worth the churn here.
+  import { foldCurrentAccount, startFoldInterval } from '$lib/dev/account-refresh'
   import { triggerSync } from '$lib/dev/sync-hooks'
   import { setAccountsSyncHook } from '$lib/stores/accounts.svelte'
+  import { sessionStore } from '$lib/stores/session.svelte'
   import { themeStore } from '$lib/stores/theme.svelte'
   import { toastStore } from '$lib/stores/toast.svelte'
 
@@ -23,6 +25,20 @@
     // Publish account mutations to Swarm app-wide (debounced). Previously wired
     // only in /dev, so the shipping app never synced (#389). Owned here now.
     setAccountsSyncHook(triggerSync)
+    // Pull peer/node state back on a periodic (cross-tab-coalesced) tick.
+    return startFoldInterval()
+  })
+
+  // Force a fold whenever the active account is set or switched — the page-load
+  // ("reload to force") and account-switch triggers. Reads ONLY the id (which
+  // applyRefreshed never changes) and defers the call so the fold's accountsStore
+  // reads aren't tracked, avoiding an $effect re-fire loop.
+  $effect(() => {
+    if (!sessionStore.currentAccountId) {
+      return
+    }
+    const timer = setTimeout(() => void foldCurrentAccount(true), 0)
+    return () => clearTimeout(timer)
   })
 </script>
 

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -4,7 +4,7 @@
 -->
 
 <script lang="ts">
-  import { onMount } from 'svelte'
+  import { onMount, untrack } from 'svelte'
 
   import Toast from '$lib/components/toast.svelte'
   // ponytail: the sync engine lives under `$lib/dev` but operates on real account
@@ -31,14 +31,13 @@
 
   // Force a fold whenever the active account is set or switched — the page-load
   // ("reload to force") and account-switch triggers. Reads ONLY the id (which
-  // applyRefreshed never changes) and defers the call so the fold's accountsStore
-  // reads aren't tracked, avoiding an $effect re-fire loop.
+  // applyRefreshed never changes); `untrack` keeps the fold's accountsStore reads
+  // out of this effect's dependencies, avoiding an $effect re-fire loop.
   $effect(() => {
     if (!sessionStore.currentAccountId) {
       return
     }
-    const timer = setTimeout(() => void foldCurrentAccount(true), 0)
-    return () => clearTimeout(timer)
+    untrack(() => void foldCurrentAccount(true))
   })
 </script>
 

--- a/ui/src/routes/account/import/+page.svelte
+++ b/ui/src/routes/account/import/+page.svelte
@@ -4,9 +4,15 @@
 -->
 
 <script lang="ts">
+  import { Bee, EthAddress } from '@ethersphere/bee-js'
   import ChevronLeft from '@lucide/svelte/icons/chevron-left'
   import CircleAlert from '@lucide/svelte/icons/circle-alert'
   import LoaderCircle from '@lucide/svelte/icons/loader-circle'
+  import {
+    type AccountData,
+    deriveAccountDerivationKey,
+    foldAccountFromSwarm,
+  } from '@snaha/swarm-id'
 
   import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'
@@ -15,11 +21,12 @@
   import { Button } from '$lib/components/ui/button'
   import { Textarea } from '$lib/components/ui/textarea'
   import { completeConnect } from '$lib/connect-handshake'
+  import { strip0x } from '$lib/crypto/hex'
   import { isValidPhrase, normalizePhrase, walletFromPhrase } from '$lib/crypto/mnemonic'
-  import { generateName } from '$lib/name-generator'
   import routes from '$lib/routes'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { connectStore } from '$lib/stores/connect.svelte'
+  import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
 
   let phrase = $state('')
@@ -55,12 +62,61 @@
         return
       }
 
-      sessionStore.startSignIn(generateName(), normalized)
+      // New device: verify the account exists on Swarm before creating it
+      // locally, and recover its synced state (name/stamps/apps). Reading the
+      // network here is what turns a mistyped phrase into a clear "not found"
+      // instead of a silent empty account.
+      const derivationKey = await deriveAccountDerivationKey(strip0x(wallet.privateKey))
+      const bee = new Bee(networkSettingsStore.beeNodeUrl)
+
+      // The fold's roster reader swallows read failures into an empty roster, so
+      // it can't by itself tell "no account" from "network down". Probe
+      // reachability first so an offline node surfaces as an error to retry, not
+      // a false "account not found".
+      if (!(await bee.isConnected())) {
+        failed = true
+        failureMessage = "Couldn't reach the Swarm network. Check your connection and try again."
+        return
+      }
+
+      const accountId = new EthAddress(wallet.address).toHex()
+      const folded = await foldAccountFromSwarm({ bee, derivationKey, accountId })
+      if (!folded) {
+        // No account has been published under this phrase — the default copy
+        // renders the "double-check your phrase" screen.
+        failed = true
+        failureMessage = undefined
+        return
+      }
+
+      // Recover the synced state so `finalize` rebuilds the real account rather
+      // than a fresh empty one. The fold freezes its arrays — copy them since
+      // downstream mutates in place.
+      const { account: state } = folded
+      const restored: AccountData = {
+        id: new EthAddress(wallet.address),
+        name: state.accountName,
+        publicKey: state.publicKey,
+        createdAt: state.createdAt,
+        derivationKey,
+        defaultPostageStampBatchID: state.defaultPostageStampBatchID,
+        settings: state.settings,
+        accountNameAt: state.accountNameAt,
+        defaultStampAt: state.defaultStampAt,
+        settingsAt: state.settingsAt,
+        lastModified: Date.now(),
+        devices: [...state.devices],
+        connectedApps: [...state.connectedApps],
+        postageStamps: [...state.postageStamps],
+        partitionCount: state.partitionCount,
+      }
+
+      sessionStore.startSignIn(state.accountName, normalized, restored)
       await goto(resolve(routes.ACCOUNT_NEW_ACCESS))
     } catch (caught) {
       // The phrase was checksum-validated before the button enabled, so a
-      // failure here is almost always the connect handshake — surface it
-      // instead of blaming the phrase.
+      // failure here is the connect handshake or the network fold — surface the
+      // message (the "error/retry" bucket, not a false "not found").
       failed = true
       failureMessage = caught instanceof Error ? caught.message : undefined
     } finally {

--- a/ui/src/routes/account/import/+page.svelte
+++ b/ui/src/routes/account/import/+page.svelte
@@ -9,9 +9,9 @@
   import CircleAlert from '@lucide/svelte/icons/circle-alert'
   import LoaderCircle from '@lucide/svelte/icons/loader-circle'
   import {
-    type AccountData,
     deriveAccountDerivationKey,
     foldAccountFromSwarm,
+    foldedToAccountData,
   } from '@snaha/swarm-id'
 
   import { goto } from '$app/navigation'
@@ -23,6 +23,8 @@
   import { completeConnect } from '$lib/connect-handshake'
   import { strip0x } from '$lib/crypto/hex'
   import { isValidPhrase, normalizePhrase, walletFromPhrase } from '$lib/crypto/mnemonic'
+  import { noteAccountFolded } from '$lib/dev/account-refresh'
+  import { generateName } from '$lib/name-generator'
   import routes from '$lib/routes'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { connectStore } from '$lib/stores/connect.svelte'
@@ -33,6 +35,9 @@
   let signingIn = $state(false)
   let failed = $state(false)
   let failureMessage = $state<string | undefined>(undefined)
+  // Distinct from `failed`: the phrase is valid but no account is published on
+  // the network (never synced). Shown with an escape hatch, not phrase-blame.
+  let notFound = $state(false)
 
   const phraseValid = $derived(isValidPhrase(phrase))
   const showInvalid = $derived(phrase.trim().length > 0 && !phraseValid)
@@ -68,50 +73,43 @@
       // instead of a silent empty account.
       const derivationKey = await deriveAccountDerivationKey(strip0x(wallet.privateKey))
       const bee = new Bee(networkSettingsStore.beeNodeUrl)
+      const accountId = new EthAddress(wallet.address).toHex()
 
       // The fold's roster reader swallows read failures into an empty roster, so
-      // it can't by itself tell "no account" from "network down". Probe
-      // reachability first so an offline node surfaces as an error to retry, not
-      // a false "account not found".
-      if (!(await bee.isConnected())) {
-        failed = true
-        failureMessage = "Couldn't reach the Swarm network. Check your connection and try again."
-        return
-      }
-
-      const accountId = new EthAddress(wallet.address).toHex()
+      // it can't by itself tell "no account" from "network down". The reachability
+      // probe disambiguates, but its answer only matters when the fold finds
+      // nothing — so run it alongside the fold instead of serially in front.
+      // `.catch(false)` both prevents a floating rejection and treats a probe
+      // error as "unreachable".
+      const connectedPromise = bee.isConnected().catch(() => false)
       const folded = await foldAccountFromSwarm({ bee, derivationKey, accountId })
+
       if (!folded) {
-        // No account has been published under this phrase — the default copy
-        // renders the "double-check your phrase" screen.
-        failed = true
-        failureMessage = undefined
+        if (!(await connectedPromise)) {
+          failed = true
+          failureMessage = "Couldn't reach the Swarm network. Check your connection and try again."
+          return
+        }
+        // Reachable, but nothing is published under this phrase — it may never
+        // have synced (no drive was ever added). Offer to set it up fresh rather
+        // than accuse the phrase.
+        notFound = true
         return
       }
 
       // Recover the synced state so `finalize` rebuilds the real account rather
-      // than a fresh empty one. The fold freezes its arrays — copy them since
-      // downstream mutates in place.
-      const { account: state } = folded
-      const restored: AccountData = {
+      // than a fresh empty one. `foldedToAccountData` owns the projection + the
+      // frozen-array copy.
+      const restored = foldedToAccountData({
         id: new EthAddress(wallet.address),
-        name: state.accountName,
-        publicKey: state.publicKey,
-        createdAt: state.createdAt,
         derivationKey,
-        defaultPostageStampBatchID: state.defaultPostageStampBatchID,
-        settings: state.settings,
-        accountNameAt: state.accountNameAt,
-        defaultStampAt: state.defaultStampAt,
-        settingsAt: state.settingsAt,
-        lastModified: Date.now(),
-        devices: [...state.devices],
-        connectedApps: [...state.connectedApps],
-        postageStamps: [...state.postageStamps],
-        partitionCount: state.partitionCount,
-      }
+        account: folded.account,
+      })
+      // We just folded directly; stamp the cooldown so the forced fold triggered
+      // right after finalize skips within the grace window instead of re-folding.
+      noteAccountFolded(accountId)
 
-      sessionStore.startSignIn(state.accountName, normalized, restored)
+      sessionStore.startSignIn(restored.name, normalized, restored)
       await goto(resolve(routes.ACCOUNT_NEW_ACCESS))
     } catch (caught) {
       // The phrase was checksum-validated before the button enabled, so a
@@ -126,8 +124,17 @@
 
   function tryAgain() {
     failed = false
+    notFound = false
     failureMessage = undefined
     phrase = ''
+  }
+
+  // Escape hatch for a never-synced account: set it up fresh on this device.
+  // `finalize`'s `accountsStore.get` returns undefined, so it builds a new
+  // account under the same phrase; a drive added later publishes it.
+  function setupFresh() {
+    sessionStore.startSignIn(generateName(), normalizePhrase(phrase))
+    goto(resolve(routes.ACCOUNT_NEW_ACCESS))
   }
 </script>
 
@@ -147,6 +154,26 @@
           </div>
         </div>
         <Button variant="outline" class="w-full" onclick={tryAgain}>Try again</Button>
+      </div>
+    </main>
+  {:else if notFound}
+    <main class="flex w-full flex-1 flex-col items-center justify-center px-8 pb-24">
+      <div class="flex w-full max-w-96 flex-col items-center gap-8">
+        <div class="flex flex-col items-center gap-2">
+          <CircleAlert class="text-muted-foreground size-5" />
+          <div class="flex flex-col items-center text-center">
+            <p class="text-sm font-bold">No account found</p>
+            <p class="text-sm">
+              We couldn't find an account for this phrase on the Swarm network. If you never added a
+              drive, it may never have synced — you can set it up fresh on this device.
+            </p>
+          </div>
+        </div>
+        <div class="flex w-full flex-col gap-2">
+          <Button class="w-full" onclick={setupFresh}>Set up on this device</Button>
+          <Button variant="outline" class="w-full" onclick={tryAgain}>Try a different phrase</Button
+          >
+        </div>
       </div>
     </main>
   {:else}

--- a/ui/src/routes/account/new/access/+page.svelte
+++ b/ui/src/routes/account/new/access/+page.svelte
@@ -37,6 +37,7 @@
   import { strip0x } from '$lib/crypto/hex'
   import { walletFromPhrase } from '$lib/crypto/mnemonic'
   import { createPasskeyKey } from '$lib/crypto/passkey'
+  import { triggerSync } from '$lib/dev/sync-hooks'
   import routes from '$lib/routes'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { connectStore } from '$lib/stores/connect.svelte'
@@ -124,6 +125,10 @@
     // `add` returns the live reactive account; the handshake mutates it.
     const liveAccount = accountsStore.add(account)
     sessionStore.setCurrentAccount(liveAccount.id)
+    // `add` persists but doesn't fire the sync hook (only field mutations do),
+    // so publish once here to register this device in the Swarm roster. No-ops
+    // harmlessly until the account has a stamp to sign the upload.
+    triggerSync(liveAccount.id.toHex())
     const flow = draft.flow
 
     // Came from a dApp connect popup — finish the handshake and hand back.

--- a/ui/src/routes/dev/+page.svelte
+++ b/ui/src/routes/dev/+page.svelte
@@ -29,7 +29,10 @@
   import { Tabs } from '$lib/components/ui/tabs'
   import { postageStampsStore } from '$lib/dev/postage-stamps.svelte'
   import { syncStore } from '$lib/dev/sync.svelte'
-  import { fetchExistingBatchFromChain } from '$lib/payment/contract'
+  import {
+    LOCAL_POSTAGE_STAMP_CONTRACT_ADDRESS,
+    fetchExistingBatchFromChain,
+  } from '$lib/payment/contract'
   import routes from '$lib/routes'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { devSettingsStore } from '$lib/stores/dev-settings.svelte'
@@ -581,13 +584,8 @@ Check console logs for details:
   // Import a batch by ID, reading its parameters from the PostageStamp contract
   // ON-CHAIN (not from a Bee node) — works for any batch id even when the
   // configured node never saw it. The signer key is NOT on-chain, so the user
-  // supplies it (required to sign uploads with the batch).
-  //
-  // ponytail: the local bee-compose (anvil) PostageStamp deployment address —
-  // deterministic, matches the `dev:ui:legacy` VITE_POSTAGE_STAMP_CONTRACT_ADDRESS
-  // injection. Only used when the RPC points at a local chain (see
-  // resolvePostageStampContractAddress); a remote RPC resolves to Gnosis mainnet.
-  const LOCAL_POSTAGE_STAMP_CONTRACT_ADDRESS = '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512'
+  // supplies it (required to sign uploads with the batch). The local anvil
+  // deployment address is shared from `$lib/payment/contract`.
 
   let importBatchId = $state('')
   let importSignerKey = $state('')
@@ -624,21 +622,21 @@ Check console logs for details:
         return
       }
 
-      const res = await fetchExistingBatchFromChain(batchId.toHex(), signerKey, '', {
+      const stamp = await fetchExistingBatchFromChain(batchId.toHex(), signerKey, '', {
         rpcUrl: importRpcUrl.trim(),
         contractAddress: effectiveContract,
       })
-      if (res.status !== 'found') {
+      if (!stamp) {
         importError =
           'Could not read the batch from the chain — no such batch here, or the RPC URL / contract address is wrong.'
         return
       }
 
-      account.addStamp(res.stamp)
-      if (importSetDefault) account.setDefaultStamp(res.stamp.batchID)
+      account.addStamp(stamp)
+      if (importSetDefault) account.setDefaultStamp(stamp.batchID)
       importMessage =
-        `✅ Imported ${batchId.toHex().slice(0, 12)}… (depth ${res.stamp.depth}` +
-        `${res.stamp.immutableFlag ? ', immutable — partition sharing needs a mutable batch' : ''}) ` +
+        `✅ Imported ${batchId.toHex().slice(0, 12)}… (depth ${stamp.depth}` +
+        `${stamp.immutableFlag ? ', immutable — partition sharing needs a mutable batch' : ''}) ` +
         `into ${account.name}`
     } catch (error) {
       importError = error instanceof Error ? error.message : String(error)

--- a/ui/src/routes/dev/+page.svelte
+++ b/ui/src/routes/dev/+page.svelte
@@ -4,7 +4,6 @@
 -->
 
 <script lang="ts">
-  import { onMount } from 'svelte'
   import { SvelteMap } from 'svelte/reactivity'
 
   import { BatchId, Bee, EthAddress, Identifier, PrivateKey, Utils } from '@ethersphere/bee-js'
@@ -15,6 +14,7 @@
     fetchChainState,
     formatTTL,
     rejectAfter,
+    resolvePostageStampContractAddress,
     uint8ArrayToHex,
     uploadSOC,
   } from '@snaha/swarm-id'
@@ -28,10 +28,10 @@
   import { Switch } from '$lib/components/ui/switch'
   import { Tabs } from '$lib/components/ui/tabs'
   import { postageStampsStore } from '$lib/dev/postage-stamps.svelte'
-  import { triggerSync } from '$lib/dev/sync-hooks'
   import { syncStore } from '$lib/dev/sync.svelte'
+  import { fetchExistingBatchFromChain } from '$lib/payment/contract'
   import routes from '$lib/routes'
-  import { accountsStore, setAccountsSyncHook } from '$lib/stores/accounts.svelte'
+  import { accountsStore } from '$lib/stores/accounts.svelte'
   import { devSettingsStore } from '$lib/stores/dev-settings.svelte'
   import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
@@ -39,14 +39,10 @@
   import DeviceList from './device-list.svelte'
   import StatusDot from './status-dot.svelte'
 
-  // Dev tooling drives Swarm publishing: register the sync hook while this page
-  // is mounted so account mutations (here and in child panels) publish to Swarm
-  // after a debounce — and reset it on unmount so the product UI stops
-  // publishing once the user navigates away from /dev.
-  onMount(() => {
-    setAccountsSyncHook(triggerSync)
-    return () => setAccountsSyncHook(undefined)
-  })
+  // The Swarm publish hook is now installed app-wide in the root layout
+  // (`+layout.svelte`), so /dev no longer manages it — a local install +
+  // unmount cleanup here would toggle publishing off for the whole app on
+  // navigating away.
 
   // Milliseconds per second — for converting TTL/Unix seconds to JS `Date` ms.
   const MS_PER_SECOND = 1000
@@ -582,6 +578,75 @@ Check console logs for details:
     }
   }
 
+  // Import a batch by ID, reading its parameters from the PostageStamp contract
+  // ON-CHAIN (not from a Bee node) — works for any batch id even when the
+  // configured node never saw it. The signer key is NOT on-chain, so the user
+  // supplies it (required to sign uploads with the batch).
+  //
+  // ponytail: the local bee-compose (anvil) PostageStamp deployment address —
+  // deterministic, matches the `dev:ui:legacy` VITE_POSTAGE_STAMP_CONTRACT_ADDRESS
+  // injection. Only used when the RPC points at a local chain (see
+  // resolvePostageStampContractAddress); a remote RPC resolves to Gnosis mainnet.
+  const LOCAL_POSTAGE_STAMP_CONTRACT_ADDRESS = '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512'
+
+  let importBatchId = $state('')
+  let importSignerKey = $state('')
+  let importRpcUrl = $state('http://localhost:9545')
+  // Blank → auto-detect from the RPC (local vs Gnosis mainnet); a value overrides.
+  let importContractOverride = $state('')
+  let importSetDefault = $state(true)
+  let importing = $state(false)
+  let importMessage = $state('')
+  let importError = $state('')
+
+  // Contract address the read will use: the override if set, else auto-detected
+  // from the RPC — local RPC → local anvil deployment, any remote RPC → Gnosis
+  // mainnet (resolvePostageStampContractAddress encodes that rule).
+  const resolvedContract = $derived(
+    resolvePostageStampContractAddress(importRpcUrl.trim(), LOCAL_POSTAGE_STAMP_CONTRACT_ADDRESS),
+  )
+  const effectiveContract = $derived(importContractOverride.trim() || resolvedContract)
+
+  async function importBatchById() {
+    importError = ''
+    importMessage = ''
+    if (!importBatchId.trim() || !importSignerKey.trim() || !selectedAccountId) {
+      importError = 'Enter a batch ID and signer key, and select an account.'
+      return
+    }
+    importing = true
+    try {
+      const batchId = new BatchId(importBatchId.trim())
+      const signerKey = new PrivateKey(importSignerKey.trim())
+      const account = accountsStore.getAccount(new EthAddress(selectedAccountId))
+      if (!account) {
+        importError = 'Account not found.'
+        return
+      }
+
+      const res = await fetchExistingBatchFromChain(batchId.toHex(), signerKey, '', {
+        rpcUrl: importRpcUrl.trim(),
+        contractAddress: effectiveContract,
+      })
+      if (res.status !== 'found') {
+        importError =
+          'Could not read the batch from the chain — no such batch here, or the RPC URL / contract address is wrong.'
+        return
+      }
+
+      account.addStamp(res.stamp)
+      if (importSetDefault) account.setDefaultStamp(res.stamp.batchID)
+      importMessage =
+        `✅ Imported ${batchId.toHex().slice(0, 12)}… (depth ${res.stamp.depth}` +
+        `${res.stamp.immutableFlag ? ', immutable — partition sharing needs a mutable batch' : ''}) ` +
+        `into ${account.name}`
+    } catch (error) {
+      importError = error instanceof Error ? error.message : String(error)
+    } finally {
+      importing = false
+    }
+  }
+
   // Clear this browser's accounts (which own their apps + stamps) + session.
   function clearAccount() {
     accountsStore.clear()
@@ -960,6 +1025,57 @@ Check console logs for details:
         <div class={CARD_CLASS}>
           <p class="text-destructive font-mono text-sm">❌ {stampError}</p>
         </div>
+      {/if}
+
+      <div class="bg-border my-4 h-px"></div>
+
+      <h3 class="text-lg font-semibold">Import batch by ID</h3>
+      <p class="text-muted-foreground text-sm">
+        Read a batch's parameters straight from the PostageStamp contract on-chain (not from a Bee
+        node), so any batch id works even if the configured node never saw it. The signer key is not
+        on-chain — paste the one the batch was bought with.
+      </p>
+      <div class="flex flex-col gap-2">
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Batch ID</span>
+          <Input bind:value={importBatchId} placeholder="0x… (64 hex chars)" />
+        </label>
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Signer Key</span>
+          <Input bind:value={importSignerKey} placeholder="64 hex chars" />
+        </label>
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Gnosis RPC URL</span>
+          <Input bind:value={importRpcUrl} />
+        </label>
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>PostageStamp contract</span>
+          <Input bind:value={importContractOverride} placeholder={resolvedContract} />
+          <span class="text-muted-foreground text-xs">
+            Auto from RPC: <span class="font-mono">{resolvedContract}</span> — leave blank to use it (local
+            RPC → local deployment, else Gnosis mainnet).
+          </span>
+        </label>
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Account</span>
+          <Select options={accountOptions} bind:value={selectedAccountId} />
+        </label>
+        <label class="flex cursor-pointer items-center gap-2 text-sm">
+          <input type="checkbox" bind:checked={importSetDefault} />
+          Set as account default
+        </label>
+      </div>
+      <Button
+        onclick={importBatchById}
+        disabled={importing || !importBatchId || !importSignerKey || !selectedAccountId}
+      >
+        {importing ? 'Importing…' : 'Import batch'}
+      </Button>
+      {#if importMessage}
+        <p class="text-success text-sm">{importMessage}</p>
+      {/if}
+      {#if importError}
+        <p class="text-destructive text-sm">{importError}</p>
       {/if}
 
       <div class="bg-border my-4 h-px"></div>

--- a/ui/src/routes/home/+page.svelte
+++ b/ui/src/routes/home/+page.svelte
@@ -13,6 +13,7 @@
   import HomeAccount from '$lib/components/home-account.svelte'
   import HomeApps from '$lib/components/home-apps.svelte'
   import HomeDrives from '$lib/components/home-drives.svelte'
+  import SettingsMenu from '$lib/components/settings-menu.svelte'
   import SwarmWordmark from '$lib/components/swarm-wordmark.svelte'
   import { Tabs } from '$lib/components/ui/tabs'
   import routes from '$lib/routes'
@@ -41,11 +42,12 @@
 <div class="flex min-h-svh flex-col">
   <header class="flex w-full items-center gap-2 p-8">
     <SwarmWordmark height={30} />
-    {#if account}
-      <div class="flex flex-1 items-center justify-end">
+    <div class="flex flex-1 items-center justify-end gap-2">
+      {#if account}
         <AccountSwitcher {account} />
-      </div>
-    {/if}
+      {/if}
+      <SettingsMenu />
+    </div>
   </header>
 
   <main class="flex w-full flex-1 flex-col items-center px-8 pb-8">


### PR DESCRIPTION
Related new-UI features that together make an account (and its drives) usable across devices and against real/independent postage batches, and wire product ↔ Swarm sync.

## Sign-in verifies & recovers the account (Closes #388)

"I already have an account" was fully offline — it derived the keypair and created a fresh empty account without ever touching the network, so a mistyped-but-valid phrase silently created a new account and no synced state was recovered.

- Sign-in now folds the account from Swarm first: **found** → recover its name, stamps and connected apps and proceed; **not found** → "double-check your phrase"; a `bee.isConnected()` probe distinguishes *no account* from *network unreachable*.

## Product ↔ Swarm account sync (Closes #389)

Publish and fold were both wired only in `/dev`, so the shipping app never synced.

- **Publish** — `setAccountsSyncHook(triggerSync)` is installed app-wide (root layout) and fires after account creation, so renames / connected-app changes / drive add·rename·resize·extend·remove now publish (debounced).
- **Fold-back** — the active account is folded from Swarm on **page load / account switch** and on a periodic **~3 min** tick (`refreshAccountFromSwarm`), so peer edits and node truth reconcile. Folds apply with `skipSync`, so they never re-publish.
- **Single fetcher across tabs** — a new lib primitive `runCoalescedAcrossTabs` (exclusive Web Lock + shared localStorage cooldown timestamp) makes only one tab fetch per window; the winner's persisted account document propagates to the other tabs via the existing accounts `storage` listener (unit-tested).

Follow-up (not blocking): the fold's read amplification/slowness against a remote gateway is tracked in #400.

## Attach existing postage batches, with network settings (Closes #391)

- **Network settings dialog** (Bee node URL + Gnosis RPC), ported from the legacy UI with new-UI components, wired into the settings menu and reachable while signed in.
- **Optional signer-key field** on "use existing batch" so a batch owned by an external key can be attached; both fields validate through the lib's Zod schemas.
- Existing-batch details are read from the **PostageStamp contract on-chain** (`fetchExistingBatchFromChain`) instead of the Bee node's `/stamps` (a public gateway doesn't expose it and never saw an independently-bought batch). This also snapshots the batch **TTL from the contract**, so an existing-batch drive shows its expiry (**#391**).
- A single **stamped test chunk** (`verifyBatchStampable`) confirms the signer can actually stamp for the batch before attaching; only a definitive node rejection blocks it, so a slow pushsync never turns a valid batch away.
- Restores the `/dev` **"Import batch by ID"** tool, sharing the same on-chain lookup.

### Note on utilization / bucket state of an attached batch

An attached batch's record is created with `utilization: 0` (the contract carries no per-bucket usage). What actually governs stamping correctness — the per-bucket counters — is handled elsewhere and is **not** regressed by this PR:

- **Same account, same browser** (e.g. remove a drive, then re-add the same batch): the bucket counters live in the local IndexedDB util store, which remove only tombstones the account record — it never purges. So stamping stays correct, and the displayed % (which momentarily shows 0 on re-add) self-corrects on the next sync.
- **Same account, multi-device**: the real upload path recovers the cross-device counter from the on-Swarm partition-state feed on the partition-lease acquire that gates every stamped write — unchanged by this PR.
- **Known limitation**: a batch owned by an **external account** (pasted external signer) can't recover its exact bucket state on attach — the on-Swarm state is addressed by the *publishing* account's encryption key, which we don't have. So `verifyBatchStampable` probes from a zeroed bucket state (a heavily-used external batch could get a spurious rejection) and the displayed utilization starts at 0. Left as a follow-up.

## Verification

`pnpm check:all` passes (incl. the `runCoalescedAcrossTabs` unit test). Exercised end-to-end against the local bee cluster: sign-in not-found/unreachable paths; app-wide publish + on-load/periodic fold (single-fetcher timestamp advancing once per window); add-drive with an existing batch (correct signer attaches, wrong signer is rejected, details/expiry read via `eth_call` with no `/stamps` request); the `/dev` import tool; and the network-settings dialog (validation, persistence, reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
