### PR TITLE
feat(ui): sign-out flow for synced accounts

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -357,6 +357,7 @@ export {
   AccessMethodSchemaV1,
   PostageStampSchemaV1,
   isLocalAccount,
+  isSignedOutAccount,
 } from "./schemas"
 
 // Base validation schemas and types

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -137,7 +137,7 @@ export {
   createAccountsStorageManager,
   createNetworkSettingsStorageManager,
   serializeAccount,
-  serializeAccountData,
+  serializeSyncedAccount,
   serializeConnectedApp,
   serializePostageStamp,
   serializeNetworkSettings,
@@ -227,7 +227,7 @@ export {
   ensureInRoster,
   ROSTER_TOPIC_PREFIX,
   foldAccountFromSwarm,
-  foldedToAccountData,
+  foldedToSyncedAccount,
 } from "./sync"
 
 // State sync types
@@ -338,7 +338,10 @@ export type {
 export type {
   Device,
   Account,
-  AccountData,
+  SyncedAccount,
+  SignedInAccount,
+  SignedOutAccount,
+  LocalVault,
   AccessMethod,
   ConnectedApp,
   PostageStamp,
@@ -352,8 +355,9 @@ export {
   DEFAULT_BEE_NODE_URL,
   DEFAULT_GNOSIS_RPC_URL,
   NetworkSettingsSchemaV1,
-  AccountSchemaV1,
-  AccountDataSchemaV1,
+  LocalAccountSchemaV1,
+  SyncedAccountSchemaV1,
+  LocalVaultSchemaV1,
   AccessMethodSchemaV1,
   PostageStampSchemaV1,
   isLocalAccount,

--- a/lib/src/schemas.test.ts
+++ b/lib/src/schemas.test.ts
@@ -1,15 +1,22 @@
 // Copyright 2026 The Swarm Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import { describe, it, expect } from "vitest"
+import { describe, it, expect, expectTypeOf } from "vitest"
 import { BatchId, PrivateKey } from "@ethersphere/bee-js"
-import { AccountSchemaV1, isLocalAccount, isSignedOutAccount } from "./schemas"
+import {
+  LocalAccountSchemaV1,
+  isLocalAccount,
+  isSignedOutAccount,
+  type AccessMethod,
+  type Account,
+} from "./schemas"
 import {
   TEST_BATCH_ID_HEX,
   TEST_BATCH_ID_2_HEX,
   TEST_PRIVATE_KEY_HEX,
   TEST_PUBLIC_KEY_HEX,
   createAccount,
+  createSignedOutAccount,
   createPostageStamp,
 } from "./test-fixtures"
 
@@ -76,10 +83,11 @@ describe("isLocalAccount", () => {
   })
 })
 
-describe("AccountSchemaV1 encryptedSeed", () => {
-  // A serialized (plain-string) account — the wire shape AccountSchemaV1 parses,
-  // before its transforms produce bee-js runtime types. Only `encryptedSeed`
-  // varies; the array fields default to [] so they can be omitted.
+describe("LocalAccountSchemaV1 encryptedSeed", () => {
+  // A serialized (plain-string) account — the wire shape LocalAccountSchemaV1
+  // parses, before its transforms produce bee-js runtime types. Only
+  // `encryptedSeed` varies; the array fields default to [] so they can be
+  // omitted.
   function serializedAccount(encryptedSeed: string) {
     return {
       id: "a".repeat(40),
@@ -98,7 +106,7 @@ describe("AccountSchemaV1 encryptedSeed", () => {
   // constraint itself: valid even-length hex passes, everything else is rejected.
   it("accepts a valid even-length hex value", () => {
     expect(
-      AccountSchemaV1.safeParse(serializedAccount("aabbccdd")).success,
+      LocalAccountSchemaV1.safeParse(serializedAccount("aabbccdd")).success,
     ).toBe(true)
   })
 
@@ -109,12 +117,12 @@ describe("AccountSchemaV1 encryptedSeed", () => {
     ["uppercase hex", "AABB"],
   ])("rejects %s", (_label, encryptedSeed) => {
     expect(
-      AccountSchemaV1.safeParse(serializedAccount(encryptedSeed)).success,
+      LocalAccountSchemaV1.safeParse(serializedAccount(encryptedSeed)).success,
     ).toBe(false)
   })
 })
 
-describe("AccountSchemaV1 signed-out vault consistency", () => {
+describe("LocalAccountSchemaV1 signed-in/signed-out union", () => {
   // Same wire shape as above; the vault group (`access` + `encryptedSeed` +
   // `signedOutAt`) varies per case.
   function serializedAccount(vault: Record<string, unknown>) {
@@ -134,14 +142,16 @@ describe("AccountSchemaV1 signed-out vault consistency", () => {
   }
 
   it("accepts a signed-out record: no vault, signedOutAt set", () => {
-    const result = AccountSchemaV1.safeParse(
+    const result = LocalAccountSchemaV1.safeParse(
       serializedAccount({ signedOutAt: 1700000000001 }),
     )
     expect(result.success).toBe(true)
   })
 
   it("rejects a record with neither vault nor signedOutAt", () => {
-    expect(AccountSchemaV1.safeParse(serializedAccount({})).success).toBe(false)
+    expect(LocalAccountSchemaV1.safeParse(serializedAccount({})).success).toBe(
+      false,
+    )
   })
 
   it.each([
@@ -149,13 +159,13 @@ describe("AccountSchemaV1 signed-out vault consistency", () => {
     ["encryptedSeed", { encryptedSeed: VAULT.encryptedSeed }],
   ])("rejects a signed-in record missing %s", (_label, partialVault) => {
     expect(
-      AccountSchemaV1.safeParse(serializedAccount(partialVault)).success,
+      LocalAccountSchemaV1.safeParse(serializedAccount(partialVault)).success,
     ).toBe(false)
   })
 
   it("rejects a signed-out record that retains vault fields", () => {
     expect(
-      AccountSchemaV1.safeParse(
+      LocalAccountSchemaV1.safeParse(
         serializedAccount({ ...VAULT, signedOutAt: 1700000000001 }),
       ).success,
     ).toBe(false)
@@ -164,15 +174,23 @@ describe("AccountSchemaV1 signed-out vault consistency", () => {
 
 describe("isSignedOutAccount", () => {
   it("is signed out when the vault is absent", () => {
-    const account = createAccount({
-      access: undefined,
-      encryptedSeed: undefined,
-      signedOutAt: 1700000000001,
-    })
-    expect(isSignedOutAccount(account)).toBe(true)
+    expect(isSignedOutAccount(createSignedOutAccount())).toBe(true)
   })
 
   it("is signed in while the vault is present", () => {
     expect(isSignedOutAccount(createAccount({}))).toBe(false)
+  })
+
+  // The point of the union model: the guard narrows, so the signed-in branch
+  // sees non-optional vault fields and the signed-out branch a non-optional
+  // `signedOutAt` — no `!`/`??` juggling at call sites.
+  it("narrows each union variant", () => {
+    const account: Account = createSignedOutAccount()
+    if (isSignedOutAccount(account)) {
+      expectTypeOf(account.signedOutAt).toEqualTypeOf<number>()
+    } else {
+      expectTypeOf(account.access).toEqualTypeOf<AccessMethod>()
+      expectTypeOf(account.encryptedSeed).toEqualTypeOf<string>()
+    }
   })
 })

--- a/lib/src/schemas.test.ts
+++ b/lib/src/schemas.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, it, expect } from "vitest"
 import { BatchId, PrivateKey } from "@ethersphere/bee-js"
-import { AccountSchemaV1, isLocalAccount } from "./schemas"
+import { AccountSchemaV1, isLocalAccount, isSignedOutAccount } from "./schemas"
 import {
   TEST_BATCH_ID_HEX,
   TEST_BATCH_ID_2_HEX,
@@ -111,5 +111,68 @@ describe("AccountSchemaV1 encryptedSeed", () => {
     expect(
       AccountSchemaV1.safeParse(serializedAccount(encryptedSeed)).success,
     ).toBe(false)
+  })
+})
+
+describe("AccountSchemaV1 signed-out vault consistency", () => {
+  // Same wire shape as above; the vault group (`access` + `encryptedSeed` +
+  // `signedOutAt`) varies per case.
+  function serializedAccount(vault: Record<string, unknown>) {
+    return {
+      id: "a".repeat(40),
+      name: "Test Account",
+      createdAt: 1700000000000,
+      derivationKey: "f".repeat(64),
+      publicKey: TEST_PUBLIC_KEY_HEX,
+      ...vault,
+    }
+  }
+
+  const VAULT = {
+    access: { type: "password", kdfSalt: "00", kdfIterations: 100000 },
+    encryptedSeed: "aabbccdd",
+  }
+
+  it("accepts a signed-out record: no vault, signedOutAt set", () => {
+    const result = AccountSchemaV1.safeParse(
+      serializedAccount({ signedOutAt: 1700000000001 }),
+    )
+    expect(result.success).toBe(true)
+  })
+
+  it("rejects a record with neither vault nor signedOutAt", () => {
+    expect(AccountSchemaV1.safeParse(serializedAccount({})).success).toBe(false)
+  })
+
+  it.each([
+    ["access", { access: VAULT.access }],
+    ["encryptedSeed", { encryptedSeed: VAULT.encryptedSeed }],
+  ])("rejects a signed-in record missing %s", (_label, partialVault) => {
+    expect(
+      AccountSchemaV1.safeParse(serializedAccount(partialVault)).success,
+    ).toBe(false)
+  })
+
+  it("rejects a signed-out record that retains vault fields", () => {
+    expect(
+      AccountSchemaV1.safeParse(
+        serializedAccount({ ...VAULT, signedOutAt: 1700000000001 }),
+      ).success,
+    ).toBe(false)
+  })
+})
+
+describe("isSignedOutAccount", () => {
+  it("is signed out when the vault is absent", () => {
+    const account = createAccount({
+      access: undefined,
+      encryptedSeed: undefined,
+      signedOutAt: 1700000000001,
+    })
+    expect(isSignedOutAccount(account)).toBe(true)
+  })
+
+  it("is signed in while the vault is present", () => {
+    expect(isSignedOutAccount(createAccount({}))).toBe(false)
   })
 })

--- a/lib/src/schemas.ts
+++ b/lib/src/schemas.ts
@@ -250,14 +250,16 @@ const AccountObjectSchemaV1 = z.object({
   // Device-local seed vault. Every account is a BIP-39 seed account: `access`
   // records how the seed is protected/unlocked on this device (passkey /
   // eth-wallet / password) and `encryptedSeed` is that seed encrypted at rest.
-  // Device-local: deliberately excluded from the sync snapshot. Absent only on
-  // a signed-out account (`signedOutAt` set) — the refinement on
-  // `AccountSchemaV1` enforces the pairing.
+  // Device-local: deliberately excluded from the sync snapshot. Optional
+  // because a signed-out account has no vault — but note the TYPE does not
+  // pair the three vault fields (they are independently optional); writers
+  // must keep them consistent themselves, and `AccountSchemaV1`'s refinement
+  // only quarantines an inconsistent record at load time (it is skipped, not
+  // repaired).
   access: AccessMethodSchemaV1.optional(),
   // BIP-39 entropy encrypted with the access-method key (hex: IV || ciphertext).
-  // Non-empty, even-length hex — never blank while signed in. Width varies with
-  // the seed size (12-word seed → 88 chars, 24-word → 120), so it is not a
-  // fixed length.
+  // Non-empty, even-length hex whenever present. Width varies with the seed
+  // size (12-word seed → 88 chars, 24-word → 120), so it is not a fixed length.
   encryptedSeed: z
     .string()
     .regex(/^([0-9a-f]{2})+$/)
@@ -265,7 +267,8 @@ const AccountObjectSchemaV1 = z.object({
   // Set when the user signed this account out on THIS device: the seed vault
   // (`access` + `encryptedSeed`) was wiped, but the account row stays so the
   // user can see it and sign back in (recovery phrase + new access method).
-  // Device-local like the vault itself — excluded from sync/backup projections.
+  // Device-local like the vault itself — excluded from the `AccountData`
+  // projection that backup files and the sync feed serialize.
   signedOutAt: z.number().optional(),
   defaultPostageStampBatchID: StoredBatchId.optional(),
   devices: z.array(DeviceSchemaV1).default([]),
@@ -298,10 +301,13 @@ const AccountObjectSchemaV1 = z.object({
 
 /**
  * Parse entrypoint for stored account records: the base object plus the
- * vault-consistency invariant — a signed-in account (no `signedOutAt`) always
- * carries BOTH vault fields, a signed-out one carries NEITHER. Keeps the
- * "never blank" guarantee for signed-in accounts now that the fields are
- * schema-optional.
+ * vault-consistency check — a signed-in account (no `signedOutAt`) carries
+ * BOTH vault fields, a signed-out one carries NEITHER. This only validates at
+ * parse (load) time: writes are not checked, and the accounts loader SKIPS a
+ * violating record rather than failing the document — so writers (account
+ * creation, `signOut`, `setAccess`) are responsible for keeping the trio
+ * consistent; this refinement is the backstop that keeps a corrupt record
+ * from loading as a half-signed-out account.
  */
 export const AccountSchemaV1 = AccountObjectSchemaV1.superRefine(
   (account, ctx) => {

--- a/lib/src/schemas.ts
+++ b/lib/src/schemas.ts
@@ -234,8 +234,12 @@ export const AccessMethodSchemaV1 = z.discriminatedUnion("type", [
  * after an explicit permission/signing request. The account OWNS its connected
  * apps and postage stamps as nested collections rather than via foreign-key
  * pointers.
+ *
+ * Unrefined base object: `AccountSchemaV1` (the parse entrypoint) adds the
+ * vault-consistency refinement, and `AccountDataSchemaV1` derives from this via
+ * `.omit` (object methods and refinements don't compose).
  */
-export const AccountSchemaV1 = z.object({
+const AccountObjectSchemaV1 = z.object({
   id: StoredEthAddress,
   name: z.string(),
   createdAt: z.number(),
@@ -246,12 +250,23 @@ export const AccountSchemaV1 = z.object({
   // Device-local seed vault. Every account is a BIP-39 seed account: `access`
   // records how the seed is protected/unlocked on this device (passkey /
   // eth-wallet / password) and `encryptedSeed` is that seed encrypted at rest.
-  // Device-local: deliberately excluded from the sync snapshot.
-  access: AccessMethodSchemaV1,
+  // Device-local: deliberately excluded from the sync snapshot. Absent only on
+  // a signed-out account (`signedOutAt` set) — the refinement on
+  // `AccountSchemaV1` enforces the pairing.
+  access: AccessMethodSchemaV1.optional(),
   // BIP-39 entropy encrypted with the access-method key (hex: IV || ciphertext).
-  // Non-empty, even-length hex — never blank. Width varies with the seed size
-  // (12-word seed → 88 chars, 24-word → 120), so it is not a fixed length.
-  encryptedSeed: z.string().regex(/^([0-9a-f]{2})+$/),
+  // Non-empty, even-length hex — never blank while signed in. Width varies with
+  // the seed size (12-word seed → 88 chars, 24-word → 120), so it is not a
+  // fixed length.
+  encryptedSeed: z
+    .string()
+    .regex(/^([0-9a-f]{2})+$/)
+    .optional(),
+  // Set when the user signed this account out on THIS device: the seed vault
+  // (`access` + `encryptedSeed`) was wiped, but the account row stays so the
+  // user can see it and sign back in (recovery phrase + new access method).
+  // Device-local like the vault itself — excluded from sync/backup projections.
+  signedOutAt: z.number().optional(),
   defaultPostageStampBatchID: StoredBatchId.optional(),
   devices: z.array(DeviceSchemaV1).default([]),
   // Account-owned nested collections (replace the old flat identities/apps/
@@ -282,15 +297,47 @@ export const AccountSchemaV1 = z.object({
 })
 
 /**
- * The portable projection of the account — everything except the device-local
- * seed vault (`access` + `encryptedSeed`). This is the single definition of
- * what travels off the device: backup files serialize/parse it directly, and
- * the sync feed carries the same shape. Serialize with `serializeAccountData`,
- * which additionally strips the live per-app session material.
+ * Parse entrypoint for stored account records: the base object plus the
+ * vault-consistency invariant — a signed-in account (no `signedOutAt`) always
+ * carries BOTH vault fields, a signed-out one carries NEITHER. Keeps the
+ * "never blank" guarantee for signed-in accounts now that the fields are
+ * schema-optional.
  */
-export const AccountDataSchemaV1 = AccountSchemaV1.omit({
+export const AccountSchemaV1 = AccountObjectSchemaV1.superRefine(
+  (account, ctx) => {
+    const hasVault =
+      account.access !== undefined && account.encryptedSeed !== undefined
+    if (account.signedOutAt === undefined && !hasVault) {
+      ctx.addIssue({
+        code: "custom",
+        message:
+          "Signed-in account must have both access and encryptedSeed set",
+      })
+    }
+    if (
+      account.signedOutAt !== undefined &&
+      (account.access !== undefined || account.encryptedSeed !== undefined)
+    ) {
+      ctx.addIssue({
+        code: "custom",
+        message: "Signed-out account must not retain its seed vault",
+      })
+    }
+  },
+)
+
+/**
+ * The portable projection of the account — everything except the device-local
+ * seed vault (`access` + `encryptedSeed`) and its sign-out marker
+ * (`signedOutAt`). This is the single definition of what travels off the
+ * device: backup files serialize/parse it directly, and the sync feed carries
+ * the same shape. Serialize with `serializeAccountData`, which additionally
+ * strips the live per-app session material.
+ */
+export const AccountDataSchemaV1 = AccountObjectSchemaV1.omit({
   access: true,
   encryptedSeed: true,
+  signedOutAt: true,
 })
 
 // ============================================================================
@@ -384,6 +431,16 @@ export function isLocalAccount(account: Account): boolean {
     stamp.usable &&
     stamp.deletedAt === undefined
   )
+}
+
+/**
+ * An account is "signed out" on this device when its seed vault has been
+ * wiped: no keys remain, so nothing can be unlocked or signed until the user
+ * signs back in with the recovery phrase (and sets a new access method). The
+ * vault absence itself is the source of truth; `signedOutAt` only records when.
+ */
+export function isSignedOutAccount(account: Account): boolean {
+  return account.access === undefined || account.encryptedSeed === undefined
 }
 
 // ============================================================================

--- a/lib/src/schemas.ts
+++ b/lib/src/schemas.ts
@@ -218,13 +218,36 @@ export const AccessMethodSchemaV1 = z.discriminatedUnion("type", [
 ])
 
 /**
- * Account Schema V1
+ * Local Vault Schema V1
+ *
+ * The device-local seed vault. Every account is a BIP-39 seed account: `access`
+ * records how the seed is protected/unlocked on THIS device (passkey /
+ * eth-wallet / password) and `encryptedSeed` is that seed encrypted at rest
+ * under the key the access method derives (hex: IV || ciphertext — width varies
+ * with the seed size: 12-word seed → 88 chars, 24-word → 120, so no fixed
+ * length). The vault never leaves the device: `SyncedAccountSchemaV1` has no
+ * vault fields, and a sign-out wipes the vault while the synced data lives on.
+ */
+export const LocalVaultSchemaV1 = z.object({
+  access: AccessMethodSchemaV1,
+  encryptedSeed: z.string().regex(/^([0-9a-f]{2})+$/),
+})
+
+/**
+ * Synced Account Schema V1
  *
  * The single, unified account model. There is exactly one kind of account: a
  * BIP-39 seed account. What used to be distinct `type`s (passkey / ethereum /
  * agent) were really just different ways of protecting the seed — now expressed
- * uniformly by the `access` method + `encryptedSeed` vault every account carries.
- * No `type` discriminant remains.
+ * uniformly by the device-local vault (`LocalVaultSchemaV1`). No `type`
+ * discriminant remains.
+ *
+ * This is the portable projection of the account — every field that may travel
+ * off the device, and nothing device-local. Backup files serialize/parse it
+ * directly and the sync feed carries the same shape (serialize with
+ * `serializeSyncedAccount`, which additionally strips the live per-app session
+ * material). What localStorage holds is `LocalAccountSchemaV1` = this plus the
+ * device-local tail.
  *
  * The account is the single-level aggregate root (the identity tier was
  * collapsed into it). It is the app-facing identity: `id` is the address apps
@@ -234,12 +257,8 @@ export const AccessMethodSchemaV1 = z.discriminatedUnion("type", [
  * after an explicit permission/signing request. The account OWNS its connected
  * apps and postage stamps as nested collections rather than via foreign-key
  * pointers.
- *
- * Unrefined base object: `AccountSchemaV1` (the parse entrypoint) adds the
- * vault-consistency refinement, and `AccountDataSchemaV1` derives from this via
- * `.omit` (object methods and refinements don't compose).
  */
-const AccountObjectSchemaV1 = z.object({
+export const SyncedAccountSchemaV1 = z.object({
   id: StoredEthAddress,
   name: z.string(),
   createdAt: z.number(),
@@ -247,29 +266,6 @@ const AccountObjectSchemaV1 = z.object({
   // App-facing public key (compressed secp256k1). Surfaced to dApps as the
   // identity public key in ConnectionInfo. Was previously on the identity.
   publicKey: CompressedPublicKeySchema,
-  // Device-local seed vault. Every account is a BIP-39 seed account: `access`
-  // records how the seed is protected/unlocked on this device (passkey /
-  // eth-wallet / password) and `encryptedSeed` is that seed encrypted at rest.
-  // Device-local: deliberately excluded from the sync snapshot. Optional
-  // because a signed-out account has no vault — but note the TYPE does not
-  // pair the three vault fields (they are independently optional); writers
-  // must keep them consistent themselves, and `AccountSchemaV1`'s refinement
-  // only quarantines an inconsistent record at load time (it is skipped, not
-  // repaired).
-  access: AccessMethodSchemaV1.optional(),
-  // BIP-39 entropy encrypted with the access-method key (hex: IV || ciphertext).
-  // Non-empty, even-length hex whenever present. Width varies with the seed
-  // size (12-word seed → 88 chars, 24-word → 120), so it is not a fixed length.
-  encryptedSeed: z
-    .string()
-    .regex(/^([0-9a-f]{2})+$/)
-    .optional(),
-  // Set when the user signed this account out on THIS device: the seed vault
-  // (`access` + `encryptedSeed`) was wiped, but the account row stays so the
-  // user can see it and sign back in (recovery phrase + new access method).
-  // Device-local like the vault itself — excluded from the `AccountData`
-  // projection that backup files and the sync feed serialize.
-  signedOutAt: z.number().optional(),
   defaultPostageStampBatchID: StoredBatchId.optional(),
   devices: z.array(DeviceSchemaV1).default([]),
   // Account-owned nested collections (replace the old flat identities/apps/
@@ -300,51 +296,50 @@ const AccountObjectSchemaV1 = z.object({
 })
 
 /**
- * Parse entrypoint for stored account records: the base object plus the
- * vault-consistency check — a signed-in account (no `signedOutAt`) carries
- * BOTH vault fields, a signed-out one carries NEITHER. This only validates at
- * parse (load) time: writes are not checked, and the accounts loader SKIPS a
- * violating record rather than failing the document — so writers (account
- * creation, `signOut`, `setAccess`) are responsible for keeping the trio
- * consistent; this refinement is the backstop that keeps a corrupt record
- * from loading as a half-signed-out account.
+ * Signed-in variant: the synced data plus the device vault. `signedOutAt` is
+ * declared undefined-only (not merely omitted) so a record carrying BOTH a
+ * vault and a sign-out marker fails this variant — and the signed-out one —
+ * and is quarantined at load, instead of silently parsing as signed-in and
+ * dropping the marker.
  */
-export const AccountSchemaV1 = AccountObjectSchemaV1.superRefine(
-  (account, ctx) => {
-    const hasVault =
-      account.access !== undefined && account.encryptedSeed !== undefined
-    if (account.signedOutAt === undefined && !hasVault) {
-      ctx.addIssue({
-        code: "custom",
-        message:
-          "Signed-in account must have both access and encryptedSeed set",
-      })
-    }
-    if (
-      account.signedOutAt !== undefined &&
-      (account.access !== undefined || account.encryptedSeed !== undefined)
-    ) {
-      ctx.addIssue({
-        code: "custom",
-        message: "Signed-out account must not retain its seed vault",
-      })
-    }
-  },
-)
+const SignedInAccountSchemaV1 = SyncedAccountSchemaV1.extend({
+  ...LocalVaultSchemaV1.shape,
+  signedOutAt: z.undefined().optional(),
+})
 
 /**
- * The portable projection of the account — everything except the device-local
- * seed vault (`access` + `encryptedSeed`) and its sign-out marker
- * (`signedOutAt`). This is the single definition of what travels off the
- * device: backup files serialize/parse it directly, and the sync feed carries
- * the same shape. Serialize with `serializeAccountData`, which additionally
- * strips the live per-app session material.
+ * Signed-out variant: the synced data plus the moment the user signed this
+ * account out on THIS device. The vault was wiped, but the account row stays
+ * so the user can see it and sign back in (recovery phrase + new access
+ * method). The vault keys are declared undefined-only so a record that kept
+ * half a vault is quarantined rather than loaded as signed-out. When a future
+ * "sign back in with the security method" flow wants to RETAIN the vault
+ * through a sign-out, it extends this variant with `LocalVaultSchemaV1.shape`.
  */
-export const AccountDataSchemaV1 = AccountObjectSchemaV1.omit({
-  access: true,
-  encryptedSeed: true,
-  signedOutAt: true,
+const SignedOutAccountSchemaV1 = SyncedAccountSchemaV1.extend({
+  access: z.undefined().optional(),
+  encryptedSeed: z.undefined().optional(),
+  signedOutAt: z.number(),
 })
+
+/**
+ * Local Account Schema V1 — parse entrypoint for stored account records (what
+ * localStorage holds): the synced projection plus the device-local tail,
+ * modeled as a union so the signed-in/signed-out states are encoded in the
+ * data itself — a signed-in account carries the vault and no `signedOutAt`, a
+ * signed-out one the reverse; half-signed-out states are unrepresentable.
+ *
+ * This only validates at parse (load) time — the accounts loader SKIPS a
+ * violating record rather than failing the document — but unlike a refinement
+ * the union also carries into the TYPE system: `Account` is a discriminated
+ * union (discriminate on `access`/`signedOutAt` presence, or narrow with
+ * `isSignedOutAccount`), so writers can't produce a half-signed-out record
+ * without a type error.
+ */
+export const LocalAccountSchemaV1 = z.union([
+  SignedInAccountSchemaV1,
+  SignedOutAccountSchemaV1,
+])
 
 // ============================================================================
 // Sync State Snapshot Schemas
@@ -364,7 +359,7 @@ export const AccountMetadataSchemaV1 = z.object({
       appSessionDuration: z.number().optional(),
     })
     .optional(),
-  // Per-field LWW clocks for the scalar fields (see `AccountSchemaV1`).
+  // Per-field LWW clocks for the scalar fields (see `SyncedAccountSchemaV1`).
   accountNameAt: z.number().optional(),
   defaultStampAt: z.number().optional(),
   settingsAt: z.number().optional(),
@@ -405,8 +400,12 @@ export const AccountStateSnapshotSchemaV1 = z.object({
 
 export type Device = z.infer<typeof DeviceSchemaV1>
 export type AccessMethod = z.infer<typeof AccessMethodSchemaV1>
-export type Account = z.infer<typeof AccountSchemaV1>
-export type AccountData = z.infer<typeof AccountDataSchemaV1>
+export type LocalVault = z.infer<typeof LocalVaultSchemaV1>
+export type SyncedAccount = z.infer<typeof SyncedAccountSchemaV1>
+export type SignedInAccount = z.infer<typeof SignedInAccountSchemaV1>
+export type SignedOutAccount = z.infer<typeof SignedOutAccountSchemaV1>
+/** The local (on-device) account record: `SignedInAccount | SignedOutAccount`. */
+export type Account = z.infer<typeof LocalAccountSchemaV1>
 export type ConnectedApp = z.infer<typeof ConnectedAppSchemaV1>
 export type PostageStamp = z.infer<typeof PostageStampSchemaV1>
 export type AccountMetadata = z.infer<typeof AccountMetadataSchemaV1>
@@ -443,10 +442,13 @@ export function isLocalAccount(account: Account): boolean {
  * An account is "signed out" on this device when its seed vault has been
  * wiped: no keys remain, so nothing can be unlocked or signed until the user
  * signs back in with the recovery phrase (and sets a new access method). The
- * vault absence itself is the source of truth; `signedOutAt` only records when.
+ * vault absence itself is the source of truth; `signedOutAt` only records
+ * when. Narrows: the false branch exposes the vault fields as non-optional.
  */
-export function isSignedOutAccount(account: Account): boolean {
-  return account.access === undefined || account.encryptedSeed === undefined
+export function isSignedOutAccount(
+  account: Account,
+): account is SignedOutAccount {
+  return account.access === undefined
 }
 
 // ============================================================================

--- a/lib/src/sync/fold-account-from-swarm.ts
+++ b/lib/src/sync/fold-account-from-swarm.ts
@@ -17,7 +17,7 @@ import {
   type DeviceStateSnapshot,
   type FoldedAccount,
 } from "./device-state"
-import type { AccountData, Device } from "../schemas"
+import type { SyncedAccount, Device } from "../schemas"
 
 export interface FoldAccountResult {
   account: FoldedAccount
@@ -25,22 +25,22 @@ export interface FoldAccountResult {
 }
 
 /**
- * Project a folded account onto the local `AccountData` record — the single
- * place the field list lives so a new `AccountData`/`FoldedAccount` field can't
+ * Project a folded account onto the `SyncedAccount` record — the single place
+ * the field list lives so a new `SyncedAccount`/`FoldedAccount` field can't
  * be silently dropped by a hand-written copy on the sign-in path. `id` and
  * `derivationKey` aren't in the fold (they come from the recovering wallet), so
  * the caller supplies them.
  *
  * `foldAccountFromSwarm` shallow-FREEZES its result arrays so coalesced callers
- * can't corrupt each other's shared view; a persisted `AccountData` outlives that
- * window and is mutated in place downstream, so the arrays are COPIED here.
+ * can't corrupt each other's shared view; a persisted `SyncedAccount` outlives
+ * that window and is mutated in place downstream, so the arrays are COPIED here.
  */
-export function foldedToAccountData(opts: {
+export function foldedToSyncedAccount(opts: {
   id: EthAddress
   derivationKey: string
   account: FoldedAccount
   lastModified?: number
-}): AccountData {
+}): SyncedAccount {
   const { id, derivationKey, account } = opts
   return {
     id,

--- a/lib/src/sync/index.ts
+++ b/lib/src/sync/index.ts
@@ -59,7 +59,7 @@ export {
 } from "./device-roster"
 export {
   foldAccountFromSwarm,
-  foldedToAccountData,
+  foldedToSyncedAccount,
 } from "./fold-account-from-swarm"
 export type { FoldAccountResult } from "./fold-account-from-swarm"
 

--- a/lib/src/sync/store-interfaces.ts
+++ b/lib/src/sync/store-interfaces.ts
@@ -10,7 +10,7 @@
  */
 
 import type { EthAddress, BatchId, Stamper } from "@ethersphere/bee-js"
-import type { Account, PostageStamp } from "../schemas"
+import type { SyncedAccount, PostageStamp } from "../schemas"
 
 /**
  * Options for creating a stamper with utilization tracking
@@ -38,10 +38,12 @@ export interface FlushableStamper extends Stamper {
 
 /**
  * Interface for accessing account data. The account is the aggregate root and
- * owns its connected apps and postage stamps inline.
+ * owns its connected apps and postage stamps inline. The sync coordinator
+ * publishes to Swarm, so it sees only the `SyncedAccount` projection — the
+ * device-local vault never enters this seam.
  */
 export interface AccountsStoreInterface {
-  getAccount(id: EthAddress): Account | undefined
+  getAccount(id: EthAddress): SyncedAccount | undefined
 }
 
 /**

--- a/lib/src/test-fixtures.ts
+++ b/lib/src/test-fixtures.ts
@@ -30,9 +30,10 @@ export function createDevice(overrides?: Partial<Device>): Device {
 }
 
 /**
- * The single account fixture. Every account is a BIP-39 seed account with a
- * required `access` + `encryptedSeed` vault (defaulted here to a password vault);
- * override them to model a different access method.
+ * The single account fixture. Every account is a BIP-39 seed account with an
+ * `access` + `encryptedSeed` vault (defaulted here to a password vault);
+ * override them to model a different access method, or override both to
+ * `undefined` (with `signedOutAt` set) to model a signed-out account.
  */
 export function createAccount(overrides?: Partial<Account>): Account {
   return {

--- a/lib/src/test-fixtures.ts
+++ b/lib/src/test-fixtures.ts
@@ -5,7 +5,14 @@
  * Shared test fixtures for backup-encryption, account-state-snapshot, and sync tests.
  */
 import { EthAddress, BatchId, PrivateKey } from "@ethersphere/bee-js"
-import type { Account, Device, ConnectedApp, PostageStamp } from "./schemas"
+import type {
+  SyncedAccount,
+  SignedInAccount,
+  SignedOutAccount,
+  Device,
+  ConnectedApp,
+  PostageStamp,
+} from "./schemas"
 
 export const TEST_ETH_ADDRESS_HEX = "a".repeat(40)
 export const TEST_ETH_ADDRESS_2_HEX = "b".repeat(40)
@@ -29,24 +36,44 @@ export function createDevice(overrides?: Partial<Device>): Device {
   }
 }
 
-/**
- * The single account fixture. Every account is a BIP-39 seed account with an
- * `access` + `encryptedSeed` vault (defaulted here to a password vault);
- * override them to model a different access method, or override both to
- * `undefined` (with `signedOutAt` set) to model a signed-out account.
- */
-export function createAccount(overrides?: Partial<Account>): Account {
+/** The synced (portable) fields both account fixtures share. */
+function createSyncedAccount(): SyncedAccount {
   return {
     id: new EthAddress(TEST_ETH_ADDRESS_HEX),
     name: "Test Account",
     createdAt: 1700000000000,
     publicKey: TEST_PUBLIC_KEY_HEX,
-    access: { type: "password", kdfSalt: "00", kdfIterations: 100000 },
-    encryptedSeed: "aabbccdd",
     derivationKey: TEST_DERIVATION_KEY_HEX,
     devices: [],
     connectedApps: [],
     postageStamps: [],
+  }
+}
+
+/**
+ * The signed-in account fixture. Every account is a BIP-39 seed account with an
+ * `access` + `encryptedSeed` vault (defaulted here to a password vault);
+ * override them to model a different access method. For the signed-out variant
+ * (vault wiped) use `createSignedOutAccount`.
+ */
+export function createAccount(
+  overrides?: Partial<SignedInAccount>,
+): SignedInAccount {
+  return {
+    ...createSyncedAccount(),
+    access: { type: "password", kdfSalt: "00", kdfIterations: 100000 },
+    encryptedSeed: "aabbccdd",
+    ...overrides,
+  }
+}
+
+/** Signed-out counterpart of `createAccount`: no vault, `signedOutAt` set. */
+export function createSignedOutAccount(
+  overrides?: Partial<SignedOutAccount>,
+): SignedOutAccount {
+  return {
+    ...createSyncedAccount(),
+    signedOutAt: 1700000000001,
     ...overrides,
   }
 }

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -1703,7 +1703,7 @@ export interface ConnectOptions {
 
 export type {
   Account,
-  AccountData,
+  SyncedAccount,
   ConnectedApp,
   PostageStamp,
 } from "./schemas"

--- a/lib/src/utils/storage-managers.test.ts
+++ b/lib/src/utils/storage-managers.test.ts
@@ -7,13 +7,14 @@ import {
   createAccountsStorageManager,
   serializeAccount,
 } from "./storage-managers"
-import { AccountSchemaV1 } from "../schemas"
+import { LocalAccountSchemaV1 } from "../schemas"
 import { STORAGE_KEY_ACCOUNTS } from "../types"
 import {
   TEST_BATCH_ID_HEX,
   TEST_ETH_ADDRESS_2_HEX,
   TEST_PRIVATE_KEY_HEX,
   createAccount,
+  createSignedOutAccount,
   createPostageStamp,
 } from "../test-fixtures"
 
@@ -34,7 +35,7 @@ describe("serializeAccount — device-local seed vault", () => {
     const serialized = serializeAccount(account)
 
     // Survives a JSON file round-trip (no class instances leak into storage).
-    const reparsed = AccountSchemaV1.parse(
+    const reparsed = LocalAccountSchemaV1.parse(
       JSON.parse(JSON.stringify(serialized)),
     )
 
@@ -57,7 +58,7 @@ describe("serializeAccount — device-local seed vault", () => {
       { type: "password", kdfSalt: "aa", kdfIterations: 200000 },
     ] as const) {
       const serialized = serializeAccount(createAccount({ access }))
-      const reparsed = AccountSchemaV1.parse(
+      const reparsed = LocalAccountSchemaV1.parse(
         JSON.parse(JSON.stringify(serialized)),
       )
       expect(reparsed.access).toEqual(access)
@@ -65,14 +66,10 @@ describe("serializeAccount — device-local seed vault", () => {
   })
 
   it("round-trips a signed-out account (vault wiped, signedOutAt set)", () => {
-    const account = createAccount({
-      access: undefined,
-      encryptedSeed: undefined,
-      signedOutAt: 1700000000123,
-    })
+    const account = createSignedOutAccount({ signedOutAt: 1700000000123 })
 
     const serialized = serializeAccount(account)
-    const reparsed = AccountSchemaV1.parse(
+    const reparsed = LocalAccountSchemaV1.parse(
       JSON.parse(JSON.stringify(serialized)),
     )
 

--- a/lib/src/utils/storage-managers.test.ts
+++ b/lib/src/utils/storage-managers.test.ts
@@ -63,6 +63,23 @@ describe("serializeAccount — device-local seed vault", () => {
       expect(reparsed.access).toEqual(access)
     }
   })
+
+  it("round-trips a signed-out account (vault wiped, signedOutAt set)", () => {
+    const account = createAccount({
+      access: undefined,
+      encryptedSeed: undefined,
+      signedOutAt: 1700000000123,
+    })
+
+    const serialized = serializeAccount(account)
+    const reparsed = AccountSchemaV1.parse(
+      JSON.parse(JSON.stringify(serialized)),
+    )
+
+    expect(reparsed.access).toBeUndefined()
+    expect(reparsed.encryptedSeed).toBeUndefined()
+    expect(reparsed.signedOutAt).toBe(1700000000123)
+  })
 })
 
 describe("createAccountsStorageManager().load() — invalid records", () => {

--- a/lib/src/utils/storage-managers.ts
+++ b/lib/src/utils/storage-managers.ts
@@ -120,11 +120,13 @@ export function serializeAccount(account: Account): Record<string, unknown> {
     // how the seed is unlocked on THIS device (the method plus its params:
     // password KDF, passkey credential, or eth-wallet salt); `encryptedSeed` is
     // the BIP-39 seed encrypted at rest under the key that method derives. Plain
-    // JSON (no byte classes); both are always set, as every account is a seed
-    // account. This pair stays on the device: the portable copy that backups and
-    // the sync feed publish omits it (`AccountData` = the record without them).
+    // JSON (no byte classes); both are set on every signed-in account, and both
+    // are absent (with `signedOutAt` marking when) after a sign-out wiped them.
+    // This group stays on the device: the portable copy that backups and the
+    // sync feed publish omits it (`AccountData` = the record without them).
     access: account.access,
     encryptedSeed: account.encryptedSeed,
+    signedOutAt: account.signedOutAt,
   }
 }
 

--- a/lib/src/utils/storage-managers.ts
+++ b/lib/src/utils/storage-managers.ts
@@ -15,10 +15,15 @@ import {
   createLocalStorageManager,
   type VersionParser,
 } from "./versioned-storage"
-import type { Account, AccountData, ConnectedApp, PostageStamp } from "../types"
+import type {
+  Account,
+  SyncedAccount,
+  ConnectedApp,
+  PostageStamp,
+} from "../types"
 import { STORAGE_KEY_ACCOUNTS, STORAGE_KEY_NETWORK_SETTINGS } from "../types"
 import {
-  AccountSchemaV1,
+  LocalAccountSchemaV1,
   NetworkSettingsSchemaV1,
   type NetworkSettings,
 } from "../schemas"
@@ -46,7 +51,7 @@ const parseAccountsV1: VersionParser<Account> = (data: unknown) => {
 
   const accounts: Account[] = []
   for (const record of records.data) {
-    const result = AccountSchemaV1.safeParse(record)
+    const result = LocalAccountSchemaV1.safeParse(record)
     if (!result.success) {
       console.error("Skipping invalid account record:", result.error.format())
       continue
@@ -70,15 +75,16 @@ const parseAccountsV1: VersionParser<Account> = (data: unknown) => {
 // ============================================================================
 
 /**
- * Serialize the portable projection of an account (`AccountData`) — what backup
- * files and the sync feed carry off the device. Beyond the schema-level omission
- * of the seed vault, it strips the live per-app session material: `appSecret`
- * (the secret the dApp proxy authenticates from, re-derivable from the master
- * key on the next connect) and `connectedUntil` (meaningless without the secret
- * — keeping it would show a "Connected" app that can no longer authenticate).
+ * Serialize the portable projection of an account (`SyncedAccount`) — what
+ * backup files and the sync feed carry off the device. Beyond the schema-level
+ * absence of the seed vault, it strips the live per-app session material:
+ * `appSecret` (the secret the dApp proxy authenticates from, re-derivable from
+ * the master key on the next connect) and `connectedUntil` (meaningless without
+ * the secret — keeping it would show a "Connected" app that can no longer
+ * authenticate).
  */
-export function serializeAccountData(
-  data: AccountData,
+export function serializeSyncedAccount(
+  data: SyncedAccount,
 ): Record<string, unknown> {
   return {
     id: data.id.toString(),
@@ -112,18 +118,15 @@ export function serializeAccountData(
  */
 export function serializeAccount(account: Account): Record<string, unknown> {
   return {
-    ...serializeAccountData(account),
+    ...serializeSyncedAccount(account),
     // Local storage keeps the live per-app session secrets the portable
     // projection strips.
     connectedApps: account.connectedApps.map(serializeConnectedApp),
-    // Device-local seed vault — the account's only secret material. `access` is
-    // how the seed is unlocked on THIS device (the method plus its params:
-    // password KDF, passkey credential, or eth-wallet salt); `encryptedSeed` is
-    // the BIP-39 seed encrypted at rest under the key that method derives. Plain
-    // JSON (no byte classes); both are set on every signed-in account, and both
-    // are absent (with `signedOutAt` marking when) after a sign-out wiped them.
-    // This group stays on the device: the portable copy that backups and the
-    // sync feed publish omits it (`AccountData` = the record without them).
+    // The device-local tail of the record: the seed vault (the account's only
+    // secret material — plain JSON, no byte classes) while signed in, or
+    // `signedOutAt` after a sign-out wiped it. This group stays on the device:
+    // the portable copy that backups and the sync feed publish is
+    // `SyncedAccount` — the record without it.
     access: account.access,
     encryptedSeed: account.encryptedSeed,
     signedOutAt: account.signedOutAt,

--- a/swarm-ui/src/lib/components/drawer.svelte
+++ b/swarm-ui/src/lib/components/drawer.svelte
@@ -111,7 +111,7 @@
     // Re-authenticate as a confirmation gate before the destructive delete (the
     // derived key itself is discarded). Password accounts have no interactive
     // ceremony, so collect the password in a modal and verify it there.
-    if (account.access.type === 'password') {
+    if (account.access?.type === 'password') {
       showDeleteModal = false
       deletePasswordError = undefined
       showDeletePasswordModal = true
@@ -187,7 +187,7 @@
       a.click()
       document.body.removeChild(a)
 
-      if (account.access.type === 'passkey') {
+      if (account.access?.type === 'passkey') {
         showPasskeyExportWarning = true
       }
     } catch (err) {
@@ -227,9 +227,9 @@
           style="padding: var(--padding)"
         >
           <Horizontal --horizontal-gap="var(--half-padding)">
-            {account.access.type === 'eth-wallet'
+            {account.access?.type === 'eth-wallet'
               ? 'Ethereum'
-              : account.access.type === 'passkey'
+              : account.access?.type === 'passkey'
                 ? 'Passkey'
                 : 'Agent'}
             <Badge>{account.defaultPostageStampBatchID ? 'Synced' : 'Local'}</Badge>
@@ -341,9 +341,9 @@
                 --horizontal-justify-content="stretch"
                 style="flex: 1"
               >
-                {#if acc.access.type === 'eth-wallet'}
+                {#if acc.access?.type === 'eth-wallet'}
                   <EthereumLogo size={20} />
-                {:else if acc.access.type === 'passkey'}
+                {:else if acc.access?.type === 'passkey'}
                   <PasskeyLogo size={20} />
                 {:else}
                   <Bot size={20} />
@@ -411,9 +411,9 @@
               oninput={onAccountNameChange}
             />
             <Horizontal --horizontal-gap="var(--quarter-padding)">
-              {#if account.access.type === 'eth-wallet'}
+              {#if account.access?.type === 'eth-wallet'}
                 <EthereumLogo size={20} />Ethereum
-              {:else if account.access.type === 'passkey'}
+              {:else if account.access?.type === 'passkey'}
                 <PasskeyLogo size={20} />Passkey
               {:else}
                 <Bot size={20} />Agent

--- a/swarm-ui/src/lib/crypto/encrypted-seed.test.ts
+++ b/swarm-ui/src/lib/crypto/encrypted-seed.test.ts
@@ -4,11 +4,11 @@
 /**
  * End-to-end check that a real BIP-39 seed phrase, encrypted by the actual
  * create/import pipeline, produces an `encryptedSeed` the lib's
- * `AccountSchemaV1` accepts (and that the constraint rejects a blanked one).
+ * `LocalAccountSchemaV1` accepts (and that the constraint rejects a blanked one).
  */
 import { describe, it, expect } from 'vitest'
 import { Mnemonic, Wallet } from 'ethers'
-import { AccountSchemaV1 } from '@snaha/swarm-id'
+import { LocalAccountSchemaV1 } from '@snaha/swarm-id'
 import { encryptSeed, deriveKeyFromPassword, randomSalt } from './encryption'
 import { bytesToHex } from './hex'
 import { walletFromPhrase } from './mnemonic'
@@ -40,7 +40,7 @@ async function encryptPhrase(phrase: string) {
   }
 }
 
-/** The serialized (wire) account shape AccountSchemaV1 parses, for a real wallet. */
+/** The serialized (wire) account shape LocalAccountSchemaV1 parses, for a real wallet. */
 function serializedAccount(phrase: string, vault: Awaited<ReturnType<typeof encryptPhrase>>) {
   const { address, publicKey } = walletFromPhrase(phrase)
   return {
@@ -59,7 +59,7 @@ describe('encryptedSeed from a real seed phrase', () => {
     [12, 88],
     [24, 120],
   ] as const)(
-    'a real %i-word phrase encrypts to %i-char hex that AccountSchemaV1 accepts',
+    'a real %i-word phrase encrypts to %i-char hex that LocalAccountSchemaV1 accepts',
     async (words, expectedLength) => {
       const phrase = realPhrase(words)
       expect(phrase.split(' ')).toHaveLength(words)
@@ -68,13 +68,13 @@ describe('encryptedSeed from a real seed phrase', () => {
       expect(vault.encryptedSeed).toMatch(/^[0-9a-f]+$/)
       expect(vault.encryptedSeed).toHaveLength(expectedLength)
 
-      expect(AccountSchemaV1.safeParse(serializedAccount(phrase, vault)).success).toBe(true)
+      expect(LocalAccountSchemaV1.safeParse(serializedAccount(phrase, vault)).success).toBe(true)
     },
   )
 
   it('rejects a real account whose encryptedSeed is blanked', async () => {
     const phrase = Wallet.createRandom().mnemonic!.phrase
     const account = serializedAccount(phrase, await encryptPhrase(phrase))
-    expect(AccountSchemaV1.safeParse({ ...account, encryptedSeed: '' }).success).toBe(false)
+    expect(LocalAccountSchemaV1.safeParse({ ...account, encryptedSeed: '' }).success).toBe(false)
   })
 })

--- a/swarm-ui/src/lib/utils/account-auth.ts
+++ b/swarm-ui/src/lib/utils/account-auth.ts
@@ -71,6 +71,12 @@ export async function secureSeedWithPassword(
  */
 export async function getMasterKeyFromAccount(account: Account, password?: string): Promise<Bytes> {
   const access = account.access
+  const encryptedSeed = account.encryptedSeed
+  if (access === undefined || encryptedSeed === undefined) {
+    // The vault fields are optional on the shared record (the new UI wipes
+    // them on sign-out); the legacy app never signs out, so this is unreachable.
+    throw new Error('This account has no seed vault on this device.')
+  }
 
   let key: CryptoKey
   if (access.type === 'passkey') {
@@ -87,7 +93,7 @@ export async function getMasterKeyFromAccount(account: Account, password?: strin
 
   let entropy: Uint8Array
   try {
-    entropy = await decryptSeed(account.encryptedSeed, key)
+    entropy = await decryptSeed(encryptedSeed, key)
   } catch {
     throw new Error(
       access.type === 'password' ? 'Wrong password.' : 'Could not decrypt the account seed.',

--- a/swarm-ui/src/routes/(app)/(create)/signin/passkey/+page.svelte
+++ b/swarm-ui/src/routes/(app)/(create)/signin/passkey/+page.svelte
@@ -31,7 +31,7 @@
       // restore from a passkey alone is therefore not possible — the account
       // must already exist locally. Unlock the first passkey account found on
       // this device.
-      const account = accountsStore.accounts.find((a) => a.access.type === 'passkey')
+      const account = accountsStore.accounts.find((a) => a.access?.type === 'passkey')
 
       if (!account) {
         error =

--- a/swarm-ui/src/routes/(app)/connect/+page.svelte
+++ b/swarm-ui/src/routes/(app)/connect/+page.svelte
@@ -249,7 +249,7 @@
 
     // Password accounts have no interactive ceremony — collect the password in
     // a modal, then re-run authentication.
-    if (account.access.type === 'password') {
+    if (account.access?.type === 'password') {
       pendingPasswordAccount = account
       passwordError = undefined
       showPasswordModal = true
@@ -346,9 +346,9 @@
   </Vertical>
 {:else if isAuthenticating && selected}
   <Confirmation
-    authenticationType={selected.access.type === 'eth-wallet'
+    authenticationType={selected.access?.type === 'eth-wallet'
       ? 'ethereum'
-      : selected.access.type === 'passkey'
+      : selected.access?.type === 'passkey'
         ? 'passkey'
         : 'agent'}
   />

--- a/ui/src/lib/components/account-switcher.svelte
+++ b/ui/src/lib/components/account-switcher.svelte
@@ -37,9 +37,6 @@
   const others = $derived(
     accountsStore.accounts.filter((candidate) => !candidate.id.equals(account.id)),
   )
-  // A local account has nothing on Swarm to come back to — signing it out
-  // would destroy it, so it only gets Delete (on the Account tab), no Sign out.
-  const isLocal = $derived(account.stamps.length === 0)
 
   function close() {
     open = false
@@ -116,7 +113,9 @@
         </div>
 
         <Button variant="outline" class="w-full" onclick={manage}>Manage account</Button>
-        {#if !isLocal}
+        <!-- A local account has nothing on Swarm to come back to — signing it out
+             would destroy it, so it only gets Delete (on the Account tab), no Sign out. -->
+        {#if !account.isLocal}
           <Button variant="outline" class="w-full" onclick={startSignOut}>Sign out</Button>
         {/if}
       </div>

--- a/ui/src/lib/components/account-switcher.svelte
+++ b/ui/src/lib/components/account-switcher.svelte
@@ -7,9 +7,12 @@
   import UserRoundMinus from '@lucide/svelte/icons/user-round-minus'
   import UserRoundPlus from '@lucide/svelte/icons/user-round-plus'
 
+  import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'
 
   import Polycon from '$lib/components/polycon.svelte'
+  import SignOutDialog from '$lib/components/sign-out-dialog.svelte'
+  import { Badge } from '$lib/components/ui/badge'
   import { Button } from '$lib/components/ui/button'
   import routes from '$lib/routes'
   import { accountsStore } from '$lib/stores/accounts.svelte'
@@ -29,10 +32,14 @@
   let container = $state<HTMLDivElement>()
   /** Replaces the panel actions with the create/import choice. */
   let addingAccount = $state(false)
+  let signingOut = $state(false)
 
   const others = $derived(
     accountsStore.accounts.filter((candidate) => !candidate.id.equals(account.id)),
   )
+  // A local account has nothing on Swarm to come back to — signing it out
+  // would destroy it, so it only gets Delete (on the Account tab), no Sign out.
+  const isLocal = $derived(account.stamps.length === 0)
 
   function close() {
     open = false
@@ -52,8 +59,19 @@
   }
 
   function select(candidate: Account) {
+    if (candidate.isSignedOut) {
+      // No keys on this device — signing back in means importing the phrase.
+      close()
+      void goto(resolve(routes.ACCOUNT_IMPORT))
+      return
+    }
     sessionStore.setCurrentAccount(candidate.id)
     close()
+  }
+
+  function startSignOut() {
+    close()
+    signingOut = true
   }
 
   function manage() {
@@ -98,7 +116,9 @@
         </div>
 
         <Button variant="outline" class="w-full" onclick={manage}>Manage account</Button>
-        <Button variant="outline" class="w-full" onclick={notImplemented}>Sign out</Button>
+        {#if !isLocal}
+          <Button variant="outline" class="w-full" onclick={startSignOut}>Sign out</Button>
+        {/if}
       </div>
 
       {#if addingAccount}
@@ -131,6 +151,9 @@
                     {truncateAddress(candidate.id.toChecksum())}
                   </span>
                 </span>
+                {#if candidate.isSignedOut}
+                  <Badge>Signed out</Badge>
+                {/if}
               </button>
             {/each}
           </div>
@@ -145,10 +168,14 @@
           {/if}
           <Button variant="ghost" size="sm" class="w-full" onclick={() => (addingAccount = true)}>
             <UserRoundPlus />
-            Add an account
+            Sign in to another account
           </Button>
         </div>
       {/if}
     </div>
   {/if}
 </div>
+
+{#if signingOut}
+  <SignOutDialog {account} onClose={() => (signingOut = false)} />
+{/if}

--- a/ui/src/lib/components/home-account.svelte
+++ b/ui/src/lib/components/home-account.svelte
@@ -98,7 +98,7 @@
   let newPassword = $state('')
   let verifyNewPassword = $state('')
 
-  const isLocal = $derived(account.stamps.length === 0)
+  const isLocal = $derived(account.isLocal)
   // The Account tab only renders for the signed-in current account, but the
   // vault fields are optional on the record — fall back to an empty label.
   const accessLabel = $derived(account.access ? methodLabel(account.access.type) : '')

--- a/ui/src/lib/components/home-account.svelte
+++ b/ui/src/lib/components/home-account.svelte
@@ -19,13 +19,13 @@
   import KeyRound from '@lucide/svelte/icons/key-round'
   import LoaderCircle from '@lucide/svelte/icons/loader-circle'
   import RefreshCw from '@lucide/svelte/icons/refresh-cw'
-  import Trash2 from '@lucide/svelte/icons/trash-2'
   import Wallet from '@lucide/svelte/icons/wallet'
   import { type AccessMethod, uint8ArrayToHex } from '@snaha/swarm-id'
 
   import DriveAddDialog from '$lib/components/drive-add-dialog.svelte'
   import PhraseGrid from '$lib/components/phrase-grid.svelte'
   import Polycon from '$lib/components/polycon.svelte'
+  import SignOutDialog from '$lib/components/sign-out-dialog.svelte'
   import { Button } from '$lib/components/ui/button'
   import { Dialog } from '$lib/components/ui/dialog'
   import { Input } from '$lib/components/ui/input'
@@ -78,6 +78,7 @@
   let bannerInfoShown = $state(false)
   let addDriveOpen = $state(false)
   let keysDetailOpen = $state(false)
+  let signingOut = $state(false)
   // Reveals cache only their derived display value — never the raw seed, which
   // is zeroed the moment each ceremony finishes with it (issue #412).
   let revealedPrivateKey = $state<string | undefined>(undefined)
@@ -98,11 +99,13 @@
   let verifyNewPassword = $state('')
 
   const isLocal = $derived(account.stamps.length === 0)
-  const accessLabel = $derived(methodLabel(account.access.type))
+  // The Account tab only renders for the signed-in current account, but the
+  // vault fields are optional on the record — fall back to an empty label.
+  const accessLabel = $derived(account.access ? methodLabel(account.access.type) : '')
   const AccessIcon: Component = $derived(
-    account.access.type === 'passkey'
+    account.access?.type === 'passkey'
       ? Fingerprint
-      : account.access.type === 'eth-wallet'
+      : account.access?.type === 'eth-wallet'
         ? Wallet
         : KeyRound,
   )
@@ -169,13 +172,13 @@
     const myAttempt = ++attempt
     dialogError = undefined
     busy = true
-    if (account.access.type !== 'password') {
+    if (account.access?.type !== 'password') {
       dialog = { kind: 'unlock', target, pending: true }
     }
     try {
       const unlocked = await unlockAccount(
         account,
-        account.access.type === 'password' ? password : undefined,
+        account.access?.type === 'password' ? password : undefined,
       )
       if (myAttempt !== attempt) {
         unlocked.fill(0)
@@ -570,11 +573,14 @@
 
   <div class="bg-border h-px w-full"></div>
 
-  <div class="flex w-full items-center justify-end">
-    <Button variant="destructive" onclick={notImplemented}>
-      <Trash2 />
-      Delete account
-    </Button>
+  <div class="flex w-full items-center justify-between">
+    {#if isLocal}
+      <!-- A local account only exists on this device: nothing to sign out of. -->
+      <span></span>
+    {:else}
+      <Button variant="outline" onclick={() => (signingOut = true)}>Sign out</Button>
+    {/if}
+    <Button variant="destructive" onclick={notImplemented}>Delete account</Button>
   </div>
 </div>
 
@@ -582,8 +588,8 @@
   {#if dialog.pending}
     <Dialog onclose={closeDialog} dismissable={false}>
       {@render pendingBody(
-        account.access.type === 'eth-wallet' ? 'Confirm with wallet' : 'Confirm with passkey',
-        account.access.type === 'eth-wallet'
+        account.access?.type === 'eth-wallet' ? 'Confirm with wallet' : 'Confirm with passkey',
+        account.access?.type === 'eth-wallet'
           ? 'Approve the request in your Ethereum wallet.'
           : 'Follow the prompts on your device.',
       )}
@@ -610,7 +616,7 @@
         {/if}
       </p>
 
-      {#if account.access.type === 'password'}
+      {#if account.access?.type === 'password'}
         <Input
           type="password"
           bind:value={password}
@@ -626,15 +632,15 @@
 
       <Button
         class="w-full"
-        disabled={busy || (account.access.type === 'password' && password.length === 0)}
+        disabled={busy || (account.access?.type === 'password' && password.length === 0)}
         onclick={confirmUnlock}
       >
         {#if busy}
           <LoaderCircle class="animate-spin" />
         {/if}
-        {account.access.type === 'passkey'
+        {account.access?.type === 'passkey'
           ? 'Confirm with passkey'
-          : account.access.type === 'eth-wallet'
+          : account.access?.type === 'eth-wallet'
             ? 'Confirm with wallet'
             : 'Confirm'}
       </Button>
@@ -721,4 +727,8 @@
 
 {#if addDriveOpen}
   <DriveAddDialog {account} onClose={() => (addDriveOpen = false)} onAdded={toastStore.show} />
+{/if}
+
+{#if signingOut}
+  <SignOutDialog {account} onClose={() => (signingOut = false)} />
 {/if}

--- a/ui/src/lib/components/sign-out-dialog.svelte
+++ b/ui/src/lib/components/sign-out-dialog.svelte
@@ -1,0 +1,63 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<!--
+  Sign out a (synced) account on this device: wipes the seed vault, so the
+  confirm is gated on the user acknowledging they can get back in with their
+  Secret Recovery Phrase. The row stays in the account list ("Signed out").
+-->
+<script lang="ts">
+  import LogOut from '@lucide/svelte/icons/log-out'
+
+  import { Button } from '$lib/components/ui/button'
+  import { Dialog } from '$lib/components/ui/dialog'
+  import { sessionStore } from '$lib/stores/session.svelte'
+  import { toastStore } from '$lib/stores/toast.svelte'
+  import type { Account } from '$lib/types'
+
+  interface Props {
+    account: Account
+    onClose: () => void
+  }
+
+  let { account, onClose }: Props = $props()
+
+  let acknowledged = $state(false)
+
+  function confirm() {
+    // Capture once: the prop is a reactive getter, and callers derive it from
+    // the session (a signed-out current account reads as "no session"), so
+    // after signOut() the prop chain can already yield undefined.
+    const target = account
+    target.signOut()
+    if (sessionStore.currentAccountId === target.id.toHex()) {
+      sessionStore.clearCurrentAccount()
+    }
+    toastStore.show('Signed out')
+    onClose()
+  }
+</script>
+
+<Dialog onclose={onClose} title="Sign out">
+  <p class="text-sm">
+    This signs <span class="font-medium">{account.name}</span> out on this device and removes its security
+    keys from it. Your account and its drives keep living on the Swarm network.
+  </p>
+  <p class="text-sm">
+    To sign back in you will need your <span class="font-medium">Secret Recovery Phrase</span> and to
+    set up a new security method.
+  </p>
+  <label class="flex cursor-pointer items-start gap-2 text-sm">
+    <input type="checkbox" bind:checked={acknowledged} class="mt-0.5 cursor-pointer" />
+    I have my Secret Recovery Phrase.
+  </label>
+  <div class="flex w-full flex-col gap-2">
+    <Button variant="destructive" class="w-full" disabled={!acknowledged} onclick={confirm}>
+      <LogOut />
+      Sign out
+    </Button>
+    <Button variant="outline" class="w-full" onclick={onClose}>Cancel</Button>
+  </div>
+</Dialog>

--- a/ui/src/lib/components/unlock-dialog.svelte
+++ b/ui/src/lib/components/unlock-dialog.svelte
@@ -42,13 +42,13 @@
     const myAttempt = ++attempt
     error = undefined
     busy = true
-    if (account.access.type !== 'password') {
+    if (account.access?.type !== 'password') {
       pendingCeremony = true
     }
     try {
       const entropy = await unlockAccount(
         account,
-        account.access.type === 'password' ? password : undefined,
+        account.access?.type === 'password' ? password : undefined,
       )
       if (myAttempt !== attempt) {
         return
@@ -79,10 +79,10 @@
     <div class="flex flex-col items-center gap-2 py-4 text-center">
       <LoaderCircle class="size-5 animate-spin" />
       <p class="text-sm font-bold">
-        {account.access.type === 'eth-wallet' ? 'Confirm with wallet' : 'Confirm with passkey'}
+        {account.access?.type === 'eth-wallet' ? 'Confirm with wallet' : 'Confirm with passkey'}
       </p>
       <p class="text-sm">
-        {account.access.type === 'eth-wallet'
+        {account.access?.type === 'eth-wallet'
           ? 'Approve the request in your Ethereum wallet.'
           : 'Follow the prompts on your device.'}
       </p>
@@ -93,7 +93,7 @@
   <Dialog onclose={close} {title}>
     <p class="text-sm">{description}</p>
 
-    {#if account.access.type === 'password'}
+    {#if account.access?.type === 'password'}
       <Input
         type="password"
         bind:value={password}
@@ -109,15 +109,15 @@
 
     <Button
       class="w-full"
-      disabled={busy || (account.access.type === 'password' && password.length === 0)}
+      disabled={busy || (account.access?.type === 'password' && password.length === 0)}
       onclick={confirm}
     >
       {#if busy}
         <LoaderCircle class="animate-spin" />
       {/if}
-      {account.access.type === 'passkey'
+      {account.access?.type === 'passkey'
         ? 'Confirm with passkey'
-        : account.access.type === 'eth-wallet'
+        : account.access?.type === 'eth-wallet'
           ? 'Confirm with wallet'
           : 'Confirm'}
     </Button>

--- a/ui/src/lib/crypto/backup.ts
+++ b/ui/src/lib/crypto/backup.ts
@@ -8,11 +8,10 @@
  */
 import { EthAddress } from '@ethersphere/bee-js'
 import {
-  type AccountData,
-  AccountDataSchemaV1,
-  type Account as AccountRecord,
+  type SyncedAccount,
+  SyncedAccountSchemaV1,
   hexToUint8Array,
-  serializeAccountData,
+  serializeSyncedAccount,
   uint8ArrayToHex,
 } from '@snaha/swarm-id'
 
@@ -53,13 +52,13 @@ function parseEnvelope(fileContents: string): BackupEnvelope | undefined {
 
 /**
  * Serialize and encrypt an account into .swarmid file contents. The payload is
- * the lib's portable projection (`serializeAccountData`): plain JSON with
+ * the lib's portable projection (`serializeSyncedAccount`): plain JSON with
  * byte-class fields as hex, never the seed vault or live per-app session
  * material (`appSecret`/`connectedUntil` — the secret is re-derived from the
  * master key on the next connect).
  */
-export async function createBackup(account: AccountRecord, entropy: Uint8Array): Promise<string> {
-  const data = serializeAccountData(account)
+export async function createBackup(account: SyncedAccount, entropy: Uint8Array): Promise<string> {
+  const data = serializeSyncedAccount(account)
 
   const salt = new Uint8Array(SALT_LENGTH)
   crypto.getRandomValues(salt)
@@ -98,7 +97,7 @@ export function isLegacyBackupFile(fileContents: string): boolean {
  * file is not a backup, the phrase does not match the file, or the backed-up
  * account does not belong to the phrase.
  */
-export async function restoreBackup(fileContents: string, phrase: string): Promise<AccountData> {
+export async function restoreBackup(fileContents: string, phrase: string): Promise<SyncedAccount> {
   const envelope = parseEnvelope(fileContents)
   if (!envelope) {
     throw new Error('Not a valid backup file.')
@@ -130,7 +129,7 @@ export async function restoreBackup(fileContents: string, phrase: string): Promi
   }
   // Rehydrate byte-class fields through the shared portable schema — the exact
   // shape `createBackup` wrote (no device-local seed vault to fake or strip).
-  const result = AccountDataSchemaV1.safeParse(raw)
+  const result = SyncedAccountSchemaV1.safeParse(raw)
   if (!result.success) {
     throw new Error('Not a valid backup file.')
   }

--- a/ui/src/lib/crypto/unlock.ts
+++ b/ui/src/lib/crypto/unlock.ts
@@ -18,14 +18,14 @@ import type { Account } from '$lib/types'
  * or wallet.
  */
 export async function unlockAccount(account: Account, password?: string): Promise<Uint8Array> {
-  const access = account.access
-  const encryptedSeed = account.encryptedSeed
-  if (access === undefined || encryptedSeed === undefined) {
+  const vault = account.vault
+  if (vault === undefined) {
     // Signed-out account: the vault was wiped, there is nothing to unlock.
     // Callers hide unlock affordances for signed-out accounts, so reaching
     // this is a programming error, not a user-facing state.
     throw new Error('This account is signed out on this device.')
   }
+  const { access, encryptedSeed } = vault
 
   let key: CryptoKey
   if (access.type === 'password') {

--- a/ui/src/lib/crypto/unlock.ts
+++ b/ui/src/lib/crypto/unlock.ts
@@ -19,6 +19,13 @@ import type { Account } from '$lib/types'
  */
 export async function unlockAccount(account: Account, password?: string): Promise<Uint8Array> {
   const access = account.access
+  const encryptedSeed = account.encryptedSeed
+  if (access === undefined || encryptedSeed === undefined) {
+    // Signed-out account: the vault was wiped, there is nothing to unlock.
+    // Callers hide unlock affordances for signed-out accounts, so reaching
+    // this is a programming error, not a user-facing state.
+    throw new Error('This account is signed out on this device.')
+  }
 
   let key: CryptoKey
   if (access.type === 'password') {
@@ -40,7 +47,7 @@ export async function unlockAccount(account: Account, password?: string): Promis
   }
 
   try {
-    return await decryptSeed(account.encryptedSeed, key)
+    return await decryptSeed(encryptedSeed, key)
   } catch {
     throw new Error(
       access.type === 'password' ? 'Wrong password.' : 'Could not decrypt the account seed.',

--- a/ui/src/lib/stores/accounts.svelte.ts
+++ b/ui/src/lib/stores/accounts.svelte.ts
@@ -72,8 +72,9 @@ export class Account {
   partitionCount = $state<number | undefined>(undefined)
   // Persist-and-publish this account's change, bound to `this` in the ctor so
   // mutators just call `this.#commit()`. `skipSync: true` saves the collection
-  // WITHOUT a Swarm publish (the change came from a remote fold, or is a
-  // volatile field peers don't need) — only ever passed by the dev mutators.
+  // WITHOUT a Swarm publish: the change came from a remote fold, is a volatile
+  // field peers don't need, or is a device-local de-auth that must not
+  // propagate (`signOut`).
   readonly #commit: (options?: { skipSync?: boolean }) => void
 
   constructor(
@@ -120,6 +121,11 @@ export class Account {
   /** Live (non-tombstoned) stamps — what the UI displays (mutators are dev-only, below). */
   get stamps(): PostageStamp[] {
     return this.postageStamps.filter((stamp) => stamp.deletedAt === undefined)
+  }
+
+  /** Local: no live drives, so nothing of this account lives on Swarm yet. */
+  get isLocal(): boolean {
+    return this.stamps.length === 0
   }
 
   /** Signed out on this device: the seed vault was wiped by `signOut()`. */

--- a/ui/src/lib/stores/accounts.svelte.ts
+++ b/ui/src/lib/stores/accounts.svelte.ts
@@ -6,9 +6,11 @@ import {
   type Account as AccountRecord,
   type ConnectedApp,
   type Device,
+  type LocalVault,
   type PostageStamp,
   PostageStampSchemaV1,
   STORAGE_KEY_ACCOUNTS,
+  type SyncedAccount,
   createAccountsStorageManager,
   isSignedOutAccount,
   serializePostageStamp,
@@ -21,15 +23,26 @@ import { daysToMs } from '$lib/duration'
 type AccountSettings = { appSessionDuration?: number }
 
 /**
+ * The device-local tail of the account record, mirroring the lib's `Account`
+ * union: the seed vault while signed in, or the sign-out marker once
+ * `signOut()` wiped it. Held as ONE union-typed field (not three independently
+ * writable ones) so a half-signed-out live object is unrepresentable.
+ */
+type DeviceAuth =
+  | { vault: LocalVault; signedOutAt?: undefined }
+  | { vault?: undefined; signedOutAt: number }
+
+/**
  * The account aggregate root. Fields are reactive (`$state`) so component reads
  * update on mutation, and every mutator is a method **on the object** that
  * commits the whole collection through the injected `#commit` callback — callers
  * mutate the account they already hold (`account.rename(…)`), never a store
  * method that takes an id and looks the account up.
  *
- * The shape is the shared `@snaha/swarm-id` `Account` record (byte-class fields,
- * serialized to hex by the lib storage manager). The private `#commit` makes
- * the class nominal, so a plain record can't be mistaken for a live account.
+ * The shape mirrors the shared `@snaha/swarm-id` `Account` record union —
+ * `applyRecord`/`toRecord` project from/to it (byte-class fields are serialized
+ * to hex by the lib storage manager). The private `#commit` makes the class
+ * nominal, so a plain record can't be mistaken for a live account.
  *
  * Instances are stable per account id: a cross-tab storage refresh updates the
  * existing instance's fields via `applyRecord` rather than replacing it, so an
@@ -55,11 +68,9 @@ export class Account {
   derivationKey = $state('')
   name = $state('')
   publicKey = $state('')
-  // The device-local seed vault. Both set while signed in; both wiped (and
-  // `signedOutAt` stamped) after `signOut()`.
-  access = $state<AccessMethod | undefined>(undefined)
-  encryptedSeed = $state<string | undefined>(undefined)
-  signedOutAt = $state<number | undefined>(undefined)
+  // Device-local auth state: the seed vault while signed in, the sign-out
+  // marker after `signOut()` wiped it (exposed via the getters below).
+  #deviceAuth = $state<DeviceAuth>({ signedOutAt: 0 })
   settings = $state<AccountSettings | undefined>(undefined)
   defaultPostageStampBatchID = $state<BatchId | undefined>(undefined)
   devices = $state<Device[]>([])
@@ -98,9 +109,9 @@ export class Account {
     this.derivationKey = record.derivationKey
     this.name = record.name
     this.publicKey = record.publicKey
-    this.access = record.access
-    this.encryptedSeed = record.encryptedSeed
-    this.signedOutAt = record.signedOutAt
+    this.#deviceAuth = isSignedOutAccount(record)
+      ? { signedOutAt: record.signedOutAt }
+      : { vault: { access: record.access, encryptedSeed: record.encryptedSeed } }
     this.settings = record.settings
     this.defaultPostageStampBatchID = record.defaultPostageStampBatchID
     this.devices = record.devices
@@ -111,6 +122,35 @@ export class Account {
     this.settingsAt = record.settingsAt
     this.lastModified = record.lastModified
     this.partitionCount = record.partitionCount
+  }
+
+  /**
+   * Project the live instance back onto the lib's `Account` record union —
+   * `applyRecord`'s inverse, what `persist()` hands the storage manager. The
+   * union return type makes a half-signed-out projection a type error.
+   */
+  toRecord(): AccountRecord {
+    const synced: SyncedAccount = {
+      id: this.id,
+      name: this.name,
+      createdAt: this.createdAt,
+      derivationKey: this.derivationKey,
+      publicKey: this.publicKey,
+      settings: this.settings,
+      defaultPostageStampBatchID: this.defaultPostageStampBatchID,
+      devices: this.devices,
+      connectedApps: this.connectedApps,
+      postageStamps: this.postageStamps,
+      accountNameAt: this.accountNameAt,
+      defaultStampAt: this.defaultStampAt,
+      settingsAt: this.settingsAt,
+      lastModified: this.lastModified,
+      partitionCount: this.partitionCount,
+    }
+    const auth = this.#deviceAuth
+    return auth.vault === undefined
+      ? { ...synced, signedOutAt: auth.signedOutAt }
+      : { ...synced, ...auth.vault }
   }
 
   /** Active (non-revoked) connected apps — what the UI displays. */
@@ -128,9 +168,24 @@ export class Account {
     return this.stamps.length === 0
   }
 
+  /** Device-local seed vault; `undefined` once `signOut()` wiped it. */
+  get vault(): LocalVault | undefined {
+    return this.#deviceAuth.vault
+  }
+
+  /** How the seed is unlocked on this device; `undefined` when signed out. */
+  get access(): AccessMethod | undefined {
+    return this.#deviceAuth.vault?.access
+  }
+
+  /** When `signOut()` wiped the vault; `undefined` while signed in. */
+  get signedOutAt(): number | undefined {
+    return this.#deviceAuth.signedOutAt
+  }
+
   /** Signed out on this device: the seed vault was wiped by `signOut()`. */
   get isSignedOut(): boolean {
-    return isSignedOutAccount(this)
+    return this.#deviceAuth.vault === undefined
   }
 
   rename(name: string) {
@@ -143,9 +198,7 @@ export class Account {
 
   /** Swap the unlock method: new access metadata + seed re-encrypted for it. */
   setAccess(access: AccessMethod, encryptedSeed: string) {
-    this.access = access
-    this.encryptedSeed = encryptedSeed
-    this.signedOutAt = undefined
+    this.#deviceAuth = { vault: { access, encryptedSeed } }
     this.lastModified = Date.now()
     this.#commit()
   }
@@ -160,9 +213,7 @@ export class Account {
    * with the keys gone there is nothing left to publish with anyway.
    */
   signOut() {
-    this.access = undefined
-    this.encryptedSeed = undefined
-    this.signedOutAt = Date.now()
+    this.#deviceAuth = { signedOutAt: Date.now() }
     this.connectedApps = this.connectedApps.map((app) => ({
       ...app,
       appSecret: undefined,
@@ -421,10 +472,11 @@ const storageManager = createAccountsStorageManager()
 
 let accounts = $state<Account[]>([])
 
-/** Save the whole collection to storage — the lib serializer converts the class
- * instances' byte-class fields to hex. No sync. */
+/** Save the whole collection to storage — each live instance projects back onto
+ * the record union (`toRecord`); the lib serializer converts the byte-class
+ * fields to hex. No sync. */
 function persist(): void {
-  storageManager.save(accounts)
+  storageManager.save(accounts.map((account) => account.toRecord()))
 }
 
 /**

--- a/ui/src/lib/stores/accounts.svelte.ts
+++ b/ui/src/lib/stores/accounts.svelte.ts
@@ -10,6 +10,7 @@ import {
   PostageStampSchemaV1,
   STORAGE_KEY_ACCOUNTS,
   createAccountsStorageManager,
+  isSignedOutAccount,
   serializePostageStamp,
 } from '@snaha/swarm-id'
 
@@ -54,8 +55,11 @@ export class Account {
   derivationKey = $state('')
   name = $state('')
   publicKey = $state('')
-  access = $state<AccessMethod>({ type: 'password', kdfSalt: '', kdfIterations: 0 })
-  encryptedSeed = $state('')
+  // The device-local seed vault. Both set while signed in; both wiped (and
+  // `signedOutAt` stamped) after `signOut()`.
+  access = $state<AccessMethod | undefined>(undefined)
+  encryptedSeed = $state<string | undefined>(undefined)
+  signedOutAt = $state<number | undefined>(undefined)
   settings = $state<AccountSettings | undefined>(undefined)
   defaultPostageStampBatchID = $state<BatchId | undefined>(undefined)
   devices = $state<Device[]>([])
@@ -95,6 +99,7 @@ export class Account {
     this.publicKey = record.publicKey
     this.access = record.access
     this.encryptedSeed = record.encryptedSeed
+    this.signedOutAt = record.signedOutAt
     this.settings = record.settings
     this.defaultPostageStampBatchID = record.defaultPostageStampBatchID
     this.devices = record.devices
@@ -117,6 +122,11 @@ export class Account {
     return this.postageStamps.filter((stamp) => stamp.deletedAt === undefined)
   }
 
+  /** Signed out on this device: the seed vault was wiped by `signOut()`. */
+  get isSignedOut(): boolean {
+    return isSignedOutAccount(this)
+  }
+
   rename(name: string) {
     const now = Date.now()
     this.name = name
@@ -129,8 +139,30 @@ export class Account {
   setAccess(access: AccessMethod, encryptedSeed: string) {
     this.access = access
     this.encryptedSeed = encryptedSeed
+    this.signedOutAt = undefined
     this.lastModified = Date.now()
     this.#commit()
+  }
+
+  /**
+   * Sign this account out on THIS device: wipe the seed vault and clear the
+   * live per-app session material so the dApp proxy can no longer authenticate
+   * from here. The row stays in the account list — signing back in requires
+   * the recovery phrase and a new access method. Deliberately NOT
+   * `disconnectApp` (no `updatedAt` bump): a device-local de-auth must not
+   * propagate as a synced disconnect. `skipSync` for the same reason — and
+   * with the keys gone there is nothing left to publish with anyway.
+   */
+  signOut() {
+    this.access = undefined
+    this.encryptedSeed = undefined
+    this.signedOutAt = Date.now()
+    this.connectedApps = this.connectedApps.map((app) => ({
+      ...app,
+      appSecret: undefined,
+      connectedUntil: undefined,
+    }))
+    this.#commit({ skipSync: true })
   }
 
   /** How long app connections stay valid, set in days (stored as ms). */

--- a/ui/src/lib/stores/session.svelte.ts
+++ b/ui/src/lib/stores/session.svelte.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 The Swarm Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 import type { EthAddress } from '@ethersphere/bee-js'
-import type { AccountData } from '@snaha/swarm-id'
+import type { SyncedAccount } from '@snaha/swarm-id'
 
 const CURRENT_ACCOUNT_KEY = 'swarm-id-current-account-v2'
 
@@ -14,7 +14,7 @@ interface SetupDraft {
   nameCustomized?: boolean
   phrase?: string
   /** Account data carried over by a restore (stamps, apps, original name). */
-  restored?: AccountData
+  restored?: SyncedAccount
 }
 
 function loadCurrentAccountId(): string | undefined {
@@ -58,10 +58,10 @@ function createSessionStore() {
         draft = { ...draft, name }
       }
     },
-    startSignIn(name: string, phrase: string, restored?: AccountData) {
+    startSignIn(name: string, phrase: string, restored?: SyncedAccount) {
       draft = { flow: 'sign-in', name, phrase, restored }
     },
-    startRestore(restored: AccountData, phrase: string) {
+    startRestore(restored: SyncedAccount, phrase: string) {
       draft = { flow: 'restore', name: restored.name, phrase, restored }
     },
     setDraftPhrase(phrase: string) {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -6,7 +6,7 @@
  * mutators are methods on the object (`account.rename(…)`), wrapping the shared
  * `@snaha/swarm-id` `Account` record. Re-exported from the store so `$lib/types`
  * is the home for the UI-local account types. The lib's record and entity types
- * (`Account`, `AccountData`, `AccessMethod`, `PostageStamp`, …) are imported
+ * (`Account`, `SyncedAccount`, `AccessMethod`, `PostageStamp`, …) are imported
  * straight from `@snaha/swarm-id`.
  */
 export type { Account } from '$lib/stores/accounts.svelte'

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -8,6 +8,7 @@
   import UserRoundMinus from '@lucide/svelte/icons/user-round-minus'
   import UserRoundPlus from '@lucide/svelte/icons/user-round-plus'
 
+  import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'
 
   import AccountList from '$lib/components/account-list.svelte'
@@ -37,13 +38,27 @@
 
   const accounts = $derived(accountsStore.accounts)
   // The active session's account, if any: with one the page IS the app
-  // (apps/drives/account tabs); without one it is the account chooser.
-  const account = $derived(
-    sessionStore.currentAccountId ? accountsStore.get(sessionStore.currentAccountId) : undefined,
-  )
+  // (apps/drives/account tabs); without one it is the account chooser. A
+  // signed-out current account (sign-out in another tab arrives via the
+  // storage listener) has no keys left, so there is no session to show.
+  const account = $derived.by(() => {
+    const current = sessionStore.currentAccountId
+      ? accountsStore.get(sessionStore.currentAccountId)
+      : undefined
+    return current?.isSignedOut ? undefined : current
+  })
 
   function select(chosen: Account) {
+    if (chosen.isSignedOut) {
+      // No keys on this device — signing back in means importing the phrase.
+      void goto(resolve(routes.ACCOUNT_IMPORT))
+      return
+    }
     sessionStore.setCurrentAccount(chosen.id)
+  }
+
+  function signedOutBadge(candidate: Account): string | undefined {
+    return candidate.isSignedOut ? 'Signed out' : undefined
   }
 </script>
 
@@ -97,7 +112,7 @@
 
       {#if accounts.length > 0 && !addingAccount}
         <div class="flex w-full flex-col gap-2">
-          <AccountList {accounts} onselect={select} />
+          <AccountList {accounts} badge={signedOutBadge} onselect={select} />
 
           <Button variant="outline" size="sm" class="w-full" onclick={notImplemented}>
             <UserRoundMinus />
@@ -105,7 +120,7 @@
           </Button>
           <Button variant="outline" size="sm" class="w-full" onclick={() => (addingAccount = true)}>
             <UserRoundPlus />
-            Add an account
+            Sign in to another account
           </Button>
         </div>
       {:else}

--- a/ui/src/routes/account/import/+page.svelte
+++ b/ui/src/routes/account/import/+page.svelte
@@ -11,7 +11,7 @@
   import {
     deriveAccountDerivationKey,
     foldAccountFromSwarm,
-    foldedToAccountData,
+    foldedToSyncedAccount,
   } from '@snaha/swarm-id'
 
   import { goto } from '$app/navigation'
@@ -98,9 +98,9 @@
       }
 
       // Recover the synced state so `finalize` rebuilds the real account rather
-      // than a fresh empty one. `foldedToAccountData` owns the projection + the
+      // than a fresh empty one. `foldedToSyncedAccount` owns the projection + the
       // frozen-array copy.
-      const restored = foldedToAccountData({
+      const restored = foldedToSyncedAccount({
         id: new EthAddress(wallet.address),
         derivationKey,
         account: folded.account,

--- a/ui/src/routes/connect/+page.svelte
+++ b/ui/src/routes/connect/+page.svelte
@@ -56,10 +56,11 @@
   })
 
   /**
-   * Previously connected to this app but the session lapsed (expired or
-   * revoked) — connecting again will ask for an unlock.
+   * Previously connected to this app but the app session lapsed (expired or
+   * revoked) — connecting again will ask for an unlock. Distinct from the
+   * account being signed out on this device (`account.isSignedOut`).
    */
-  function signedOut(account: Account): boolean {
+  function sessionLapsed(account: Account): boolean {
     const appOrigin = request?.appOrigin
     if (!appOrigin) {
       return false
@@ -72,6 +73,11 @@
 
   async function select(account: Account) {
     if (!request) {
+      return
+    }
+    if (account.isSignedOut) {
+      // No keys on this device — signing back in means importing the phrase.
+      await goto(resolve(routes.ACCOUNT_IMPORT))
       return
     }
     // A still-valid prior connection carries the secret — no unlock needed.
@@ -139,7 +145,8 @@
           <div class="flex w-full flex-col gap-2">
             <AccountList
               accounts={sortedAccounts}
-              badge={(account) => (signedOut(account) ? 'Signed out' : undefined)}
+              badge={(account) =>
+                account.isSignedOut || sessionLapsed(account) ? 'Signed out' : undefined}
               onselect={select}
             />
 
@@ -149,7 +156,7 @@
             </Button>
             <Button variant="outline" size="sm" class="w-full" onclick={startAdding}>
               <UserRoundPlus />
-              Add an account
+              Sign in to another account
             </Button>
           </div>
         {:else}

--- a/ui/src/routes/dev/device-list.svelte
+++ b/ui/src/routes/dev/device-list.svelte
@@ -11,9 +11,9 @@
   import Laptop from '@lucide/svelte/icons/laptop'
   import RefreshCw from '@lucide/svelte/icons/refresh-cw'
   import {
-    type Account,
     PartitionLease,
     type PartitionLeaseStateSnapshot,
+    type SyncedAccount,
     deriveSwarmEncryptionKey,
     getOrCreateDeviceId,
     hexToUint8Array,
@@ -28,7 +28,7 @@
   import { syncStore } from '$lib/dev/sync.svelte'
   import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
 
-  const { account }: { account: Account } = $props()
+  const { account }: { account: SyncedAccount } = $props()
 
   // Re-read the shared lease cache this often so the self row picks up the
   // proxy's per-tick `leasedUntil` advances even when `storage` events don't


### PR DESCRIPTION
Implements the sign-out flow agreed in the delete/sign-out design discussion: signing out removes the security keys from this device but the account keeps living on Swarm and stays listed on the device. Signing back in requires the recovery phrase + setting a new security method. Matches the updated Figma (Account tab buttons, switcher, connect screen).

## What changed

- **lib**: the account record is modeled as @agazso suggested in review — `SyncedAccountSchemaV1` (the portable projection the sync feed and backups carry; was `AccountDataSchemaV1`), `LocalVaultSchemaV1` (`access` + `encryptedSeed`), and `LocalAccountSchemaV1` (was `AccountSchemaV1`): a union of signed-in (synced & vault) and signed-out (synced & device-local `signedOutAt`). The distinction is encoded in the type system — `isSignedOutAccount` is a narrowing type guard, and a half-signed-out record is a type error for writers (no Zod refine; a corrupt stored record is still quarantined at load). Wire format unchanged. `AccountsStoreInterface.getAccount` now returns the `SyncedAccount` projection, so the sync seam provably never sees the vault.
- **ui**: the live `Account` class mirrors the union — one `#deviceAuth` state (`{vault} | {signedOutAt}`) behind `vault`/`access`/`signedOutAt` getters, with `toRecord()` projecting back onto the record union, so half-signed-out states are unrepresentable in the live object too. `Account.signOut()` swaps in the sign-out marker and clears per-app session secrets *without* bumping sync clocks (`skipSync`), so a device-local sign-out never propagates as a synced disconnect. New confirmation dialog gated on an "I have my Secret Recovery Phrase" checkbox.
- **ui**: entry points in the account switcher and the Account tab (hidden for local accounts — they only get Delete, per design); "Signed out" badges in the switcher, home chooser and connect screen; selecting a signed-out account routes to the import flow (interim sign-back-in until the dedicated flow exists); a current account signed out in another tab drops the session to the chooser via the storage listener.
- **ui**: "Add an account" renamed to "Sign in to another account" (switcher, chooser, connect).
- **swarm-ui (legacy)**: type-level guards only — the union surfaces `access`/`encryptedSeed` as possibly-undefined, requiring optional chaining; the legacy app never signs accounts out.

## Notes for review

- `unlockAccount` now throws early for a vault-less account; all unlock affordances are hidden for signed-out accounts, so this is a programming-error guard.
- The sign-out dialog captures the account reference before mutating: the prop chain derives from the session, which re-evaluates to `undefined` mid-handler once the account reads as signed out.
- Follow-ups (not in this PR): delete-account flow (#433), "Remove an account" mode, dedicated sign-back-in flow, device-roster removal propagation.

## Screenshots

**Account tab — Sign out next to Delete (synced account)**

![Account tab](https://raw.githubusercontent.com/snaha/swarm-id/pr-442-assets/sign-out/01-account-tab.png)

**Sign-out confirmation, gated on the recovery-phrase checkbox**

![Sign-out dialog](https://raw.githubusercontent.com/snaha/swarm-id/pr-442-assets/sign-out/02-sign-out-dialog.png)

**Home chooser after sign-out — the account stays listed**

![Home chooser](https://raw.githubusercontent.com/snaha/swarm-id/pr-442-assets/sign-out/03-home-chooser.png)

**Account switcher — Sign out for the current account, badge on the signed-out one**

![Account switcher](https://raw.githubusercontent.com/snaha/swarm-id/pr-442-assets/sign-out/04-account-switcher.png)

**Dark mode**

![Account switcher dark](https://raw.githubusercontent.com/snaha/swarm-id/pr-442-assets/sign-out/05-account-switcher-dark.png)

Verified: lib tests (936 passing, new schema/round-trip/type-narrowing cases), `pnpm check:all`, and the full flow driven in the browser (both entry points, badge + chooser fallback, reload persistence, local-account behavior, cross-tab sign-out; re-driven end-to-end after the union remodel — create → mock drive → sign out → reload).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

