### PR TITLE
feat(ui): connect screen for devices with existing accounts

### DIFF
--- a/ui/src/lib/connect-handshake.ts
+++ b/ui/src/lib/connect-handshake.ts
@@ -86,19 +86,29 @@ export async function completeConnect(
   sendSecretToOpener(account, request, appSecret)
 }
 
+/** The still-valid prior connection to this app, if the account has one. */
+function findReusableConnection(account: Account, appOrigin: string): ConnectedApp | undefined {
+  return account.connectedApps.find(
+    (app) =>
+      app.appUrl === appOrigin &&
+      app.appSecret !== undefined &&
+      app.revokedAt === undefined &&
+      (app.connectedUntil ?? 0) > Date.now(),
+  )
+}
+
+/** Whether connecting can skip the unlock ceremony (see `reuseConnection`). */
+export function hasReusableConnection(account: Account, appOrigin: string): boolean {
+  return findReusableConnection(account, appOrigin) !== undefined
+}
+
 /**
  * Reconnect with the secret of a still-valid prior connection, skipping the
  * unlock ceremony. Returns false when there is none and a full
  * unlock + derivation is required.
  */
 export function reuseConnection(account: Account, request: ConnectRequest): boolean {
-  const existing = account.connectedApps.find(
-    (app) =>
-      app.appUrl === request.appOrigin &&
-      app.appSecret !== undefined &&
-      app.revokedAt === undefined &&
-      (app.connectedUntil ?? 0) > Date.now(),
-  )
+  const existing = findReusableConnection(account, request.appOrigin)
   if (!existing?.appSecret) {
     return false
   }

--- a/ui/src/routes/connect/+page.svelte
+++ b/ui/src/routes/connect/+page.svelte
@@ -6,8 +6,12 @@
 <script lang="ts">
   import { onMount } from 'svelte'
 
+  import ChevronLeft from '@lucide/svelte/icons/chevron-left'
   import CircleAlert from '@lucide/svelte/icons/circle-alert'
   import LoaderCircle from '@lucide/svelte/icons/loader-circle'
+  import UserRoundMinus from '@lucide/svelte/icons/user-round-minus'
+  import UserRoundPlus from '@lucide/svelte/icons/user-round-plus'
+  import X from '@lucide/svelte/icons/x'
 
   import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'
@@ -15,11 +19,11 @@
   import AppHeader from '$lib/components/app-header.svelte'
   import AppIcon from '$lib/components/app-icon.svelte'
   import Polycon from '$lib/components/polycon.svelte'
+  import { Badge } from '$lib/components/ui/badge'
   import { Button } from '$lib/components/ui/button'
   import { Dialog } from '$lib/components/ui/dialog'
   import { Input } from '$lib/components/ui/input'
-  import { Tabs } from '$lib/components/ui/tabs'
-  import { completeConnect, reuseConnection } from '$lib/connect-handshake'
+  import { completeConnect, hasReusableConnection, reuseConnection } from '$lib/connect-handshake'
   import { unlockAccount } from '$lib/crypto/unlock'
   import routes from '$lib/routes'
   import { accountsStore } from '$lib/stores/accounts.svelte'
@@ -36,6 +40,12 @@
   let dialogError = $state<string | undefined>(undefined)
   /** Bumped on cancel/retry — a stale ceremony resolution must not connect. */
   let attempt = 0
+  /** Rows become remove targets instead of connect choices. */
+  let removeMode = $state(false)
+  /** Account awaiting removal confirmation. */
+  let removing = $state<Account | undefined>(undefined)
+  /** Shows the create/import choice while other accounts exist on the device. */
+  let addingAccount = $state(false)
 
   const request = $derived(connectStore.request)
   const appIcon = $derived(
@@ -43,40 +53,43 @@
   )
   const accounts = $derived(accountsStore.accounts)
 
-  // Accounts previously connected to this app, most recently used first.
-  const previouslyUsed = $derived.by(() => {
+  // Accounts previously connected to this app first, most recently used on top;
+  // the stable sort keeps never-connected accounts in their stored order.
+  const sortedAccounts = $derived.by(() => {
     const appOrigin = request?.appOrigin
     if (!appOrigin) {
-      return []
+      return accounts
     }
-    return accounts
-      .map((account) => ({
-        account,
-        connection: account.connectedApps.find((app) => app.appUrl === appOrigin),
-      }))
-      .filter((entry) => entry.connection !== undefined)
-      .sort((a, b) => (b.connection?.lastConnectedAt ?? 0) - (a.connection?.lastConnectedAt ?? 0))
-      .map((entry) => entry.account)
+    const lastConnected = (account: Account) =>
+      account.connectedApps.find((app) => app.appUrl === appOrigin)?.lastConnectedAt ?? 0
+    return [...accounts].sort((a, b) => lastConnected(b) - lastConnected(a))
   })
-
-  const TABS = [
-    { value: 'previously-used', label: 'Previously used' },
-    { value: 'all-accounts', label: 'All accounts' },
-  ]
-
-  // Defaults to "Previously used" when available; a user selection takes precedence.
-  let selectedTab = $state<string | undefined>(undefined)
-  const activeTab = $derived(
-    selectedTab ?? (previouslyUsed.length > 0 ? 'previously-used' : 'all-accounts'),
-  )
-  const shownAccounts = $derived(activeTab === 'previously-used' ? previouslyUsed : accounts)
 
   onMount(() => {
     missingRequest = !connectStore.initFromHash(window.location.hash)
   })
 
+  /**
+   * Previously connected to this app but the session lapsed (expired or
+   * revoked) — connecting again will ask for an unlock.
+   */
+  function signedOut(account: Account): boolean {
+    const appOrigin = request?.appOrigin
+    if (!appOrigin) {
+      return false
+    }
+    return (
+      account.connectedApps.some((app) => app.appUrl === appOrigin) &&
+      !hasReusableConnection(account, appOrigin)
+    )
+  }
+
   async function select(account: Account) {
     if (!request) {
+      return
+    }
+    if (removeMode) {
+      removing = account
       return
     }
     // A still-valid prior connection carries the secret — no unlock needed.
@@ -89,6 +102,26 @@
     password = ''
     pendingCeremony = false
     unlocking = account
+  }
+
+  function confirmRemove() {
+    const account = removing
+    if (!account) {
+      return
+    }
+    if (sessionStore.currentAccountId === account.id.toHex()) {
+      sessionStore.clearCurrentAccount()
+    }
+    accountsStore.remove(account.id)
+    removing = undefined
+    if (accountsStore.accounts.length === 0) {
+      removeMode = false
+    }
+  }
+
+  function startAdding() {
+    removeMode = false
+    addingAccount = true
   }
 
   async function confirmUnlock() {
@@ -155,6 +188,18 @@
       </div>
     {:else if request}
       <div class="flex w-full max-w-96 flex-col items-center gap-8">
+        {#if addingAccount && accounts.length > 0}
+          <Button
+            variant="outline"
+            size="icon"
+            aria-label="Back to your accounts"
+            class="size-6 self-start rounded-md [&_svg]:size-3"
+            onclick={() => (addingAccount = false)}
+          >
+            <ChevronLeft />
+          </Button>
+        {/if}
+
         <div class="flex flex-col items-center gap-2">
           <AppIcon src={appIcon} name={request.appName} size={48} />
           <div class="flex flex-col items-center text-center">
@@ -163,58 +208,82 @@
           </div>
         </div>
 
-        {#if accounts.length > 0}
+        {#if accounts.length > 0 && !addingAccount}
           <div class="flex w-full flex-col gap-2">
-            <p class="text-muted-foreground text-xs">Connect with an account on this device</p>
-            {#if previouslyUsed.length > 0}
-              <Tabs tabs={TABS} bind:value={() => activeTab, (value) => (selectedTab = value)} />
-            {/if}
-            <div class="flex w-full flex-col rounded-lg border p-1">
-              {#each shownAccounts as account (account.id.toHex())}
-                <button
-                  type="button"
-                  class="hover:bg-muted focus-visible:bg-muted flex w-full cursor-pointer items-center gap-2 rounded-md px-1.5 py-1.5 text-left text-sm outline-none"
-                  onclick={() => select(account)}
-                >
-                  <Polycon
-                    value={account.id.toHex()}
-                    size={32}
-                    class="shrink-0 overflow-hidden rounded-md"
-                  />
-                  <span class="flex min-w-0 flex-col">
-                    <span class="truncate font-medium">{account.name}</span>
-                    <span class="text-muted-foreground text-xs">
-                      {truncateAddress(account.id.toChecksum())}
-                    </span>
+            {#each sortedAccounts as account (account.id.toHex())}
+              <button
+                type="button"
+                class="hover:bg-muted focus-visible:bg-muted flex w-full cursor-pointer items-center gap-2 rounded-lg border p-2 text-left outline-none"
+                onclick={() => select(account)}
+              >
+                <Polycon
+                  value={account.id.toHex()}
+                  size={36}
+                  class="shrink-0 overflow-hidden rounded-md"
+                />
+                <span class="flex min-w-0 flex-1 flex-col">
+                  <span class="truncate text-sm font-medium">{account.name}</span>
+                  <span class="text-muted-foreground text-xs">
+                    {truncateAddress(account.id.toChecksum())}
                   </span>
-                </button>
-              {/each}
-            </div>
+                </span>
+                {#if removeMode}
+                  <X class="text-destructive size-4 shrink-0" aria-hidden="true" />
+                {:else if signedOut(account)}
+                  <Badge>Signed out</Badge>
+                {/if}
+              </button>
+            {/each}
+
+            <Button
+              variant="outline"
+              size="sm"
+              class="w-full"
+              onclick={() => (removeMode = !removeMode)}
+            >
+              {#if removeMode}
+                Done
+              {:else}
+                <UserRoundMinus />
+                Remove an account
+              {/if}
+            </Button>
+            <Button variant="outline" size="sm" class="w-full" onclick={startAdding}>
+              <UserRoundPlus />
+              Add an account
+            </Button>
+          </div>
+        {:else}
+          <div class="flex w-full flex-col items-center gap-4">
+            <Button size="lg" class="w-full" href={resolve(routes.ACCOUNT_NEW)}>
+              Create a new account
+            </Button>
+            <Button
+              size="lg"
+              variant="secondary"
+              class="w-full"
+              href={resolve(routes.ACCOUNT_IMPORT)}
+            >
+              I already have an account
+            </Button>
           </div>
         {/if}
 
-        <div class="flex w-full flex-col items-center gap-4">
-          <Button
-            size="lg"
-            variant={accounts.length > 0 ? 'secondary' : 'default'}
-            class="w-full"
-            href={resolve(routes.ACCOUNT_NEW)}>Create a new account</Button
-          >
-          <Button
-            size="lg"
-            variant="secondary"
-            class="w-full"
-            href={resolve(routes.ACCOUNT_IMPORT)}
-          >
-            I already have an account
-          </Button>
-        </div>
-
-        <Button variant="ghost" size="xs" onclick={notImplemented}>WTF is Swarm ID?</Button>
+        <Button variant="ghost" size="xs" onclick={notImplemented}>What is Swarm ID?</Button>
       </div>
     {/if}
   </main>
 </div>
+
+{#if removing}
+  <Dialog onclose={() => (removing = undefined)} title="Remove {removing.name}?">
+    <p class="text-sm">
+      This removes the account from this device only. You can add it back by signing in with its
+      recovery phrase — without the phrase the account cannot be recovered.
+    </p>
+    <Button variant="destructive" class="w-full" onclick={confirmRemove}>Remove account</Button>
+  </Dialog>
+{/if}
 
 {#if unlocking}
   {#if pendingCeremony}

--- a/ui/src/routes/connect/+page.svelte
+++ b/ui/src/routes/connect/+page.svelte
@@ -327,9 +327,9 @@
   {:else}
     <Dialog onclose={closeDialog} title="Remove {removing.name}?">
       <p class="text-sm">
-        This removes the account from this device only. You can add it back by signing in with its
-        recovery phrase — without the phrase the account cannot be recovered. Unlock the account to
-        confirm.
+        This removes the account from this device only. You can sign back in anytime with its secret
+        recovery phrase — its drives and connected apps are recovered from Swarm. Without the
+        phrase, the account cannot be recovered. Unlock the account to confirm.
       </p>
 
       {#if removing.access.type === 'password'}

--- a/ui/src/routes/connect/+page.svelte
+++ b/ui/src/routes/connect/+page.svelte
@@ -11,7 +11,6 @@
   import LoaderCircle from '@lucide/svelte/icons/loader-circle'
   import UserRoundMinus from '@lucide/svelte/icons/user-round-minus'
   import UserRoundPlus from '@lucide/svelte/icons/user-round-plus'
-  import X from '@lucide/svelte/icons/x'
 
   import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'
@@ -40,10 +39,6 @@
   let dialogError = $state<string | undefined>(undefined)
   /** Bumped on cancel/retry — a stale ceremony resolution must not connect. */
   let attempt = 0
-  /** Rows become remove targets instead of connect choices. */
-  let removeMode = $state(false)
-  /** Account awaiting removal confirmation (unlock-gated, like account deletion). */
-  let removing = $state<Account | undefined>(undefined)
   /** Shows the create/import choice while other accounts exist on the device. */
   let addingAccount = $state(false)
 
@@ -88,13 +83,6 @@
     if (!request) {
       return
     }
-    if (removeMode) {
-      dialogError = undefined
-      password = ''
-      pendingCeremony = false
-      removing = account
-      return
-    }
     // A still-valid prior connection carries the secret — no unlock needed.
     if (reuseConnection(account, request)) {
       sessionStore.setCurrentAccount(account.id)
@@ -107,48 +95,7 @@
     unlocking = account
   }
 
-  async function confirmRemove() {
-    const account = removing
-    if (busy || !account) {
-      return
-    }
-    const myAttempt = ++attempt
-    dialogError = undefined
-    busy = true
-    if (account.access.type !== 'password') {
-      pendingCeremony = true
-    }
-    try {
-      // Re-authenticate as a confirmation gate before the destructive removal
-      // (the unlocked seed itself is discarded).
-      await unlockAccount(account, account.access.type === 'password' ? password : undefined)
-      if (myAttempt !== attempt) {
-        return
-      }
-      if (sessionStore.currentAccountId === account.id.toHex()) {
-        sessionStore.clearCurrentAccount()
-      }
-      accountsStore.remove(account.id)
-      removing = undefined
-      pendingCeremony = false
-      password = ''
-      if (accountsStore.accounts.length === 0) {
-        removeMode = false
-      }
-    } catch (caught) {
-      if (myAttempt === attempt) {
-        dialogError = caught instanceof Error ? caught.message : 'Unlock failed.'
-        pendingCeremony = false
-      }
-    } finally {
-      if (myAttempt === attempt) {
-        busy = false
-      }
-    }
-  }
-
   function startAdding() {
-    removeMode = false
     addingAccount = true
   }
 
@@ -190,10 +137,9 @@
 
   function closeDialog() {
     // Invalidate any in-flight ceremony — wallet prompts can't be aborted, so
-    // a later approval of a cancelled prompt must not connect (or remove).
+    // a later approval of a cancelled prompt must not connect.
     attempt++
     unlocking = undefined
-    removing = undefined
     pendingCeremony = false
     busy = false
     password = ''
@@ -256,26 +202,15 @@
                     {truncateAddress(account.id.toChecksum())}
                   </span>
                 </span>
-                {#if removeMode}
-                  <X class="text-destructive size-4 shrink-0" aria-hidden="true" />
-                {:else if signedOut(account)}
+                {#if signedOut(account)}
                   <Badge>Signed out</Badge>
                 {/if}
               </button>
             {/each}
 
-            <Button
-              variant="outline"
-              size="sm"
-              class="w-full"
-              onclick={() => (removeMode = !removeMode)}
-            >
-              {#if removeMode}
-                Done
-              {:else}
-                <UserRoundMinus />
-                Remove an account
-              {/if}
+            <Button variant="outline" size="sm" class="w-full" onclick={notImplemented}>
+              <UserRoundMinus />
+              Remove an account
             </Button>
             <Button variant="outline" size="sm" class="w-full" onclick={startAdding}>
               <UserRoundPlus />
@@ -304,70 +239,22 @@
   </main>
 </div>
 
-{#snippet ceremonyPending(accessType: string)}
-  <Dialog onclose={closeDialog} dismissable={false}>
-    <div class="flex flex-col items-center gap-2 py-4 text-center">
-      <LoaderCircle class="size-5 animate-spin" />
-      <p class="text-sm font-bold">
-        {accessType === 'eth-wallet' ? 'Confirm with wallet' : 'Confirm with passkey'}
-      </p>
-      <p class="text-sm">
-        {accessType === 'eth-wallet'
-          ? 'Approve the request in your Ethereum wallet.'
-          : 'Follow the prompts on your device.'}
-      </p>
-    </div>
-    <Button variant="outline" class="w-full" onclick={closeDialog}>Cancel</Button>
-  </Dialog>
-{/snippet}
-
-{#if removing}
-  {#if pendingCeremony}
-    {@render ceremonyPending(removing.access.type)}
-  {:else}
-    <Dialog onclose={closeDialog} title="Remove {removing.name}?">
-      <p class="text-sm">
-        This removes the account from this device only. You can sign back in anytime with its secret
-        recovery phrase — its drives and connected apps are recovered from Swarm. Without the
-        phrase, the account cannot be recovered. Unlock the account to confirm.
-      </p>
-
-      {#if removing.access.type === 'password'}
-        <Input
-          type="password"
-          bind:value={password}
-          placeholder="Account password"
-          autocomplete="current-password"
-          onkeydown={(event: KeyboardEvent) => event.key === 'Enter' && confirmRemove()}
-        />
-      {/if}
-
-      {#if dialogError}
-        <p class="text-destructive text-xs">{dialogError}</p>
-      {/if}
-
-      <Button
-        variant="destructive"
-        class="w-full"
-        disabled={busy || (removing.access.type === 'password' && password.length === 0)}
-        onclick={confirmRemove}
-      >
-        {#if busy}
-          <LoaderCircle class="animate-spin" />
-        {/if}
-        {removing.access.type === 'passkey'
-          ? 'Confirm with passkey'
-          : removing.access.type === 'eth-wallet'
-            ? 'Confirm with wallet'
-            : 'Remove account'}
-      </Button>
-    </Dialog>
-  {/if}
-{/if}
-
 {#if unlocking}
   {#if pendingCeremony}
-    {@render ceremonyPending(unlocking.access.type)}
+    <Dialog onclose={closeDialog} dismissable={false}>
+      <div class="flex flex-col items-center gap-2 py-4 text-center">
+        <LoaderCircle class="size-5 animate-spin" />
+        <p class="text-sm font-bold">
+          {unlocking.access.type === 'eth-wallet' ? 'Confirm with wallet' : 'Confirm with passkey'}
+        </p>
+        <p class="text-sm">
+          {unlocking.access.type === 'eth-wallet'
+            ? 'Approve the request in your Ethereum wallet.'
+            : 'Follow the prompts on your device.'}
+        </p>
+      </div>
+      <Button variant="outline" class="w-full" onclick={closeDialog}>Cancel</Button>
+    </Dialog>
   {:else}
     <Dialog onclose={closeDialog} title="Connect as {unlocking.name}">
       <p class="text-sm">

--- a/ui/src/routes/connect/+page.svelte
+++ b/ui/src/routes/connect/+page.svelte
@@ -42,7 +42,7 @@
   let attempt = 0
   /** Rows become remove targets instead of connect choices. */
   let removeMode = $state(false)
-  /** Account awaiting removal confirmation. */
+  /** Account awaiting removal confirmation (unlock-gated, like account deletion). */
   let removing = $state<Account | undefined>(undefined)
   /** Shows the create/import choice while other accounts exist on the device. */
   let addingAccount = $state(false)
@@ -89,6 +89,9 @@
       return
     }
     if (removeMode) {
+      dialogError = undefined
+      password = ''
+      pendingCeremony = false
       removing = account
       return
     }
@@ -104,18 +107,43 @@
     unlocking = account
   }
 
-  function confirmRemove() {
+  async function confirmRemove() {
     const account = removing
-    if (!account) {
+    if (busy || !account) {
       return
     }
-    if (sessionStore.currentAccountId === account.id.toHex()) {
-      sessionStore.clearCurrentAccount()
+    const myAttempt = ++attempt
+    dialogError = undefined
+    busy = true
+    if (account.access.type !== 'password') {
+      pendingCeremony = true
     }
-    accountsStore.remove(account.id)
-    removing = undefined
-    if (accountsStore.accounts.length === 0) {
-      removeMode = false
+    try {
+      // Re-authenticate as a confirmation gate before the destructive removal
+      // (the unlocked seed itself is discarded).
+      await unlockAccount(account, account.access.type === 'password' ? password : undefined)
+      if (myAttempt !== attempt) {
+        return
+      }
+      if (sessionStore.currentAccountId === account.id.toHex()) {
+        sessionStore.clearCurrentAccount()
+      }
+      accountsStore.remove(account.id)
+      removing = undefined
+      pendingCeremony = false
+      password = ''
+      if (accountsStore.accounts.length === 0) {
+        removeMode = false
+      }
+    } catch (caught) {
+      if (myAttempt === attempt) {
+        dialogError = caught instanceof Error ? caught.message : 'Unlock failed.'
+        pendingCeremony = false
+      }
+    } finally {
+      if (myAttempt === attempt) {
+        busy = false
+      }
     }
   }
 
@@ -162,9 +190,10 @@
 
   function closeDialog() {
     // Invalidate any in-flight ceremony — wallet prompts can't be aborted, so
-    // a later approval of a cancelled prompt must not connect.
+    // a later approval of a cancelled prompt must not connect (or remove).
     attempt++
     unlocking = undefined
+    removing = undefined
     pendingCeremony = false
     busy = false
     password = ''
@@ -275,32 +304,70 @@
   </main>
 </div>
 
-{#if removing}
-  <Dialog onclose={() => (removing = undefined)} title="Remove {removing.name}?">
-    <p class="text-sm">
-      This removes the account from this device only. You can add it back by signing in with its
-      recovery phrase — without the phrase the account cannot be recovered.
-    </p>
-    <Button variant="destructive" class="w-full" onclick={confirmRemove}>Remove account</Button>
+{#snippet ceremonyPending(accessType: string)}
+  <Dialog onclose={closeDialog} dismissable={false}>
+    <div class="flex flex-col items-center gap-2 py-4 text-center">
+      <LoaderCircle class="size-5 animate-spin" />
+      <p class="text-sm font-bold">
+        {accessType === 'eth-wallet' ? 'Confirm with wallet' : 'Confirm with passkey'}
+      </p>
+      <p class="text-sm">
+        {accessType === 'eth-wallet'
+          ? 'Approve the request in your Ethereum wallet.'
+          : 'Follow the prompts on your device.'}
+      </p>
+    </div>
+    <Button variant="outline" class="w-full" onclick={closeDialog}>Cancel</Button>
   </Dialog>
+{/snippet}
+
+{#if removing}
+  {#if pendingCeremony}
+    {@render ceremonyPending(removing.access.type)}
+  {:else}
+    <Dialog onclose={closeDialog} title="Remove {removing.name}?">
+      <p class="text-sm">
+        This removes the account from this device only. You can add it back by signing in with its
+        recovery phrase — without the phrase the account cannot be recovered. Unlock the account to
+        confirm.
+      </p>
+
+      {#if removing.access.type === 'password'}
+        <Input
+          type="password"
+          bind:value={password}
+          placeholder="Account password"
+          autocomplete="current-password"
+          onkeydown={(event: KeyboardEvent) => event.key === 'Enter' && confirmRemove()}
+        />
+      {/if}
+
+      {#if dialogError}
+        <p class="text-destructive text-xs">{dialogError}</p>
+      {/if}
+
+      <Button
+        variant="destructive"
+        class="w-full"
+        disabled={busy || (removing.access.type === 'password' && password.length === 0)}
+        onclick={confirmRemove}
+      >
+        {#if busy}
+          <LoaderCircle class="animate-spin" />
+        {/if}
+        {removing.access.type === 'passkey'
+          ? 'Confirm with passkey'
+          : removing.access.type === 'eth-wallet'
+            ? 'Confirm with wallet'
+            : 'Remove account'}
+      </Button>
+    </Dialog>
+  {/if}
 {/if}
 
 {#if unlocking}
   {#if pendingCeremony}
-    <Dialog onclose={closeDialog} dismissable={false}>
-      <div class="flex flex-col items-center gap-2 py-4 text-center">
-        <LoaderCircle class="size-5 animate-spin" />
-        <p class="text-sm font-bold">
-          {unlocking.access.type === 'eth-wallet' ? 'Confirm with wallet' : 'Confirm with passkey'}
-        </p>
-        <p class="text-sm">
-          {unlocking.access.type === 'eth-wallet'
-            ? 'Approve the request in your Ethereum wallet.'
-            : 'Follow the prompts on your device.'}
-        </p>
-      </div>
-      <Button variant="outline" class="w-full" onclick={closeDialog}>Cancel</Button>
-    </Dialog>
+    {@render ceremonyPending(unlocking.access.type)}
   {:else}
     <Dialog onclose={closeDialog} title="Connect as {unlocking.name}">
       <p class="text-sm">


### PR DESCRIPTION
Implements the connect-popup screen for the case where accounts already exist on the device, per the [Figma design](https://www.figma.com/design/RyprPgEZIeCoaqjTcKXGUo/SwarmID-MVP--Copy-?node-id=159-14450&m=dev) (frame 159-14450), replacing the previous tabs-based layout.

**Scope note:** the destructive account actions (sign out / remove / delete) are still being settled by the team — incl. whether deletion must dilute the batch — so **Remove an account is stubbed** with `notImplemented` here; the remove mode + confirmation land with that follow-up.

## What's included

- **Account list** — one bordered row per device account (identicon, name, truncated address), ordered by most recent connection to the requesting app; never-connected accounts keep their stored order. Selection behavior is unchanged: a still-valid session reconnects instantly, otherwise the unlock dialog (password / passkey / ETH wallet) opens.
- **"Signed out" badge** — shown on accounts that were previously connected to this app but whose session lapsed (expired or revoked), signalling that reconnecting will ask for an unlock. Backed by a new `hasReusableConnection` helper in `connect-handshake.ts` (shared with `reuseConnection`).
- **Remove an account** — button per the design, stubbed `notImplemented` (see scope note).
- **Add an account** — swaps the list for the create/import choice (the same view a device with no accounts gets), with a back button to return to the list.
- Ghost-button label updated to the design's **"What is Swarm ID?"** (was "WTF is Swarm ID?").

The no-request and no-accounts states, the unlock ceremony, and `/connect/done` are unchanged.

## Testing

- `pnpm check:all` green across packages.
- Exercised in-browser against the dev server with real accounts created through the setup flow: instant reconnect (valid session), unlock with wrong + correct password, add-account view and back, badge + ordering, Remove an account alerts not-implemented; light and dark themes; no console errors.

## Screens

**Connect — accounts on device (badge on lapsed session)**

![Connect with accounts](https://raw.githubusercontent.com/snaha/swarm-id/pr-429-assets/connect/01-connect-accounts.png)

**Add an account**

![Add an account](https://raw.githubusercontent.com/snaha/swarm-id/pr-429-assets/connect/02-add-account.png)

**Unlock to connect**

![Unlock dialog](https://raw.githubusercontent.com/snaha/swarm-id/pr-429-assets/connect/03-unlock-dialog.png)

**Dark mode**

![Dark mode](https://raw.githubusercontent.com/snaha/swarm-id/pr-429-assets/connect/04-connect-accounts-dark.png)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
