### PR TITLE
feat(ui): add manifest.json for PWA install

### DIFF
--- a/ui/src/app.html
+++ b/ui/src/app.html
@@ -11,6 +11,7 @@
     <meta name="apple-mobile-web-app-status-bar-style" content="black" />
     <meta name="apple-mobile-web-app-title" content="Swarm Identity" />
     <link rel="icon" href="%sveltekit.assets%/favicon.png" type="image/png" />
+    <link rel="manifest" href="%sveltekit.assets%/manifest.json" />
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/ui/static/manifest.json
+++ b/ui/static/manifest.json
@@ -1,0 +1,10 @@
+{
+  "name": "Swarm Identity",
+  "short_name": "Swarm ID",
+  "description": "Identity management for Swarm dApps",
+  "start_url": ".",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#ff6600",
+  "icons": [{ "src": "favicon.png", "type": "image/png", "sizes": "any" }]
+}


### PR DESCRIPTION
Adds a web app manifest to the new UI so it can be installed as a PWA, mirroring the legacy UI.

- New `ui/static/manifest.json`, modelled on `swarm-ui/static/manifest.json`
- Uses **base-relative** paths (`start_url: "."`, icon `src: "favicon.png"`) so it resolves under `BASE_PATH=/id`, unlike the legacy absolute paths
- Links it from `ui/src/app.html` via `%sveltekit.assets%/manifest.json`

Depends on #404 (adds `ui/static/favicon.png`, which the manifest references); merge that first.

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)