### PR TITLE
fix(lib): arm init-timeout timers in initialize(), not the constructor

### DIFF
--- a/lib/src/swarm-id-client.test.ts
+++ b/lib/src/swarm-id-client.test.ts
@@ -245,3 +245,65 @@ describe("SwarmIdClient connectionInfo", () => {
     )
   })
 })
+
+describe("SwarmIdClient init-timeout timers (#421)", () => {
+  // A distinctive value so the init timers are identifiable by delay.
+  const INIT_TIMEOUT = 12345
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.stubGlobal("window", {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      parent: { postMessage: vi.fn() },
+      location: { origin: "https://localhost" },
+      open: vi.fn(),
+    })
+    vi.stubGlobal("document", {
+      createElement: vi.fn().mockReturnValue({
+        style: {},
+        onload: null,
+        onerror: null,
+        src: "",
+        contentWindow: { postMessage: vi.fn() },
+      }),
+      body: { appendChild: vi.fn(), removeChild: vi.fn() },
+    })
+  })
+
+  function makeClient(): SwarmIdClient {
+    return new SwarmIdClient({
+      iframeOrigin: "https://swarm-id.example.com",
+      metadata: { name: "Test App", description: "A test application" },
+      initializationTimeout: INIT_TIMEOUT,
+    })
+  }
+
+  it("arms no init-timeout timer at construction", () => {
+    const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout")
+    makeClient()
+    const initTimers = setTimeoutSpy.mock.calls.filter(
+      ([, ms]) => ms === INIT_TIMEOUT,
+    )
+    expect(initTimers).toHaveLength(0)
+  })
+
+  it("does not reject an init timeout when never initialized", async () => {
+    vi.useFakeTimers()
+    try {
+      const rejections: unknown[] = []
+      const onUnhandled = (reason: unknown) => rejections.push(reason)
+      process.on("unhandledRejection", onUnhandled)
+
+      makeClient()
+      await vi.advanceTimersByTimeAsync(INIT_TIMEOUT + 100)
+      // Let any microtask-queued rejection surface.
+      await Promise.resolve()
+
+      process.off("unhandledRejection", onUnhandled)
+      expect(rejections).toHaveLength(0)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/lib/src/swarm-id-client.ts
+++ b/lib/src/swarm-id-client.ts
@@ -137,7 +137,7 @@ export class SwarmIdClient {
   private containerId?: string
   private subsidisedGatewayUrl?: string
   private ready: boolean = false
-  private readyPromise: Promise<void>
+  private readyPromise: Promise<void> | undefined
   private readyResolve?: () => void
   private readyReject?: (error: Error) => void
   private pendingRequests: Map<
@@ -151,7 +151,7 @@ export class SwarmIdClient {
   > = new Map()
   private requestIdCounter = 0
   private messageListener: ((event: MessageEvent) => void) | undefined
-  private proxyInitializedPromise: Promise<void>
+  private proxyInitializedPromise: Promise<void> | undefined
   private proxyInitializedResolve?: () => void
   private proxyInitializedReject?: (error: Error) => void
 
@@ -198,42 +198,12 @@ export class SwarmIdClient {
       throw new Error(`Invalid app metadata: ${error}`)
     }
 
-    // Create promise that resolves when iframe is ready
-    this.readyPromise = new Promise<void>((resolve, reject) => {
-      this.readyResolve = resolve
-      this.readyReject = reject
-
-      // Timeout if proxy doesn't respond
-      setTimeout(() => {
-        reject(
-          new Error(
-            `Proxy initialization timeout - proxy did not respond within ${this.initializationTimeout}ms`,
-          ),
-        )
-      }, this.initializationTimeout)
-    })
-
-    // Note: `firstConnectionInfoPromise` (and its timeout) is created in
-    // `initialize()`, not here — starting the timer at construction would
-    // make it expire on consumers that instantiate the client and call
-    // `initialize()` later (or never, in tests).
-
-    // Create promise for proxyInitialized message
-    this.proxyInitializedPromise = new Promise<void>((resolve, reject) => {
-      this.proxyInitializedResolve = resolve
-      this.proxyInitializedReject = reject
-
-      // Timeout if proxy doesn't send proxyInitialized
-      setTimeout(() => {
-        if (this.proxyInitializedReject) {
-          this.proxyInitializedReject(
-            new Error(
-              `Proxy initialization timeout - proxy did not signal readiness within ${this.initializationTimeout}ms`,
-            ),
-          )
-        }
-      }, this.initializationTimeout)
-    })
+    // Note: `readyPromise`, `proxyInitializedPromise`, and
+    // `firstConnectionInfoPromise` (with their timeouts) are all created in
+    // `initialize()`, not here — starting the timers at construction would
+    // make them expire on consumers that instantiate the client and call
+    // `initialize()` later (or never, in tests), and leak an armed timer plus
+    // an unguarded rejection in the meantime.
 
     this.setupMessageListener()
   }
@@ -293,6 +263,30 @@ export class SwarmIdClient {
     // The original promise is still rejected; the `await` on line 359 will
     // re-throw it normally.
     this.firstConnectionInfoPromise.catch(() => {})
+
+    // Same deferred+timeout pattern for the proxyReady handshake and the
+    // iframe-ready signal: created here (not the constructor) so the timers
+    // start when init begins and `withTimeout` clears them on settle. The
+    // stashed resolve/reject are invoked later from `handleIframeMessage`.
+    this.proxyInitializedPromise = withTimeout(
+      new Promise<void>((resolve, reject) => {
+        this.proxyInitializedResolve = resolve
+        this.proxyInitializedReject = reject
+      }),
+      this.initializationTimeout,
+      `Proxy initialization timeout - proxy did not signal readiness within ${this.initializationTimeout}ms`,
+    )
+    this.proxyInitializedPromise.catch(() => {})
+
+    this.readyPromise = withTimeout(
+      new Promise<void>((resolve, reject) => {
+        this.readyResolve = resolve
+        this.readyReject = reject
+      }),
+      this.initializationTimeout,
+      `Proxy initialization timeout - proxy did not respond within ${this.initializationTimeout}ms`,
+    )
+    this.readyPromise.catch(() => {})
 
     // Create iframe for proxy
     this.iframe = document.createElement("iframe")
@@ -3213,6 +3207,19 @@ export class SwarmIdClient {
       this.iframe.parentNode.removeChild(this.iframe)
       this.iframe = undefined
     }
+
+    // Reject any still-pending init deferreds so their `withTimeout` timers
+    // clear now instead of lingering the full initializationTimeout. The
+    // `.catch(() => {})` guards attached in initialize() keep these from
+    // surfacing as unhandled when nothing is awaiting.
+    this.readyReject?.(new Error("Client destroyed"))
+    this.proxyInitializedReject?.(new Error("Client destroyed"))
+    this.readyResolve = undefined
+    this.readyReject = undefined
+    this.proxyInitializedResolve = undefined
+    this.proxyInitializedReject = undefined
+    this.readyPromise = undefined
+    this.proxyInitializedPromise = undefined
 
     this.ready = false
   }


### PR DESCRIPTION
## Problem
`readyPromise` and `proxyInitializedPromise` armed their 30s rejection timers in the **constructor**. Consequences:
- Constructing a client >30s before calling `initialize()` guaranteed a timeout failure — the clock started at construction.
- A constructed-but-never-initialized client emitted a global `unhandledrejection` after 30s (nothing `.catch`es a promise nobody awaits yet).
- The timers never cleared on success or in `destroy()`, leaking a live timer + closure for the full 30s.

## Fix
Move both deferreds into `initialize()`, built with the `withTimeout` helper — the same pattern already used for `firstConnectionInfoPromise`. `withTimeout` clears the timer on settle, and a `.catch(() => {})` guard prevents spurious unhandled rejections. `destroy()` now rejects any still-pending deferreds so their timers clear immediately instead of lingering.

Root cause behind the unhelpful "proxy initialization timeout" in #246.

## Tests
TDD, both written failing-first:
- no init-timeout timer is armed at construction (was 2),
- a never-initialized client raises no unhandled rejection after the timeout (was 2).

Full `lib/` suite (911 tests) and typecheck pass.

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)