### PR TITLE
fix(sync): reuse lock generation on lease refresh

### DIFF
--- a/lib/src/sync/partition-lease.integration.test.ts
+++ b/lib/src/sync/partition-lease.integration.test.ts
@@ -2614,6 +2614,41 @@ describe("PartitionLease.acquire — holder presence beacons (gateway holder-exi
     // DEVICE_A is the earlier holder → keeps the lease.
     expect(await lease.refresh()).toBe("held")
   })
+
+  it("refresh keeps the earlier claimant's lease across an ADVANCING clock (issue #413)", async () => {
+    // The frozen-clock test above passes even with the bug because a re-minted
+    // generation lands on the SAME timestamp. Under a real advancing clock, a
+    // refresh that re-mints its generation stamps a LATER timestamp than the
+    // rightful first claimant ever had — inverting claim order so the first
+    // claimant wrongly yields. This test advances the clock across the tick.
+    let clock = NOW
+    const lease = makeLease({
+      deviceId: DEVICE_A,
+      bee: bee as unknown as Bee,
+      now: () => clock,
+      knownDeviceIds: () => [DEVICE_A, DEVICE_B],
+      intentReadTimeoutMs: 50,
+    })
+    expect(
+      (await lease.acquire({ partitionCount: PARTITION_COUNT })).partition,
+    ).toBe(0)
+
+    // DEVICE_B dual-acquired LATER than DEVICE_A (generation NOW + 1000): its
+    // beacon must always order after DEVICE_A's, so DEVICE_A keeps the lease.
+    await writeBeacon({
+      partition: 0,
+      deviceId: DEVICE_B,
+      epochBucket: intentEpochBucket(NOW),
+      leasedUntil: NOW + LEASE_TTL_MS,
+      genTimestamp: NOW + 1000,
+    })
+
+    // A refresh tick later (still the same epoch bucket). With the bug, refresh
+    // re-mints generation NOW + 5000 > B's NOW + 1000, so B now orders first and
+    // DEVICE_A is displaced. With the fix the generation stays NOW → still "held".
+    clock = NOW + 5000
+    expect(await lease.refresh()).toBe("held")
+  })
 })
 
 describe("PartitionLease.refresh — occupancy displacement vs a PRUNED peer", () => {

--- a/lib/src/sync/partition-lease.ts
+++ b/lib/src/sync/partition-lease.ts
@@ -915,6 +915,10 @@ export class PartitionLease {
       deviceId: this.opts.deviceId,
       ttlMs: LEASE_TTL_MS,
       guardMs: this.opts.guardMs ?? PARTITION_LOCK_GUARD_MS,
+      // Reuse the held claim's generation — it identifies the claim SESSION.
+      // Re-minting a fresh generation each tick stamps a later timestamp than
+      // the rightful first claimant, inverting claim order (issue #413).
+      generation: this.self.generation,
       now: () => this.now(),
       // A release closes the lease session; a refresh that overlaps it must
       // not mint a fresh ghost claim — the generation-fenced release would

--- a/lib/src/sync/partition-lock.ts
+++ b/lib/src/sync/partition-lock.ts
@@ -307,15 +307,17 @@ export async function acquirePartitionLock(opts: {
   if (verified.holderDeviceId !== opts.deviceId) {
     return { outcome: "acquired", payload: ourPayload }
   }
-  // Our own claim, read back at a generation OLDER than the one we just wrote:
-  // the gateway served a frozen cached copy of the lock SOC. Trust the fresh
-  // claim we wrote — otherwise a self-refresh silently keeps the stale
-  // leasedUntil, the lease never extends, and the holder believes it holds
-  // while peers see it expire and take the slot (a dual-acquire).
-  if (compareGenerations(verified.generation, ourGeneration) < 0) {
-    return { outcome: "acquired", payload: ourPayload }
+  // Our own claim, read back at our generation — or an OLDER frozen-cache copy
+  // of it. Refresh now REUSES the claim's generation (issue #413), so a stale
+  // gateway read of a prior tick compares EQUAL, not older; keying on `< 0`
+  // alone would let it through with a stale `leasedUntil`, silently stalling
+  // the lease (the holder believes it holds while peers see it expire and take
+  // the slot — a dual-acquire). Trust the freshest lease we know either way.
+  return {
+    outcome: "acquired",
+    payload:
+      verified.leasedUntil >= ourPayload.leasedUntil ? verified : ourPayload,
   }
-  return { outcome: "acquired", payload: verified }
 }
 
 /**


### PR DESCRIPTION
## Problem

`PartitionLease.refresh()` called `acquirePartitionLock` **without** a `generation`, so `partition-lock.ts` minted a fresh `{ timestampMs, tiebreaker }` on every ~10s tick. The deconfliction design treats `generation` as the identity of the **claim session** — re-minting it each tick inverts claim order:

- A claims at T0, B dual-acquires at T0+1s. A's refresh at T0+10s mints a *later* generation, so B's older beacon now orders first → the rightful first claimant yields.
- Both channels read current+previous epoch buckets, so each holder's stale beacon orders before the other's fresh mint → **both** return `"displaced"` (mutual-demotion churn).

Every existing lease/lock test freezes the clock (`now: () => NOW`), producing identical timestamps that masked the bug.

## Fix

- **`partition-lease.ts`** — `refresh()` passes `generation: this.self.generation`, reusing the claim session.
- **`partition-lock.ts`** — with a reused generation, a stale frozen-cache verify-read compares **EQUAL** (not older), so the old `< 0` guard no longer caught it. The own-claim branch now returns the **fresher-`leasedUntil`** payload, else the lease would silently stop extending.

## Tests

- New advancing-clock lease test asserts the earlier claimant stays `"held"` across a refresh tick (fails before the fix with `"displaced"`, passes after).
- Full lib unit suite: 906/906.
- Live gateway suite (`test:live`): `partition-acquire-3` + `three-device-acquire-handoff`, 8/8 — the real advancing-clock counterpart the mocks can't provide.

Part of #217. Closes #413.

🤖 Generated with [Claude Code](https://claude.com/claude-code)