### PR TITLE
fix(ui): match Figma copy for local/synced account drive prompts

### DIFF
--- a/ui/src/lib/components/home-account.svelte
+++ b/ui/src/lib/components/home-account.svelte
@@ -351,7 +351,7 @@
       </div>
       {#if bannerInfoShown}
         <p class="text-muted-foreground pl-6 text-sm">
-          This is a local account, view-only and not synced. Upgrade by adding a drive to upload
+          This is a local account, view-only and not synced. Upgrade by setting up a drive to upload
           data and use your Swarm ID across all your devices.
         </p>
       {/if}

--- a/ui/src/routes/account/new/done/+page.svelte
+++ b/ui/src/routes/account/new/done/+page.svelte
@@ -64,13 +64,15 @@
 
           <div class="bg-muted flex w-full flex-col items-center rounded-lg p-2 text-center">
             <p class="text-sm font-bold">Want the full experience?</p>
-            <p class="text-sm">Upload data and sync your Swarm ID across devices with a drive.</p>
+            <p class="text-sm">
+              Upload data and sync your Swarm ID across devices with a Swarm drive.
+            </p>
           </div>
         </div>
 
         <div class="flex w-full flex-col items-center gap-4">
           <div class="flex w-full flex-col items-center gap-2">
-            <Button class="w-full" onclick={() => (addDriveOpen = true)}>Add a drive</Button>
+            <Button class="w-full" onclick={() => (addDriveOpen = true)}>Set up a drive</Button>
             <Button variant="outline" class="w-full" href={resolve(routes.ROOT)}>
               Stay local for now
             </Button>


### PR DESCRIPTION
Aligns the local/synced account copy with the designer's Figma spec so it uses "drive" language consistently.

## Changes
- **Account-created screen** (`account/new/done`): "…with a drive." → "…with a **Swarm drive**."; primary button "Add a drive" → "**Set up a drive**".
- **Local-account banner** (`home-account`): "Upgrade by **adding a** drive…" → "Upgrade by **setting up a** drive…".

Completes the drive-terminology copy started in #444 (#441). The add-drive dialog intentionally keeps "batch" — that copy names the actual on-chain Swarm Batch (Batch ID, signer key), not generic storage.

Matches Figma nodes `15-948` and `73-3333` from the issue.

Closes #364

🤖 Generated with [Claude Code](https://claude.com/claude-code)