### PR TITLE
fix: migrate remaining timeout races to withTimeout

### DIFF
--- a/lib/src/swarm-id-client.ts
+++ b/lib/src/swarm-id-client.ts
@@ -85,7 +85,7 @@ import { EthAddress, Identifier, PrivateKey, Topic } from "@ethersphere/bee-js"
 import { uint8ArrayToHex } from "./utils/hex"
 import { buildAuthUrl } from "./utils/url"
 import { isWebKit } from "./utils/browser"
-import { rejectAfter } from "./utils/promise"
+import { withTimeout } from "./utils/promise"
 
 const DEFAULT_TIMEOUT_MS = 30000
 const DEFAULT_INITIALIZATION_TIMEOUT_MS = 30000
@@ -280,15 +280,14 @@ export class SwarmIdClient {
     // `handleIframeMessage` when the `connectionInfoChanged` arrives — not
     // from this executor. ES2024's `Promise.withResolvers()` would express
     // the same shape more directly.
-    this.firstConnectionInfoPromise = Promise.race([
-      new Promise<void>((resolve) => {
-        this.firstConnectionInfoResolve = resolve
-      }),
-      rejectAfter(
+    this.firstConnectionInfoPromise = withTimeout(
+        new Promise<void>((resolve)=>{
+            this.firstConnectionInfoResolve = resolve
+        }),
         this.initializationTimeout,
         `Proxy initialization timeout - proxy did not send initial connectionInfoChanged within ${this.initializationTimeout}ms`,
-      ),
-    ])
+    )
+
     // Attach a no-op handler so the rejection isn't surfaced as
     // "unhandled" if the timeout fires before we reach the awaiting line
     // below (e.g. because an earlier `await` in this method hung first).

--- a/lib/src/sync/batch-write-coordinator.ts
+++ b/lib/src/sync/batch-write-coordinator.ts
@@ -55,6 +55,7 @@ import { readPartitionLock, NO_HOLDER_DEVICE_ID } from "./partition-lock"
 import { STATE_POINTER_EPOCH_MS } from "./partition-state"
 import type { UploadTarget } from "../proxy/upload"
 import type { StampWorkerPool } from "../proxy/stamp-worker-pool"
+import { withTimeout } from "../utils/promise"
 
 /** Hard cap on the acquire path (including any wait-for-slot retry). */
 const PARTITION_LEASE_ACQUIRE_TIMEOUT_MS = 45000
@@ -417,19 +418,14 @@ export class BatchWriteCoordinator {
           }
           return
         }
-        const timeout = new Promise<void>((_, reject) =>
-          setTimeout(
-            () =>
-              reject(
-                new Error(
-                  `Partition lease timed out after ${PARTITION_LEASE_ACQUIRE_TIMEOUT_MS}ms`,
-                ),
-              ),
-            PARTITION_LEASE_ACQUIRE_TIMEOUT_MS,
-          ),
-        )
+
         try {
-          await Promise.race([this.acquireWithSlotWait(), timeout])
+            await withTimeout(
+                this.acquireWithSlotWait(),
+                PARTITION_LEASE_ACQUIRE_TIMEOUT_MS,
+                `Partition lease timed out after ${PARTITION_LEASE_ACQUIRE_TIMEOUT_MS}ms`,
+            )
+            
         } catch (error) {
           console.warn(
             "[BatchWriteCoordinator] Partition lease acquisition failed, pausing background work:",

--- a/lib/src/sync/sync-account.ts
+++ b/lib/src/sync/sync-account.ts
@@ -35,7 +35,7 @@ import type {
 } from "./store-interfaces"
 import type { SyncResult } from "./types"
 import type { AccountStateSnapshot } from "../utils/account-state-snapshot"
-import { rejectAfter } from "../utils/promise"
+import { withTimeout } from "../utils/promise"
 import type { PostageStamp } from "../schemas"
 import {
   BatchWriteCoordinator,
@@ -217,13 +217,12 @@ export function createSyncAccount(
         },
       )
 
-      return Promise.race([
-        uploadPromise,
-        rejectAfter(
-          UTILIZATION_UPLOAD_TIMEOUT_MS,
-          `Utilization upload timeout (${UTILIZATION_UPLOAD_TIMEOUT_MS}ms)`,
-        ),
-      ])
+
+      return withTimeout(
+          uploadPromise,
+          UTILIZATION_UPLOAD_TIMEOUT_MS, 
+          `Utilization upload timeout (${UTILIZATION_UPLOAD_TIMEOUT_MS}ms)`
+      )
     }
   }
 


### PR DESCRIPTION
Closes #383

## Summary

- Replace remaining internal `Promise.race(..., rejectAfter(...))` usages with `withTimeout()`
- Replace the inline timeout in `batch-write-coordinator.ts` with `withTimeout()`
- Remove unused `rejectAfter` imports

`partition-intent.ts` was already migrated in #382, so no changes were needed there.

## Verification

- ✅ `pnpm --filter @snaha/swarm-id typecheck`
- ✅ `pnpm --filter @snaha/swarm-id lint` (one existing unrelated warning)
- ✅ `pnpm --filter @snaha/swarm-id test`