### PR TITLE
fix(ui): use "drive" instead of "postage stamp" in info text

### DIFF
--- a/ui/src/lib/components/home-account.svelte
+++ b/ui/src/lib/components/home-account.svelte
@@ -351,8 +351,8 @@
       </div>
       {#if bannerInfoShown}
         <p class="text-muted-foreground pl-6 text-sm">
-          This is a local account, view-only and not synced. Upgrade by adding a postage stamp to
-          upload data and use your Swarm ID across all your devices.
+          This is a local account, view-only and not synced. Upgrade by adding a drive to upload
+          data and use your Swarm ID across all your devices.
         </p>
       {/if}
     </div>

--- a/ui/src/routes/account/new/done/+page.svelte
+++ b/ui/src/routes/account/new/done/+page.svelte
@@ -64,9 +64,7 @@
 
           <div class="bg-muted flex w-full flex-col items-center rounded-lg p-2 text-center">
             <p class="text-sm font-bold">Want the full experience?</p>
-            <p class="text-sm">
-              Upload data and sync your Swarm ID across devices with a postage stamp.
-            </p>
+            <p class="text-sm">Upload data and sync your Swarm ID across devices with a drive.</p>
           </div>
         </div>
 


### PR DESCRIPTION
Two user-facing info strings in the new UI still said "postage stamp", but the concept is now called a **drive** (buttons already read "Add a drive"). Aligns the copy.

- `ui/src/routes/account/new/done/+page.svelte` — done screen
- `ui/src/lib/components/home-account.svelte` — local-account Info expander

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)