### PR TITLE
fix(lib)!: remove unsafe utilization-cache LRU eviction

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -111,15 +111,11 @@ export {
 } from "./schemas"
 
 // Utilization storage (IndexedDB cache)
-export {
-  UtilizationStoreDB,
-  evictOldEntries,
-} from "./storage/utilization-store"
+export { UtilizationStoreDB } from "./storage/utilization-store"
 
 export type {
   ChunkCacheEntry,
   BatchMetadata,
-  CacheEvictionPolicy,
 } from "./storage/utilization-store"
 
 // Debounced utilization uploader

--- a/lib/src/storage/utilization-store.ts
+++ b/lib/src/storage/utilization-store.ts
@@ -153,7 +153,8 @@ export class UtilizationStoreDB {
         // Index for querying by batchId
         chunksStore.createIndex("batchId", "batchId", { unique: false })
 
-        // Index for eviction by lastAccess
+        // Unused since LRU eviction was removed (#419); kept to avoid a
+        // schema version bump just to drop an index.
         chunksStore.createIndex("lastAccess", "lastAccess", {
           unique: false,
         })
@@ -367,82 +368,4 @@ export class UtilizationStoreDB {
       this.db = undefined
     }
   }
-}
-
-// ============================================================================
-// Cache Eviction
-// ============================================================================
-
-/**
- * Policy for cache eviction
- */
-export interface CacheEvictionPolicy {
-  /** Maximum age in milliseconds (default: 7 days) */
-  maxAge?: number
-
-  /** Maximum number of chunks to keep (default: 640) */
-  maxChunks?: number
-}
-
-/**
- * Evict old cache entries based on policy
- * @param cache - Cache database instance
- * @param policy - Eviction policy
- */
-export async function evictOldEntries(
-  cache: UtilizationStoreDB,
-  policy: CacheEvictionPolicy = {},
-): Promise<void> {
-  const maxAge = policy.maxAge ?? 7 * 24 * 60 * 60 * 1000 // 7 days
-  const maxChunks = policy.maxChunks ?? 640 // ≈10–20 batches depending on depth
-
-  await cache.open()
-
-  const db = (cache as never)["db"] as IDBDatabase
-
-  return new Promise((resolve, reject) => {
-    const transaction = db.transaction([CHUNKS_STORE], "readwrite")
-    const store = transaction.objectStore(CHUNKS_STORE)
-    const index = store.index("lastAccess")
-
-    const oldestAllowed = Date.now() - maxAge
-    const entries: Array<{ key: IDBValidKey; lastAccess: number }> = []
-
-    // Collect all entries with their lastAccess times
-    const request = index.openCursor()
-
-    request.onsuccess = () => {
-      const cursor = request.result
-      if (cursor) {
-        const entry = cursor.value as ChunkCacheEntry
-        entries.push({
-          key: cursor.primaryKey,
-          lastAccess: entry.lastAccess,
-        })
-        cursor.continue()
-      } else {
-        // All entries collected, now evict
-        // 1. Delete entries older than maxAge
-        for (const entry of entries) {
-          if (entry.lastAccess < oldestAllowed) {
-            store.delete(entry.key)
-          }
-        }
-
-        // 2. If still over maxChunks, delete oldest entries
-        if (entries.length > maxChunks) {
-          entries.sort((a, b) => a.lastAccess - b.lastAccess)
-          const toDelete = entries.slice(0, entries.length - maxChunks)
-          for (const entry of toDelete) {
-            store.delete(entry.key)
-          }
-        }
-      }
-    }
-
-    transaction.oncomplete = () => resolve()
-    transaction.onerror = () => {
-      reject(new Error(`Failed to evict entries: ${transaction.error}`))
-    }
-  })
 }

--- a/lib/src/storage/utilization-store.ts
+++ b/lib/src/storage/utilization-store.ts
@@ -153,12 +153,6 @@ export class UtilizationStoreDB {
         // Index for querying by batchId
         chunksStore.createIndex("batchId", "batchId", { unique: false })
 
-        // Unused since LRU eviction was removed (#419); kept to avoid a
-        // schema version bump just to drop an index.
-        chunksStore.createIndex("lastAccess", "lastAccess", {
-          unique: false,
-        })
-
         // Metadata store
         db.createObjectStore(METADATA_STORE, { keyPath: "batchId" })
       }


### PR DESCRIPTION
## Problem

`evictOldEntries` LRU-deleted chunk rows of the utilization store. For a still-active batch, `loadUtilizationState` then re-seeds the missing range as zeroed/dirty, so the stamper restarts those buckets at slot 0 and **overstamps existing user data** (Bee evicts the older chunk at a colliding stamp index). It also reached into the store's private `db` field via `(cache as never)["db"]`.

## Why removal instead of hardening

- **Zero callers**: `evictOldEntries` was exported but never wired up anywhere in the monorepo (shipped with #111).
- **No safe eviction exists**: for legacy single-device accounts the local counter is *authoritative* — there is no on-Swarm state to resync from, so both suggested mitigations (active-batch allowlist, "must resync" marker) still end in counter loss or a permanent error.
- **No growth problem**: counters are ≤256KB per batch; `clearBatch` remains for explicit removal.

The unused `lastAccess` index is dropped from the `onupgradeneeded` handler — no `DB_VERSION` bump needed (fresh DBs won’t create it; existing v3 DBs keep a harmless orphan index nothing queries). Deliberately not bumping to v4: the upgrade handler drops both stores, which would wipe authoritative local counters.

**BREAKING CHANGE**: `evictOldEntries` and `CacheEvictionPolicy` are no longer exported from `@snaha/swarm-id`.

Closes #419

🤖 Generated with [Claude Code](https://claude.com/claude-code)
