### PR TITLE
docs: align examples with the 0.2.0 API surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,17 @@ const client = new SwarmIdClient({
     name: 'My dApp',
     description: 'A demo Swarm application',
   },
-  onAuthChange: (authenticated) => {
-    console.log('Auth status:', authenticated)
+  onConnectionChange: (info) => {
+    console.log('Connection changed:', info.identity?.name, 'canUpload=', info.canUpload)
   },
 })
 
 await client.initialize()
 
-const status = await client.checkAuthStatus()
-if (status.authenticated) {
+// A connected user can still have canUpload=false (no postage stamp and no
+// subsidised gateway), so gate uploads on both.
+const info = client.connectionInfo
+if (info.identity && info.canUpload) {
   const result = await client.uploadData(new TextEncoder().encode('Hello, Swarm!'))
   console.log('Uploaded:', result.reference)
 }

--- a/demo/README.md
+++ b/demo/README.md
@@ -72,8 +72,8 @@ const client = new SwarmIdClient({
   iframeOrigin: proxyOrigin,
   iframePath: '/proxy',
   timeout: 60000,
-  onAuthChange: async (auth: boolean) => {
-    // Handle auth status changes
+  onConnectionChange: (info) => {
+    // Handle connection/auth status changes
   },
   metadata: {
     name: 'Swarm ID Demo',

--- a/docs-site/src/content/docs/api/index.mdx
+++ b/docs-site/src/content/docs/api/index.mdx
@@ -1604,11 +1604,12 @@ Derive an AES-GCM-256 `CryptoKey` for backup encryption from the `swarmEncryptio
 ### Types
 
 ```typescript
-// Discriminated union of backup headers (passkey | ethereum | agent)
-type EncryptedSwarmIdExport = PasskeyBackupHeader | EthereumBackupHeader | AgentBackupHeader
-
-// Common fields in all headers
-interface BackupHeaderBase {
+// There is a single account model (a BIP-39 seed account), so the header
+// carries no account-type discriminant and no key material. Only the account
+// name and timestamps travel in plaintext; on import the user re-enters the
+// recovery phrase, from which the master key (and everything derived from it)
+// is recomputed.
+interface EncryptedSwarmIdExport {
   version: 1
   accountName: string
   exportedAt: number // Unix timestamp

--- a/docs-site/src/content/docs/getting-started.mdx
+++ b/docs-site/src/content/docs/getting-started.mdx
@@ -42,9 +42,8 @@ await client.initialize()
 // The iframe will show a connect/disconnect button automatically
 
 // 3b. Option B: Manual authentication with connect()
-// Open authentication page in new window/browser tab (useful for custom UI)
-const authUrl = client.connect()
-console.log('Authentication opened at:', authUrl)
+// Opens the authentication page in a new window/tab (useful for custom UI)
+await client.connect()
 
 // 4. Read current connection state synchronously
 const info = client.connectionInfo

--- a/lib/README.md
+++ b/lib/README.md
@@ -33,27 +33,33 @@ const client = new SwarmIdClient({
     name: "My dApp",
     description: "A demo Swarm application",
   },
-  onAuthChange: (authenticated) => {
-    console.log("Auth status:", authenticated)
+  onConnectionChange: (info) => {
+    console.log(
+      "Connection changed:",
+      info.identity?.name,
+      "canUpload=",
+      info.canUpload,
+    )
   },
 })
 
-// 2. Initialize (creates hidden iframe)
+// 2. Initialize (creates hidden iframe; populates client.connectionInfo)
 await client.initialize()
 
 // 3a. Option A: Use iframe authentication button
 // The iframe will show a connect/disconnect button automatically
 
 // 3b. Option B: Manual authentication with connect()
-// Open authentication page in new window/browser tab (useful for custom UI)
-const authUrl = client.connect()
-console.log("Authentication opened at:", authUrl)
+// Opens the authentication page in a new window/tab (useful for custom UI)
+await client.connect()
 
-// 4. Check if user is authenticated
-const status = await client.checkAuthStatus()
+// 4. Read current connection state synchronously
+const info = client.connectionInfo
 
-// 5. Upload data (after authentication)
-if (status.authenticated) {
+// 5. Upload data (requires authentication AND upload capability — a connected
+//    user can still have canUpload=false with no postage stamp and no
+//    subsidised gateway)
+if (info.identity && info.canUpload) {
   const result = await client.uploadData(
     new TextEncoder().encode("Hello, Swarm!"),
   )


### PR DESCRIPTION
Refreshes the human-written docs to match the API changes shipping in the pending **0.2.0** release (release-please PR #323), so the docs (and the npm package readme, which is `lib/README.md`) are correct when 0.2.0 publishes.

### Fixed broken references
- `onAuthChange` → `onConnectionChange` — the old callback was removed (`ClientOptions`).
- `connect()` shown assigned to `authUrl` → it returns `Promise<void>`; use `await client.connect()`.
- `api/index.mdx`: `EncryptedSwarmIdExport` was documented as a `passkey | ethereum | agent` discriminated union — it's now a single flat header (unified BIP-39 seed account model, #377).

### Modernized examples
- Root README post-init example now uses the synchronous `client.connectionInfo` / `canUpload` gate that `getting-started.mdx` and `api/index.mdx` already promote (instead of `checkAuthStatus()` + `authenticated`).

Docs-only; `pnpm build:docs` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)