### PR TITLE
fix(lib): don't treat read failures as a free slot in feed finder and roster

### DIFF
--- a/lib/src/proxy/feeds/sequence/finder.test.ts
+++ b/lib/src/proxy/feeds/sequence/finder.test.ts
@@ -1,0 +1,101 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest"
+import { Binary } from "cafe-utility"
+import { EthAddress, Topic } from "@ethersphere/bee-js"
+import { SyncSequentialFinder } from "./finder"
+
+const OWNER = new EthAddress("a".repeat(40))
+
+// Replicate the module-private address derivation so the fake bee can reverse-map
+// a requested chunk address back to its sequence index.
+function addrForIndex(topic: Topic, index: bigint): string {
+  const indexBytes = Binary.numberToUint64(index, "BE")
+  const identifier = Binary.keccak256(
+    Binary.concatBytes(topic.toUint8Array(), indexBytes),
+  )
+  const address = Binary.keccak256(
+    Binary.concatBytes(identifier, OWNER.toUint8Array()),
+  )
+  return Binary.uint8ArrayToHex(address)
+}
+
+// Bee's /chunks endpoint returns 500 for a genuinely-absent chunk, so a miss is
+// a 500 here (NOT a 404). A transient failure is indistinguishable by status.
+function notFound500(): Error {
+  return Object.assign(new Error("read chunk failed"), { status: 500 })
+}
+
+/**
+ * Fake bee serving sequential SOCs. `present` indices resolve; `failTimes` maps
+ * an index to how many leading reads throw before it resolves (models a
+ * transient blip on an existing chunk). Missing indices always throw.
+ */
+function fakeBee(opts: {
+  topic: Topic
+  present: Set<number>
+  failTimes?: Map<number, number>
+}): { downloads: number; bee: unknown } {
+  const addrToIndex = new Map<string, number>()
+  for (let i = 0; i < 64; i++)
+    addrToIndex.set(addrForIndex(opts.topic, BigInt(i)), i)
+  const calls = new Map<number, number>()
+  const state = { downloads: 0 }
+  const bee = {
+    downloadChunk: async (hex: string) => {
+      state.downloads++
+      const index = addrToIndex.get(hex.toLowerCase())
+      if (index === undefined) throw notFound500()
+      const n = (calls.get(index) ?? 0) + 1
+      calls.set(index, n)
+      const fails = opts.failTimes?.get(index) ?? 0
+      if (n <= fails) throw notFound500()
+      if (!opts.present.has(index)) throw notFound500()
+      return new Uint8Array(32)
+    },
+  }
+  return {
+    get downloads() {
+      return state.downloads
+    },
+    bee,
+  }
+}
+
+describe("SyncSequentialFinder — retry-then-conclude (anti-clobber)", () => {
+  it("reads a contiguous feed and returns the tail index", async () => {
+    const topic = Topic.fromString("seq-a")
+    const { bee } = fakeBee({ topic, present: new Set([0, 1, 2]) })
+    const finder = new SyncSequentialFinder(bee as never, topic, OWNER)
+    const result = await finder.findAt(0n)
+    expect(result.current).toBe(2n)
+    expect(result.next).toBe(3n)
+  })
+
+  it("treats a slot that fails once then succeeds as PRESENT (not a free slot)", async () => {
+    // Index 1 blips on its first read. Without the retry, the scan would stop at
+    // 1 and hand back next=1, clobbering the existing entry there. With retry it
+    // recovers and continues to the true tail.
+    const topic = Topic.fromString("seq-b")
+    const { bee } = fakeBee({
+      topic,
+      present: new Set([0, 1, 2]),
+      failTimes: new Map([[1, 1]]),
+    })
+    const finder = new SyncSequentialFinder(bee as never, topic, OWNER)
+    const result = await finder.findAt(0n)
+    expect(result.next).toBe(3n)
+  })
+
+  it("concludes a slot free only after BOTH reads fail (exactly two reads)", async () => {
+    const topic = Topic.fromString("seq-c")
+    const fake = fakeBee({ topic, present: new Set() }) // empty feed
+    const finder = new SyncSequentialFinder(fake.bee as never, topic, OWNER)
+    const result = await finder.findAt(0n)
+    expect(result.current).toBeUndefined()
+    expect(result.next).toBe(0n)
+    // index 0 read twice (initial + one retry) before concluding free.
+    expect(fake.downloads).toBe(2)
+  })
+})

--- a/lib/src/proxy/feeds/sequence/finder.ts
+++ b/lib/src/proxy/feeds/sequence/finder.ts
@@ -62,15 +62,28 @@ export class SyncSequentialFinder implements SequentialFinder {
     const identifier = makeSequentialIdentifier(this.topic, index)
     const address = makeSequentialAddress(identifier, this.owner)
 
-    try {
-      await this.bee.downloadChunk(
-        Binary.uint8ArrayToHex(address.toUint8Array()),
-        undefined,
-        requestOptions,
-      )
-      return true
-    } catch {
-      return false
+    // Bee's /chunks endpoint returns 500 ("read chunk failed") for a genuinely
+    // absent chunk — indistinguishable by status from a transient 500 — so a
+    // single failed read can't tell "free slot" from "blip on an existing entry".
+    // Retry once; conclude the slot is free only if BOTH reads fail. This narrows
+    // the window where a transient failure lets an append clobber a peer's roster
+    // entry. We can't rethrow on failure (absence has no distinct signal here), so
+    // the scan must still terminate on a persistent miss.
+    // ponytail: single retry — matches readPartitionSoc; add backoff/more attempts
+    // only if real gateways prove one insufficient.
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        await this.bee.downloadChunk(
+          Binary.uint8ArrayToHex(address.toUint8Array()),
+          undefined,
+          requestOptions,
+        )
+        return true
+      } catch {
+        if (attempt === 0) continue
+        return false
+      }
     }
+    return false
   }
 }

--- a/lib/src/proxy/feeds/sequence/roundtrip.test.ts
+++ b/lib/src/proxy/feeds/sequence/roundtrip.test.ts
@@ -577,7 +577,8 @@ describe("Sequential Feeds Integration", () => {
       // Finder should return undefined, not crash
       const result = await finder.findAt(0n, 0n)
       expect(result.current).toBeUndefined()
-      expect(countingBee.downloadCalls).toBe(1) // Only tried index 0
+      // Index 0 only, read twice (initial + one retry before concluding free).
+      expect(countingBee.downloadCalls).toBe(2)
     })
 
     it("should handle mixed error types", async () => {
@@ -613,8 +614,8 @@ describe("Sequential Feeds Integration", () => {
       const result = await finder.findAt(0n, 0n)
       expect(result.current).toBe(2n)
       expect(result.next).toBe(3n)
-      // Should have probed indices 0, 1, 2, 3 (where 3 returns 404)
-      expect(countingBee.downloadCalls).toBe(4)
+      // Probes 0,1,2 (present) then 3 twice (miss + one retry) = 5.
+      expect(countingBee.downloadCalls).toBe(5)
     })
 
     it("should handle empty payload gracefully", async () => {
@@ -798,8 +799,8 @@ describe("Sequential Feeds Integration", () => {
         const result = await finder.findAt(0n, 0n)
 
         expect(result.current).toBe(BigInt(updateCount - 1))
-        // Linear scan should probe exactly updateCount + 1 times (0 to 100 inclusive, where 100 is 404)
-        expect(countingBee.downloadCalls).toBe(updateCount + 1)
+        // Probes 0..99 (present) then 100 twice (miss + one retry) = updateCount + 2.
+        expect(countingBee.downloadCalls).toBe(updateCount + 2)
       },
     )
 

--- a/lib/src/sync/device-roster.test.ts
+++ b/lib/src/sync/device-roster.test.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, it, expect, vi, beforeEach } from "vitest"
-import { EthAddress } from "@ethersphere/bee-js"
+import { EthAddress, PrivateKey } from "@ethersphere/bee-js"
 import type { Device } from "../schemas"
 
 // readRosterEntry downloads the device blob via downloadDataWithChunkAPI; mock it
@@ -12,7 +12,13 @@ vi.mock("../proxy/download-data", () => ({
   downloadDataWithChunkAPI: (...args: unknown[]) => mockDownloadData(...args),
 }))
 
-import { readRoster, rosterTopic, rosterIdentifier } from "./device-roster"
+import {
+  readRoster,
+  ensureInRoster,
+  RosterScanInconclusiveError,
+  rosterTopic,
+  rosterIdentifier,
+} from "./device-roster"
 
 const OWNER = new EthAddress("a".repeat(40))
 const ACCOUNT_ID = "b".repeat(40)
@@ -34,6 +40,19 @@ function refForIndex(index: number): Uint8Array {
   return ref
 }
 
+// Bee's /soc endpoint returns a real 404 for an absent single-owner chunk — the
+// only signal that a roster slot is genuinely empty (end-of-feed).
+function notFound404(): Error {
+  return Object.assign(new Error("requested chunk cannot be retrieved"), {
+    status: 404,
+  })
+}
+
+// A 5xx is a transient/inconclusive read, NOT a confirmed-empty slot.
+function serverError500(): Error {
+  return Object.assign(new Error("internal error"), { status: 500 })
+}
+
 /**
  * Fake Bee that serves roster SOCs ONLY for `presentIndices`. Reverse-maps the
  * requested identifier back to its index via `rosterIdentifier`, so the windowed
@@ -50,7 +69,7 @@ function fakeBee(presentIndices: Set<number>) {
       download: async (identifier: { toHex(): string }) => {
         const index = identToIndex.get(identifier.toHex())
         if (index === undefined || !presentIndices.has(index)) {
-          throw new Error("empty slot")
+          throw notFound404()
         }
         return { payload: { toUint8Array: () => refForIndex(index) } }
       },
@@ -138,6 +157,8 @@ function fakeBeeWithSlow(opts: {
   present: Set<number>
   slowOnce?: number
   alwaysSlow?: number
+  serverErrorOnce?: number
+  alwaysServerError?: number
 }): { readCount: number; bee: unknown } {
   const topic = rosterTopic(ACCOUNT_ID)
   const identToIndex = new Map<string, number>()
@@ -150,14 +171,21 @@ function fakeBeeWithSlow(opts: {
     makeSOCReader: () => ({
       download: (identifier: { toHex(): string }) => {
         const index = identToIndex.get(identifier.toHex())
-        if (index === undefined) throw new Error("empty slot")
+        if (index === undefined) throw notFound404()
         state.readCount++
         const n = (calls.get(index) ?? 0) + 1
         calls.set(index, n)
         if (index === opts.alwaysSlow) return new Promise(() => {}) // never settles
         if (index === opts.slowOnce && n === 1) return new Promise(() => {})
-        const present = opts.present.has(index) || index === opts.slowOnce
-        if (!present) throw new Error("empty slot") // clean miss → end of feed
+        // A 5xx is inconclusive, like a timeout — the scan must not read it as
+        // a confirmed-empty slot.
+        if (index === opts.alwaysServerError) throw serverError500()
+        if (index === opts.serverErrorOnce && n === 1) throw serverError500()
+        const present =
+          opts.present.has(index) ||
+          index === opts.slowOnce ||
+          index === opts.serverErrorOnce
+        if (!present) throw notFound404() // clean 404 → end of feed
         return Promise.resolve({
           payload: { toUint8Array: () => refForIndex(index) },
         })
@@ -217,16 +245,39 @@ describe("readRoster — a timed-out read is not end-of-feed", () => {
     expect(devices.some((d) => d.deviceId === "dev-16")).toBe(true)
   })
 
-  it("stops (bounded, one retry) when a slot times out on both the read and the retry", async () => {
+  it("throws when index 0 times out on both the read and the retry (nothing folded)", async () => {
+    // Index 0 inconclusive on both attempts, zero devices folded: an empty roster
+    // and an outage are indistinguishable, so surface it rather than return [].
     const { bee } = fakeBeeWithSlow({ present: new Set(), alwaysSlow: 0 })
     const promise = readRoster({
       bee: bee as never,
       accountId: ACCOUNT_ID,
       owner: OWNER,
     })
+    // Attach the rejection assertion before advancing timers so the rejection is
+    // handled (no unhandled-rejection noise).
+    const assertion = expect(promise).rejects.toBeInstanceOf(
+      RosterScanInconclusiveError,
+    )
     await vi.advanceTimersByTimeAsync(ROSTER_READ_TIMEOUT_MS) // first read
     await vi.advanceTimersByTimeAsync(ROSTER_READ_TIMEOUT_MS) // the one retry
-    expect(await promise).toEqual([])
+    await assertion
+  })
+
+  it("treats a 5xx like a timeout: retries and does NOT truncate the tail", async () => {
+    // Window 0 (0..15) full + index 16 present-but-500-once in window 1. A 5xx is
+    // inconclusive (not a confirmed-empty slot), so the retry recovers dev-16
+    // instead of reading window 1 as end-of-feed.
+    const present = new Set<number>()
+    for (let i = 0; i <= 15; i++) present.add(i)
+    const { bee } = fakeBeeWithSlow({ present, serverErrorOnce: 16 })
+    const devices = await readRoster({
+      bee: bee as never,
+      accountId: ACCOUNT_ID,
+      owner: OWNER,
+    })
+    expect(devices).toHaveLength(17)
+    expect(devices.some((d) => d.deviceId === "dev-16")).toBe(true)
   })
 
   it("does not retry a cleanly-empty window (clean 404s stop the scan immediately)", async () => {
@@ -243,5 +294,62 @@ describe("readRoster — a timed-out read is not end-of-feed", () => {
     expect(devices).toHaveLength(16)
     // 16 (window 0) + 16 (window 1, all clean miss → stop). No retry round.
     expect(fake.readCount).toBe(32)
+  })
+})
+
+describe("readRoster / ensureInRoster — inconclusive is not empty", () => {
+  beforeEach(() => {
+    mockDownloadData.mockReset()
+    mockDownloadData.mockImplementation((_bee: unknown, refHex: string) => {
+      const index = parseInt(refHex.slice(0, 2), 16)
+      return new TextEncoder().encode(JSON.stringify(makeDevice(index)))
+    })
+  })
+
+  it("throws (not []) when index 0 is persistently inconclusive", async () => {
+    // A 5xx on every read of index 0 can't be told apart from an outage — the
+    // roster is unknown, not empty. Returning [] would let a caller conclude
+    // "no devices" and clobber; instead the scan surfaces the ambiguity.
+    const { bee } = fakeBeeWithSlow({
+      present: new Set(),
+      alwaysServerError: 0,
+    })
+    await expect(
+      readRoster({ bee: bee as never, accountId: ACCOUNT_ID, owner: OWNER }),
+    ).rejects.toBeInstanceOf(RosterScanInconclusiveError)
+  })
+
+  it("still returns [] for a genuinely empty roster (clean 404 at index 0)", async () => {
+    const bee = fakeBee(new Set())
+    await expect(
+      readRoster({ bee: bee as never, accountId: ACCOUNT_ID, owner: OWNER }),
+    ).resolves.toEqual([])
+  })
+
+  it("ensureInRoster skips the append when the roster read is inconclusive", async () => {
+    // downloadChunk is the sequential finder's read inside appendToRoster. If
+    // ensureInRoster wrongly treated the failed read as "device absent", it would
+    // start the append and hit downloadChunk. Skipping means it never does.
+    const downloadChunk = vi.fn(async () => {
+      throw serverError500()
+    })
+    const bee = {
+      makeSOCReader: () => ({
+        download: async () => {
+          throw serverError500()
+        },
+      }),
+      downloadChunk,
+    }
+    await ensureInRoster({
+      bee: bee as never,
+      accountKey: new PrivateKey("11".repeat(32)),
+      owner: OWNER,
+      encryptionKey: "00".repeat(32),
+      accountId: ACCOUNT_ID,
+      device: makeDevice(0),
+      target: { mode: "stamper" } as never,
+    })
+    expect(downloadChunk).not.toHaveBeenCalled()
   })
 })

--- a/lib/src/sync/device-roster.ts
+++ b/lib/src/sync/device-roster.ts
@@ -40,7 +40,8 @@ import {
 } from "../proxy/feeds/sequence"
 import { uploadData, type UploadTarget } from "../proxy/upload"
 import { downloadDataWithChunkAPI } from "../proxy/download-data"
-import { TimeoutError, withTimeout } from "../utils/promise"
+import { withTimeout } from "../utils/promise"
+import { isNotFoundError } from "../utils/bee-error"
 import { SYNC_READ_TIMEOUT_MS } from "./timing-constants"
 import { mergeDevicesList } from "./merge-snapshot"
 
@@ -57,20 +58,31 @@ const ROSTER_SCAN_WINDOW = 16
 
 // Per-read cap so an empty/unreachable slot on a slow gateway fails fast instead
 // of hanging on peer-exhaustion. A present slot retrieves well under this.
-// Matches the epoch finder's bound. A timed-out read is INCONCLUSIVE (not a
-// confirmed empty slot): `readRosterEntry` surfaces it as `ROSTER_READ_TIMED_OUT`
-// so `readRoster` retries it once at the stop boundary rather than mistaking it
-// for end-of-feed and truncating the roster.
+// Matches the epoch finder's bound. An inconclusive read (timeout / 5xx /
+// network) is NOT a confirmed empty slot: `readRosterEntry` surfaces it as
+// `ROSTER_READ_INCONCLUSIVE` so `readRoster` retries it once at the stop boundary
+// rather than mistaking it for end-of-feed and truncating the roster.
 const ROSTER_READ_TIMEOUT_MS = SYNC_READ_TIMEOUT_MS
 
 /**
- * Sentinel for a roster slot whose read TIMED OUT — distinct from `undefined`
- * (a clean miss / garbage blob). A timeout is inconclusive: the slot may well
- * hold a live device the slow gateway just couldn't return in time, so the scan
- * must not treat it as end-of-feed.
+ * Sentinel for a roster slot whose read was INCONCLUSIVE — a timeout, a 5xx, or
+ * a network error, as opposed to a clean 404 (`undefined`, a genuinely empty
+ * slot). An inconclusive read may hide a live device the gateway just couldn't
+ * return, so the scan must not treat it as end-of-feed. Only Bee's `/soc` 404
+ * confirms a slot is empty.
  */
-const ROSTER_READ_TIMED_OUT = Symbol("roster-read-timed-out")
-type RosterReadResult = Device | undefined | typeof ROSTER_READ_TIMED_OUT
+const ROSTER_READ_INCONCLUSIVE = Symbol("roster-read-inconclusive")
+type RosterReadResult = Device | undefined | typeof ROSTER_READ_INCONCLUSIVE
+
+/** Thrown by {@link readRoster} when it cannot distinguish an empty roster from
+ *  an outage (index 0 stays inconclusive after the retry, nothing folded).
+ *  Callers must NOT treat this as "no devices" — see {@link ensureInRoster}. */
+export class RosterScanInconclusiveError extends Error {
+  constructor() {
+    super("roster scan inconclusive: cannot confirm the roster is empty")
+    this.name = "RosterScanInconclusiveError"
+  }
+}
 
 export function rosterTopic(accountId: string): Topic {
   return Topic.fromString(`${ROSTER_TOPIC_PREFIX}:${accountId}`)
@@ -85,10 +97,10 @@ export function rosterIdentifier(topic: Topic, index: bigint): Identifier {
 
 /**
  * Read one roster entry (the device record) at `index`. Returns the `Device`
- * when present, `undefined` for a clean miss / garbage blob (a confirmed-empty
- * slot — the scan's stop signal), or {@link ROSTER_READ_TIMED_OUT} when the
- * read timed out (INCONCLUSIVE — the slot may hold a live device the slow
- * gateway couldn't return, so the scan must not stop on it).
+ * when present, `undefined` for a clean 404 / garbage blob (a confirmed-empty
+ * slot — the scan's stop signal), or {@link ROSTER_READ_INCONCLUSIVE} when the
+ * read was inconclusive (timeout / 5xx / network — the slot may hold a live
+ * device the gateway couldn't return, so the scan must not stop on it).
  */
 async function readRosterEntry(opts: {
   bee: Bee
@@ -106,23 +118,28 @@ async function readRosterEntry(opts: {
     )
     refBytes = soc.payload.toUint8Array()
   } catch (error) {
-    return error instanceof TimeoutError ? ROSTER_READ_TIMED_OUT : undefined
+    // Bee's `/soc` returns a clean 404 for a genuinely-absent slot (end-of-feed);
+    // a timeout / 5xx / network error is inconclusive (retried at the stop
+    // boundary) — NOT a confirmed empty slot.
+    return isNotFoundError(error) ? undefined : ROSTER_READ_INCONCLUSIVE
   }
+  // Split the blob download from the parse: a download failure is a read outcome
+  // (404 = empty, else = inconclusive), whereas a parse failure is a genuinely
+  // garbage blob (the SOC resolved) — a skippable hole `readRoster` folds around.
+  let data: Uint8Array
   try {
-    const data = await withTimeout(
+    data = await withTimeout(
       downloadDataWithChunkAPI(opts.bee, new Reference(refBytes).toHex()),
       ROSTER_READ_TIMEOUT_MS,
       "roster read timed out",
     )
-    return DeviceSchemaV1.parse(JSON.parse(new TextDecoder().decode(data)))
   } catch (error) {
-    // A timeout here is inconclusive (retried at the stop boundary). Otherwise
-    // the SOC was reachable but the blob is unretrievable/garbage: return
-    // `undefined` like an empty slot — `readRoster` treats a hole inside an
-    // otherwise-present window as a transient (skippable) read failure (the
-    // caching-gateway case this roster exists to survive) and only stops on a
-    // fully-empty window.
-    return error instanceof TimeoutError ? ROSTER_READ_TIMED_OUT : undefined
+    return isNotFoundError(error) ? undefined : ROSTER_READ_INCONCLUSIVE
+  }
+  try {
+    return DeviceSchemaV1.parse(JSON.parse(new TextDecoder().decode(data)))
+  } catch {
+    return undefined
   }
 }
 
@@ -155,18 +172,18 @@ export async function readRoster(opts: {
         readRosterEntry({ bee: opts.bee, topic, owner: opts.owner, index }),
       ),
     )
-    // A window with no present entry is a stop candidate — but a timed-out read
-    // is inconclusive (a slow gateway may have hidden a live device). Retry just
-    // the timed-out slots ONCE before concluding end-of-feed, so a transiently
-    // slow tail window doesn't truncate the roster. Bounded to one extra partial
-    // read; a still-timed-out slot reconciles on the next sync.
+    // A window with no present entry is a stop candidate — but an inconclusive
+    // read (timeout / 5xx) may have hidden a live device. Retry just the
+    // inconclusive slots ONCE before concluding end-of-feed, so a transiently
+    // flaky tail window doesn't truncate the roster. Bounded to one extra partial
+    // read; a still-inconclusive slot reconciles on the next sync.
     if (
       !entries.some(isDevice) &&
-      entries.some((entry) => entry === ROSTER_READ_TIMED_OUT)
+      entries.some((entry) => entry === ROSTER_READ_INCONCLUSIVE)
     ) {
       entries = await Promise.all(
         indices.map((index, i) =>
-          entries[i] === ROSTER_READ_TIMED_OUT
+          entries[i] === ROSTER_READ_INCONCLUSIVE
             ? readRosterEntry({
                 bee: opts.bee,
                 topic,
@@ -180,16 +197,27 @@ export async function readRoster(opts: {
     for (const entry of entries) {
       if (isDevice(entry)) devices = mergeDevicesList(devices, [entry])
     }
-    // Stop on a window with no present entry (clean end-of-feed, or one whose
-    // timeouts survived the retry — bounded, the slow slot reconciles later).
-    if (!entries.some(isDevice)) break
+    // Stop on a window with no present entry. If that window is still
+    // inconclusive after the retry AND we have folded nothing, we cannot tell an
+    // empty roster from an outage — surface it rather than lie "[] = no devices",
+    // which a caller could act on and clobber. A truncated but non-empty read is
+    // the existing bounded behaviour (reconciles next sync).
+    if (!entries.some(isDevice)) {
+      if (
+        devices.length === 0 &&
+        entries.some((entry) => entry === ROSTER_READ_INCONCLUSIVE)
+      ) {
+        throw new RosterScanInconclusiveError()
+      }
+      break
+    }
   }
   return devices
 }
 
-/** Narrow a roster read to a present device (not a miss or a timeout). */
+/** Narrow a roster read to a present device (not a miss or an inconclusive read). */
 function isDevice(entry: RosterReadResult): entry is Device {
-  return entry !== undefined && entry !== ROSTER_READ_TIMED_OUT
+  return entry !== undefined && entry !== ROSTER_READ_INCONCLUSIVE
 }
 
 /** Append one device record at the next free index. Each device writes only its own. */
@@ -241,13 +269,20 @@ export async function ensureInRoster(opts: {
   device: Device
   target: UploadTarget
 }): Promise<void> {
-  const existing = (
-    await readRoster({
+  // If the roster read is inconclusive we cannot tell "device absent" from "read
+  // failed" — skip rather than append on a guess (an append would compute its
+  // index against the same failing feed and could clobber a peer's entry).
+  let roster: Device[]
+  try {
+    roster = await readRoster({
       bee: opts.bee,
       accountId: opts.accountId,
       owner: opts.owner,
-    }).catch(() => [] as Device[])
-  ).find((d) => d.deviceId === opts.device.deviceId)
+    })
+  } catch {
+    return
+  }
+  const existing = roster.find((d) => d.deviceId === opts.device.deviceId)
 
   const upToDate =
     existing !== undefined &&

--- a/lib/src/utils/bee-error.ts
+++ b/lib/src/utils/bee-error.ts
@@ -1,0 +1,26 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+const NOT_FOUND = 404
+
+/**
+ * True only for a definitive "chunk absent" — an HTTP 404, as Bee's `/soc`
+ * endpoint returns for a missing single-owner chunk (`BeeResponseError.status`).
+ * A timeout / 5xx / network error is INCONCLUSIVE, not a confirmed miss.
+ *
+ * NOTE: Bee's `/chunks` endpoint returns **500** ("read chunk failed") for an
+ * absent chunk, so this predicate is usable for the roster `/soc` existence read
+ * but NOT for the `/chunks`-based feed finders — there, absence and a transient
+ * server error are indistinguishable by status.
+ */
+export function isNotFoundError(error: unknown): boolean {
+  if (typeof error === "object" && error !== null) {
+    const status = (error as { status?: unknown }).status
+    if (status === NOT_FOUND) return true
+    // A real, non-404 numeric status (e.g. 500) is a server error, not a miss —
+    // decide on it and never fall through to the message text.
+    if (typeof status === "number") return false
+  }
+  const message = error instanceof Error ? error.message : String(error)
+  return /404|not found/i.test(message) // fallback for message-only mocks/wrappers
+}


### PR DESCRIPTION
## Problem

Several read paths collapsed *"the read failed"* (timeout / 5xx / offline) into *"the slot is empty"*, reopening the **dual-acquire** hole this machinery exists to prevent: under a transient outage a device could overwrite a peer's roster entry (`appendToRoster` picks a too-low index) or read an existing feed as empty.

## Verified premise correction

The issue prescribed "distinguish a clean 404", but a live probe of **Bee 2.7.1** shows the two endpoints differ for a genuinely-absent target:

| Read | endpoint | absent returns |
| --- | --- | --- |
| Feed finders (`downloadChunk`) | `GET /chunks/{addr}` | **500** `read chunk failed` (local cluster) / 404 (some gateways) |
| Roster SOC existence | `GET /soc/{owner}/{id}` | **404** `requested chunk cannot be retrieved` |

So a 404 check is valid only for the roster `/soc` read; on `/chunks` absence and a transient 500 are indistinguishable by status. The fix matches this reality.

## Changes

- **`SyncSequentialFinder.indexExists`** — retry-then-conclude: only call a slot free when **both** reads fail (mirrors `readPartitionSoc`). Backend-agnostic, never throws (scans must still terminate). Narrows the window where a blip lets an append clobber a peer.
- **`device-roster.ts`** — the `/soc` existence read now treats a clean **404** as empty and **5xx/timeout/network** as inconclusive (was: everything-but-timeout → "confirmed empty"). Sentinel renamed `ROSTER_READ_INCONCLUSIVE`; blob download split from parse. `readRoster` throws `RosterScanInconclusiveError` when it can't tell an empty roster from an outage, and `ensureInRoster` **skips the append** on it.
- **`utils/bee-error.ts`** (new) — `isNotFoundError`, keyed on `BeeResponseError.status`.
- Epoch finder left unchanged (absent=500 there makes a 404 check inapplicable — out of scope).

## Tests (TDD)

- New `sequence/finder.test.ts` (anti-clobber retry), 4 new roster tests (5xx-inconclusive, throw-on-outage, `ensureInRoster` skip, empty-roster still `[]`), fakes updated to emit real 404-shaped misses, download-count expectations bumped for the terminal retry.
- **Unit:** full lib suite 912/912 green; `pnpm check:all` clean.
- **Live:** `pnpm test:live` against a real remote Bee — **9 files / 24 tests passed** (~19 min), covering multi-device acquire, per-device sync, and rename-clobber.

Closes #415

🤖 Generated with [Claude Code](https://claude.com/claude-code)