### PR TITLE
fix(sync): publish state pointer after its referenced chunks

### DIFF
--- a/lib/src/sync/partition-state.test.ts
+++ b/lib/src/sync/partition-state.test.ts
@@ -57,7 +57,20 @@ vi.mock("../chunk", async (importOriginal) => {
   }
 })
 
+// Wrap the real upload module so partition-state's own bindings resolve to these
+// spies (default behaviour passes through to the real round-trip). A test can
+// then fail a single chunk PUT and assert the pointer SOC never lands.
+vi.mock("../proxy/upload", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../proxy/upload")>()
+  return {
+    ...actual,
+    uploadData: vi.fn(actual.uploadData),
+    uploadSOC: vi.fn(actual.uploadSOC),
+  }
+})
+
 import { statePointerAddress, writePartitionState } from "./partition-state"
+import { uploadData, uploadSOC } from "../proxy/upload"
 import {
   intentEpochBucket,
   partitionOccupancyAddress,
@@ -228,6 +241,38 @@ describe("writePartitionState — distinct-bucket invariant guard", () => {
     // Every reserved-slot write lands at (bucket, slot=PARTITION); the parallel
     // publish is only race-free because those buckets are all distinct.
     expect(new Set(stateBuckets).size).toBe(stateBuckets.length)
+  })
+})
+
+describe("writePartitionState — two-phase publish (pointer after chunks)", () => {
+  it("does not write the state pointer when a chunk PUT fails", async () => {
+    const stamper = await makeBoundStamper()
+    const localCounter = new Uint32Array(NUM_BUCKETS)
+    localCounter[1000] = 1
+
+    // Fail the first counter-chunk PUT. The pointer must NOT land: a durable
+    // pointer referencing chunks Bee never stored bricks every future takeover
+    // (readFailed → read-only until batch expiry), since there is no
+    // older-pointer fallback. See #414.
+    vi.mocked(uploadData).mockRejectedValueOnce(new Error("chunk PUT failed"))
+    vi.mocked(uploadSOC).mockClear()
+
+    await expect(
+      writePartitionState({
+        bee: bee as unknown as Bee,
+        stamper,
+        batchId: TEST_BATCH_ID,
+        batchDepth: TEST_BATCH_DEPTH,
+        partition: PARTITION,
+        localCounter,
+        backupSigner: BACKUP_SIGNER,
+        swarmEncryptionKey: TEST_ENC_KEY,
+        deviceId: DEVICE_ID,
+      }),
+    ).rejects.toThrow()
+
+    // Two-phase: the pointer SOC is written ONLY after every chunk PUT acks.
+    expect(uploadSOC).not.toHaveBeenCalled()
   })
 })
 

--- a/lib/src/sync/partition-state.ts
+++ b/lib/src/sync/partition-state.ts
@@ -852,7 +852,7 @@ export async function writePartitionState(opts: {
   // so a counter/reference chunk sharing one of their buckets would evict — or
   // be evicted by — them under Bee's newer-stamp-wins replacement. Exclude their
   // buckets (current + previous epoch, covering the rotation boundary):
-  //  - the state-pointer SOC this publish writes in the same Promise.all below
+  //  - the state-pointer SOC this publish writes (phase 2 below)
   //    (an intra-publish self-collision otherwise);
   //  - the deviceId-independent occupancy beacon, and (when known) this device's
   //    intent beacon, both re-written off-lock by the refresh tick concurrently.
@@ -932,12 +932,17 @@ export async function writePartitionState(opts: {
     )
   }
 
-  // One batch: dirty counter chunks + the reference chunk + the state-pointer
-  // SOC (at the current rotating bucket, naming the COMPUTED reference-chunk
-  // ref). All addresses are known up front, so they land together; the caller
-  // awaits all before acking (ack-after-publish).
+  // TWO-PHASE PUBLISH (#414). Phase 1: the dirty counter chunks + the reference
+  // chunk. Phase 2 (only after ALL of phase 1 acks): the state-pointer SOC that
+  // NAMES the reference chunk. The pointer must never become durable before the
+  // chunks it references — with `deferred: false` a chunk PUT can fail while the
+  // pointer PUT succeeds; if the holder then crashes, every takeover finds the
+  // fresh pointer, fails to read its missing chunk(s) → `readFailed` → read-only
+  // with no older-pointer fallback (stuck until batch expiry). Ordering the
+  // pointer after the chunk acks costs one extra round-trip and closes that gap:
+  // a failed chunk PUT rejects phase 1 before any pointer is written.
   //
-  // CONCURRENCY: these PUTs share one `stamper`. They are safe to fire in
+  // CONCURRENCY: the phase-1 PUTs share one `stamper`. They are safe to fire in
   // parallel ONLY because (a) every chunk here lands in a DISTINCT bucket
   // (`claimedBuckets` above guarantees it) and (b) the reserved-slot `stamp()`
   // branches set `stamper.buckets[bucket]` and call `stamp()` with NO await
@@ -957,17 +962,17 @@ export async function writePartitionState(opts: {
       encryptionKey: refPicked.key,
       deferred: false,
     }),
-    writeStatePointer({
-      bee,
-      stamper,
-      backupSigner,
-      swarmEncryptionKey,
-      batchId,
-      partition,
-      referenceHex,
-      nowMs: now,
-    }),
   ])
+  await writeStatePointer({
+    bee,
+    stamper,
+    backupSigner,
+    swarmEncryptionKey,
+    batchId,
+    partition,
+    referenceHex,
+    nowMs: now,
+  })
 
   // Diagnostic (visible in the browser console): how many chunks this publish
   // actually wrote — counter chunks + the reference chunk + the pointer SOC —


### PR DESCRIPTION
## Problem

`writePartitionState` fired the counter chunks, the reference chunk, **and** `writeStatePointer` in one `Promise.all`. With `deferred: false`, a counter/reference chunk PUT can fail while the pointer PUT succeeds. If the holder then crashes, every future takeover finds the freshest pointer, fails to read its referenced chunks → `readFailed` → read-only. There is no older-pointer fallback (deliberate), so the partition is stuck read-only until batch expiry.

## Fix

Two-phase publish: `await` the counter + reference chunk PUTs, **then** write the pointer. A failed chunk PUT now rejects before any pointer lands. Costs one extra round-trip on the ack path.

## Test (TDD)

`partition-state.test.ts` — mocks `uploadData` to fail one chunk PUT and asserts the pointer SOC (`uploadSOC`) is never written. Red before the fix, green after.

## Verification

- `pnpm --filter @snaha/swarm-id test` (sync suite): 255 passed
- Full live suite (`pnpm test:live`, public gateway): **9 files / 24 tests passed**, including the three-device B→C→B handoff cycle — confirms the reordered pointer still lands and is readable by taking-over devices.

Closes #414. Part of #217.

🤖 Generated with [Claude Code](https://claude.com/claude-code)