### PR TITLE
perf(lib): cut fold-from-Swarm over-reads on roster scan and epoch probes

### DIFF
--- a/lib/src/proxy/feeds/epochs/async-finder.test.ts
+++ b/lib/src/proxy/feeds/epochs/async-finder.test.ts
@@ -1,0 +1,112 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * `AsyncEpochFinder.findAt` probing behaviour (#400): the exact-timestamp
+ * fast-path probe must not run in SERIES before the tree traversal — on a
+ * "latest as of now" read (every fold) it never hits and would otherwise cost a
+ * full absent-chunk timeout before the traversal even starts. Its result
+ * preference is unchanged: an exact hit wins even when the traversal finds
+ * nothing (poisoned-ancestor recovery, the reason the fast path exists).
+ */
+
+import { describe, it, expect, vi } from "vitest"
+import { EthAddress, Reference, Topic } from "@ethersphere/bee-js"
+import { Binary } from "cafe-utility"
+import { AsyncEpochFinder } from "./async-finder"
+import { EpochIndex, MAX_LEVEL } from "./epoch"
+
+const TOPIC = Topic.fromString("async-finder-test")
+const OWNER = new EthAddress("a".repeat(40))
+const AT = 1_700_000_000n
+
+/** The chunk address `getEpochChunk` computes for an epoch of our topic/owner. */
+async function epochAddressHex(epoch: EpochIndex): Promise<string> {
+  const epochHash = await epoch.marshalBinary()
+  const identifier = Binary.keccak256(
+    Binary.concatBytes(TOPIC.toUint8Array(), epochHash),
+  )
+  return new Reference(
+    Binary.keccak256(Binary.concatBytes(identifier, OWNER.toUint8Array())),
+  ).toHex()
+}
+
+/** A minimal unencrypted SOC feed chunk: 40-byte payload = ts(8 BE) + ref(32). */
+function socChunk(timestamp: bigint, ref: Uint8Array): Uint8Array {
+  const IDENTIFIER_SIZE = 32
+  const SIGNATURE_SIZE = 65
+  const SPAN_SIZE = 8
+  const TIMESTAMP_SIZE = 8
+  const PAYLOAD_LENGTH = TIMESTAMP_SIZE + ref.length
+  const spanStart = IDENTIFIER_SIZE + SIGNATURE_SIZE
+  const chunk = new Uint8Array(spanStart + SPAN_SIZE + PAYLOAD_LENGTH)
+  const view = new DataView(chunk.buffer)
+  view.setBigUint64(spanStart, BigInt(PAYLOAD_LENGTH), true) // span, LE
+  view.setBigUint64(spanStart + SPAN_SIZE, timestamp, false) // timestamp, BE
+  chunk.set(ref, spanStart + SPAN_SIZE + TIMESTAMP_SIZE)
+  return chunk
+}
+
+function notFound(): Error {
+  return Object.assign(new Error("chunk not found"), { status: 404 })
+}
+
+describe("AsyncEpochFinder — exact probe does not gate the traversal (#400)", () => {
+  it("issues the root traversal before the exact-timestamp probe settles", async () => {
+    const exactAddr = await epochAddressHex(new EpochIndex(AT, 0))
+    const rootAddr = await epochAddressHex(new EpochIndex(0n, MAX_LEVEL))
+    const requested: string[] = []
+    let failExact!: () => void
+    const exactGate = new Promise<Uint8Array>((_, reject) => {
+      failExact = () => reject(notFound())
+    })
+    const bee = {
+      downloadChunk: (addr: string) => {
+        requested.push(addr)
+        if (addr === exactAddr) return exactGate // gateway still probing peers
+        return Promise.reject(notFound())
+      },
+    }
+
+    const finder = new AsyncEpochFinder(bee as never, TOPIC, OWNER)
+    const pending = finder.findAt(AT)
+    // The root request must go out while the exact probe is still in flight.
+    await vi.waitFor(() => expect(requested).toContain(rootAddr))
+    failExact()
+    await expect(pending).resolves.toBeUndefined()
+  })
+
+  it("an exact hit wins even when the traversal finds nothing (poisoned ancestors)", async () => {
+    const exactAddr = await epochAddressHex(new EpochIndex(AT, 0))
+    const ref = new Uint8Array(32).fill(7)
+    const bee = {
+      downloadChunk: async (addr: string) => {
+        if (addr === exactAddr) return socChunk(AT, ref)
+        throw notFound() // every ancestor missing
+      },
+    }
+    const result = await new AsyncEpochFinder(
+      bee as never,
+      TOPIC,
+      OWNER,
+    ).findAt(AT)
+    expect(result).toEqual(ref)
+  })
+
+  it("an exact miss falls back to the traversal's result", async () => {
+    const rootAddr = await epochAddressHex(new EpochIndex(0n, MAX_LEVEL))
+    const ref = new Uint8Array(32).fill(9)
+    const bee = {
+      downloadChunk: async (addr: string) => {
+        if (addr === rootAddr) return socChunk(AT - 100n, ref)
+        throw notFound()
+      },
+    }
+    const result = await new AsyncEpochFinder(
+      bee as never,
+      TOPIC,
+      OWNER,
+    ).findAt(AT)
+    expect(result).toEqual(ref)
+  })
+})

--- a/lib/src/proxy/feeds/epochs/async-finder.ts
+++ b/lib/src/proxy/feeds/epochs/async-finder.ts
@@ -45,23 +45,23 @@ export class AsyncEpochFinder implements EpochFinder {
     after: bigint = 0n,
   ): Promise<Uint8Array | undefined> {
     // Fast path: exact timestamp updates are written at level-0 and should be
-    // retrievable without traversing potentially poisoned ancestors.
-    const exactEpoch = new EpochIndex(at, 0)
-    try {
-      const exact = await this.getEpochChunk(at, exactEpoch)
-      if (exact) {
-        return exact
-      }
-    } catch {
-      // Ignore and fall back to tree traversal.
-    }
-
-    // Start from top epoch and traverse down
-    const traversed = await this.findAtEpoch(
-      at,
-      new EpochIndex(0n, MAX_LEVEL),
-      undefined,
+    // retrievable without traversing potentially poisoned ancestors. It runs
+    // CONCURRENTLY with the traversal (#400): on a "latest as of now" read
+    // (every account fold) the exact probe virtually never hits, and awaiting
+    // it first serialised a full absent-chunk timeout before the traversal even
+    // started. Both are awaited — not raced — because an exact hit must win
+    // even when the traversal returns nothing (that IS the poisoned-ancestor
+    // recovery this fast path exists for).
+    const exactProbe = this.getEpochChunk(at, new EpochIndex(at, 0)).catch(
+      () => undefined,
     )
+    const [exact, traversed] = await Promise.all([
+      exactProbe,
+      this.findAtEpoch(at, new EpochIndex(0n, MAX_LEVEL), undefined),
+    ])
+    if (exact) {
+      return exact
+    }
     if (traversed) {
       return traversed
     }

--- a/lib/src/sync/device-roster.test.ts
+++ b/lib/src/sync/device-roster.test.ts
@@ -15,6 +15,7 @@ vi.mock("../proxy/download-data", () => ({
 import {
   readRoster,
   ensureInRoster,
+  resetRosterScanCache,
   RosterScanInconclusiveError,
   rosterTopic,
   rosterIdentifier,
@@ -22,6 +23,12 @@ import {
 
 const OWNER = new EthAddress("a".repeat(40))
 const ACCOUNT_ID = "b".repeat(40)
+
+// Every test shares one ACCOUNT_ID/OWNER — forget the known-length memo between
+// tests so a warm scan in one test can't change another's probing.
+beforeEach(() => {
+  resetRosterScanCache()
+})
 
 function makeDevice(index: number): Device {
   return {
@@ -56,9 +63,10 @@ function serverError500(): Error {
 /**
  * Fake Bee that serves roster SOCs ONLY for `presentIndices`. Reverse-maps the
  * requested identifier back to its index via `rosterIdentifier`, so the windowed
- * scan exercises real gap detection.
+ * scan exercises real gap detection. Pass `probed` to record which indices the
+ * scan actually read (in request order).
  */
-function fakeBee(presentIndices: Set<number>) {
+function fakeBee(presentIndices: Set<number>, probed?: number[]) {
   const topic = rosterTopic(ACCOUNT_ID)
   const identToIndex = new Map<string, number>()
   for (let i = 0; i < 64; i++) {
@@ -68,6 +76,7 @@ function fakeBee(presentIndices: Set<number>) {
     makeSOCReader: () => ({
       download: async (identifier: { toHex(): string }) => {
         const index = identToIndex.get(identifier.toHex())
+        if (index !== undefined) probed?.push(index)
         if (index === undefined || !presentIndices.has(index)) {
           throw notFound404()
         }
@@ -351,5 +360,81 @@ describe("readRoster / ensureInRoster — inconclusive is not empty", () => {
       target: { mode: "stamper" } as never,
     })
     expect(downloadChunk).not.toHaveBeenCalled()
+  })
+})
+
+describe("readRoster — known-length memo (#400)", () => {
+  const scan = (present: Set<number>, probed?: number[]) =>
+    readRoster({
+      bee: fakeBee(present, probed) as never,
+      accountId: ACCOUNT_ID,
+      owner: OWNER,
+    })
+
+  beforeEach(() => {
+    mockDownloadData.mockReset()
+    mockDownloadData.mockImplementation((_bee: unknown, refHex: string) => {
+      const index = parseInt(refHex.slice(0, 2), 16)
+      return new TextEncoder().encode(JSON.stringify(makeDevice(index)))
+    })
+  })
+
+  it("keeps the full stop window on a cold scan (no memo yet)", async () => {
+    const probed: number[] = []
+    await scan(new Set([0, 1]), probed)
+    // Window [0..15] (2 present) + full empty stop window [16..31] — the
+    // conservative cold-scan margin is unchanged.
+    expect(probed).toHaveLength(32)
+  })
+
+  it("a warm rescan probes only the known range plus a short tail", async () => {
+    await scan(new Set([0, 1])) // cold scan primes the memo (length 2)
+    const probed: number[] = []
+    const devices = await scan(new Set([0, 1]), probed)
+    expect(devices.map((d) => d.deviceId).sort()).toEqual(["dev-0", "dev-1"])
+    // Known range [0,1] + ROSTER_TAIL_PROBES (2) past it — not another 32 reads.
+    expect(probed).toHaveLength(4)
+    expect(Math.max(...probed)).toBe(3)
+  })
+
+  it("a warm rescan still discovers entries appended past the memo", async () => {
+    await scan(new Set([0, 1])) // memo = 2
+    const probed: number[] = []
+    const devices = await scan(new Set([0, 1, 2]), probed) // peer appended at 2
+    expect(devices).toHaveLength(3)
+    expect(devices.some((d) => d.deviceId === "dev-2")).toBe(true)
+    // Tail probe hits index 2 → the scan continues past it, still far under a
+    // cold scan's 32 reads.
+    expect(probed.length).toBeLessThanOrEqual(8)
+  })
+
+  it("never shrinks the memo on a stale read (holes inside the known range)", async () => {
+    await scan(new Set([0, 1, 2])) // memo = 3
+    // A stale endpoint cleanly-404s indices 1 and 2 — holes, folded around.
+    const stale = await scan(new Set([0]))
+    expect(stale.map((d) => d.deviceId)).toEqual(["dev-0"])
+    // The memo must still cover index 2, so a later scan re-reads it directly.
+    const probed: number[] = []
+    const recovered = await scan(new Set([0, 1, 2]), probed)
+    expect(recovered).toHaveLength(3)
+    expect(probed).toHaveLength(5) // known range [0..2] + 2 tail probes
+  })
+
+  it("persists the length to localStorage and seeds a fresh session from it", async () => {
+    const store = new Map<string, string>()
+    vi.stubGlobal("localStorage", {
+      getItem: (k: string) => store.get(k) ?? null,
+      setItem: (k: string, v: string) => void store.set(k, v),
+    })
+    try {
+      await scan(new Set([0, 1])) // memo → localStorage
+      resetRosterScanCache() // "page reload": in-memory memo gone
+      const probed: number[] = []
+      const devices = await scan(new Set([0, 1]), probed)
+      expect(devices).toHaveLength(2)
+      expect(probed).toHaveLength(4) // seeded from localStorage, warm scan
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 })

--- a/lib/src/sync/device-roster.ts
+++ b/lib/src/sync/device-roster.ts
@@ -56,6 +56,66 @@ const MAX_ROSTER_SCAN = 256
 // a single round-trip instead of K+1 serial ones.
 const ROSTER_SCAN_WINDOW = 16
 
+// How many indices to probe past a KNOWN roster length to detect new appends
+// (#400). Absent-slot probes are the expensive kind (Bee has no fast
+// authoritative 404), so once a scan has proven the roster reaches N we only
+// need a short lookahead — a transient 404 here can at worst delay discovering
+// a BRAND-NEW device until the next fold (minutes), never drop a known one.
+// Cold scans (no memo) keep the full ROSTER_SCAN_WINDOW stop margin.
+const ROSTER_TAIL_PROBES = 2
+
+/**
+ * Known roster length per `accountId:owner` — a monotonic LOWER bound learned
+ * from previous scans/appends (#400). The roster is append-only, so a once-seen
+ * length can never overshoot; it must also never shrink (a stale endpoint's
+ * truncated read must not poison later scans). Mirrored to localStorage when
+ * available so a page reload's first fold is warm too; in Node (tests, CLI) the
+ * mirror self-disables and only the in-memory memo applies.
+ */
+const knownRosterLength = new Map<string, number>()
+
+const ROSTER_LENGTH_STORAGE_PREFIX = "swarm-id-roster-len"
+
+function rosterMemoKey(accountId: string, owner: EthAddress): string {
+  return `${accountId}:${owner.toHex()}`
+}
+
+function getKnownRosterLength(key: string): number {
+  const cached = knownRosterLength.get(key)
+  if (cached !== undefined) return cached
+  if (typeof localStorage === "undefined") return 0
+  let raw: string | null
+  try {
+    raw = localStorage.getItem(`${ROSTER_LENGTH_STORAGE_PREFIX}:${key}`)
+  } catch {
+    return 0
+  }
+  const parsed = raw === null ? 0 : Number.parseInt(raw, 10)
+  const length =
+    Number.isInteger(parsed) && parsed > 0
+      ? Math.min(parsed, MAX_ROSTER_SCAN)
+      : 0
+  knownRosterLength.set(key, length)
+  return length
+}
+
+function bumpKnownRosterLength(key: string, length: number): void {
+  const capped = Math.min(length, MAX_ROSTER_SCAN)
+  if (capped <= getKnownRosterLength(key)) return
+  knownRosterLength.set(key, capped)
+  if (typeof localStorage === "undefined") return
+  try {
+    localStorage.setItem(`${ROSTER_LENGTH_STORAGE_PREFIX}:${key}`, `${capped}`)
+  } catch {
+    // Quota/permission failure only costs the cross-reload warm-up.
+  }
+}
+
+/** Test-only: forget every memoised roster length (in-memory module state). */
+export function resetRosterScanCache(): void {
+  knownRosterLength.clear()
+}
+
 // Per-read cap so an empty/unreachable slot on a slow gateway fails fast instead
 // of hanging on peer-exhaustion. A present slot retrieves well under this.
 // Matches the epoch finder's bound. An inconclusive read (timeout / 5xx /
@@ -154,7 +214,11 @@ export async function readRoster(opts: {
   owner: EthAddress
 }): Promise<Device[]> {
   const topic = rosterTopic(opts.accountId)
+  const memoKey = rosterMemoKey(opts.accountId, opts.owner)
+  const known = getKnownRosterLength(memoKey)
   let devices: Device[] = []
+  // One past the highest index seen present in THIS scan — feeds the memo.
+  let scanEnd = 0
   // Scan in parallel windows. Appends are contiguous (the same-index race
   // re-adds at the new tail, never leaving a permanent hole), so no real entry
   // lives past the true end. A hole *inside* an otherwise-present window is
@@ -162,11 +226,21 @@ export async function readRoster(opts: {
   // roster exists to survive — so we skip it and keep folding later entries
   // rather than truncating every device after it. Only a window with no present
   // entry means we may have scanned past the end of the feed.
-  for (let base = 0; base < MAX_ROSTER_SCAN; base += ROSTER_SCAN_WINDOW) {
-    const indices = Array.from(
-      { length: Math.min(ROSTER_SCAN_WINDOW, MAX_ROSTER_SCAN - base) },
-      (_, i) => BigInt(base + i),
-    )
+  //
+  // Window sizing (#400): the memoised known range [0..known) is read as ONE
+  // parallel window (all expected hits — cheap), and past it only
+  // ROSTER_TAIL_PROBES slots are probed to detect new appends. With no memo the
+  // full ROSTER_SCAN_WINDOW stop margin applies, so a cold scan (restore,
+  // first-ever fold) is exactly as conservative as before.
+  for (let base = 0; base < MAX_ROSTER_SCAN; ) {
+    const width =
+      base < known
+        ? known - base
+        : Math.min(
+            known > 0 ? ROSTER_TAIL_PROBES : ROSTER_SCAN_WINDOW,
+            MAX_ROSTER_SCAN - base,
+          )
+    const indices = Array.from({ length: width }, (_, i) => BigInt(base + i))
     let entries = await Promise.all(
       indices.map((index) =>
         readRosterEntry({ bee: opts.bee, topic, owner: opts.owner, index }),
@@ -194,9 +268,12 @@ export async function readRoster(opts: {
         ),
       )
     }
-    for (const entry of entries) {
-      if (isDevice(entry)) devices = mergeDevicesList(devices, [entry])
-    }
+    entries.forEach((entry, i) => {
+      if (isDevice(entry)) {
+        devices = mergeDevicesList(devices, [entry])
+        scanEnd = base + i + 1
+      }
+    })
     // Stop on a window with no present entry. If that window is still
     // inconclusive after the retry AND we have folded nothing, we cannot tell an
     // empty roster from an outage — surface it rather than lie "[] = no devices",
@@ -211,7 +288,9 @@ export async function readRoster(opts: {
       }
       break
     }
+    base += width
   }
+  if (devices.length > 0) bumpKnownRosterLength(memoKey, scanEnd)
   return devices
 }
 
@@ -247,6 +326,11 @@ async function appendToRoster(opts: {
   const updater = new BasicSequentialUpdater(opts.bee, topic, opts.accountKey)
   updater.setState({ nextIndex: next })
   await updater.update(refBytes, opts.target.stamper)
+  // Our own append proves the roster now reaches next+1 — warm the scan memo.
+  bumpKnownRosterLength(
+    rosterMemoKey(opts.accountId, opts.owner),
+    Number(next) + 1,
+  )
 }
 
 function isStamperTarget(

--- a/lib/test/live/fold-latency.test.ts
+++ b/lib/test/live/fold-latency.test.ts
@@ -1,0 +1,155 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Fold-latency benchmark for #400: measures what `foldAccountFromSwarm` costs
+ * against a real gateway for a small (2-device) account — wall-clock time AND
+ * Bee read count per fold — the product's page-load / recurring (#389) fold.
+ *
+ * Publishes a steady-state 2-device account, then runs 10 sequential folds and
+ * prints a per-fold table + summary stats. Asserts only convergence (both
+ * devices in every fold); the timings are the deliverable, not an assertion —
+ * gateway variance would make a hard latency bound flaky.
+ *
+ * Caveat when comparing runs: the gateway negative-caches absent chunks (~50s),
+ * so back-to-back folds resolve absent-slot probes faster than the product's
+ * minutes-apart folds. Both before/after runs share that bias.
+ *
+ * Opt-in — skips unless a `.env` configures BATCH_ID/SIGNER_KEY (see README).
+ */
+
+import { describe, it, expect, beforeAll } from "vitest"
+import type { Bee } from "@ethersphere/bee-js"
+import { publishDeviceState } from "../../src/sync/device-state"
+import { foldAccountFromSwarm } from "../../src/sync/fold-account-from-swarm"
+import {
+  liveEnv,
+  createContext,
+  deriveAgentKeys,
+  deviceId,
+  makeDevice,
+  makeView,
+  foldUntil,
+  delay,
+  type LiveContext,
+} from "./env"
+
+const FOLD_RUNS = 10
+
+/**
+ * Wrap a Bee so every chunk/SOC read increments `reads` — `downloadChunk` and
+ * `makeSOCReader().download` are the only two read paths the fold uses
+ * (roster SOCs, epoch-finder probes, and `downloadDataWithChunkAPI` blobs).
+ */
+function withReadCounter(bee: Bee): { bee: Bee; counter: { reads: number } } {
+  const counter = { reads: 0 }
+  const proxied = new Proxy(bee, {
+    get(target, prop) {
+      if (prop === "downloadChunk") {
+        return (...args: Parameters<Bee["downloadChunk"]>) => {
+          counter.reads++
+          return target.downloadChunk(...args)
+        }
+      }
+      if (prop === "makeSOCReader") {
+        return (...args: Parameters<Bee["makeSOCReader"]>) => {
+          const reader = target.makeSOCReader(...args)
+          return {
+            ...reader,
+            download: (...a: Parameters<(typeof reader)["download"]>) => {
+              counter.reads++
+              return reader.download(...a)
+            },
+          }
+        }
+      }
+      // Bind methods to the real instance so bee-js internals (private state)
+      // keep working through the proxy.
+      const value = Reflect.get(target, prop, target)
+      return typeof value === "function" ? value.bind(target) : value
+    },
+  })
+  return { bee: proxied, counter }
+}
+
+describe.skipIf(!liveEnv.configured)("live — fold latency (#400)", () => {
+  let ctx: LiveContext
+  let keys: Awaited<ReturnType<typeof deriveAgentKeys>>
+  let DEVICE_A: string
+  let DEVICE_B: string
+
+  beforeAll(async () => {
+    ctx = createContext()
+    keys = await deriveAgentKeys()
+    DEVICE_A = deviceId("device-a")
+    DEVICE_B = deviceId("device-b")
+    console.log(`account ${keys.accountId}  A=${DEVICE_A}  B=${DEVICE_B}`)
+  })
+
+  it("publishes a steady-state 2-device account", async () => {
+    const pub = (
+      device: ReturnType<typeof makeDevice>,
+      view: ReturnType<typeof makeView>,
+    ) =>
+      publishDeviceState({
+        bee: ctx.bee,
+        accountId: keys.accountId,
+        device,
+        accountKey: keys.accountKey,
+        owner: keys.owner,
+        encryptionKey: keys.encryptionKey,
+        view,
+        target: ctx.target,
+      })
+
+    const sA = await pub(makeDevice(DEVICE_A, "Device A"), makeView())
+    expect(sA.status).not.toBe("error")
+    // Space the announces past the gateway's ~50s negative cache so B's roster
+    // append sees A's entry (same reason as per-device-sync.test.ts).
+    await delay(liveEnv.propDelayMs)
+    const sB = await pub(makeDevice(DEVICE_B, "Device B"), makeView())
+    expect(sB.status).not.toBe("error")
+
+    const folded = await foldUntil(
+      ctx.bee,
+      keys.derivationKey,
+      keys.accountId,
+      (a) => a.devices.filter((d) => !d.removedAt).length === 2,
+      "2 devices visible",
+    )
+    expect(folded, "steady state reached").toBeDefined()
+  })
+
+  it(`measures ${FOLD_RUNS} sequential folds (time + reads)`, async () => {
+    const { bee, counter } = withReadCounter(ctx.bee)
+    const times: number[] = []
+    const rows: string[] = []
+
+    for (let i = 0; i < FOLD_RUNS; i++) {
+      counter.reads = 0
+      const t0 = Date.now()
+      const folded = await foldAccountFromSwarm({
+        bee,
+        derivationKey: keys.derivationKey,
+        accountId: keys.accountId,
+      })
+      const ms = Date.now() - t0
+      times.push(ms)
+      rows.push(
+        `  fold-${String(i + 1).padStart(2)}  ${String(ms).padStart(7)}ms` +
+          `  reads=${String(counter.reads).padStart(3)}`,
+      )
+      expect(folded, `fold ${i + 1} returned a result`).toBeDefined()
+      expect(folded!.devices).toHaveLength(2)
+    }
+
+    const sorted = [...times].sort((a, b) => a - b)
+    const mean = Math.round(times.reduce((s, t) => s + t, 0) / times.length)
+    const median = sorted[Math.floor(sorted.length / 2)]
+    console.log(
+      `\n  ⏱  fold latency (${FOLD_RUNS} runs, 2 devices, ${liveEnv.beeUrl}):\n` +
+        rows.join("\n") +
+        `\n  min=${sorted[0]}ms  median=${median}ms  mean=${mean}ms  max=${sorted[sorted.length - 1]}ms\n`,
+    )
+  })
+})


### PR DESCRIPTION
## Problem

A 2-device `foldAccountFromSwarm` issued ~40–60 reads against a remote gateway, most of them expensive absent-chunk probes (Bee has no fast authoritative 404, so each burns the full client read timeout). With the product folding on page load + every few minutes (#389), this is the multi-second "refresh took a while" users see.

## Changes

- **Roster known-length memo** (`device-roster.ts`): memoise the last-seen roster length per `accountId:owner` — a monotonic lower bound of the append-only feed, mirrored to localStorage when available. A warm scan reads the known range in one parallel round plus a 2-slot tail probe instead of needing a full extra 16-slot empty window to detect end-of-feed. Cold scans (restore, first-ever fold) keep the conservative full stop window, and the #415 clean-404 vs. inconclusive semantics are untouched. Truncation below the known length becomes impossible — strictly more robust than before.
- **Concurrent exact-probe** (`epochs/async-finder.ts`): `findAt` ran the exact-timestamp fast-path probe in series before the tree traversal; on a "latest as of now" read (every fold) it never hits and cost a full absent-chunk timeout up front. Both now run concurrently; an exact hit still wins (poisoned-ancestor recovery preserved).
- **Live benchmark** (`test/live/fold-latency.test.ts`): publishes a steady-state 2-device account on the real gateway, then times 10 sequential folds and counts Bee reads per fold.

## Measured (api.gateway.ethswarm.org, 10 folds, 2 devices)

| | reads/fold | min | median | mean | max |
|---|---|---|---|---|---|
| before | 42–58 | 1057ms | 2187ms | 2500ms | 4881ms |
| after | **14–16** | **765ms** | **1018ms** | **1689ms** | **3071ms** |

(Back-to-back folds benefit from the gateway's ~50s negative cache; the product's minutes-apart folds sit at the slow end of these ranges, so the real-world win is larger.)

Follow-up candidates (out of scope): seed the epoch traversal with the last-known update timestamp (`after` is accepted but unused by `AsyncEpochFinder`); overlap device-state folds with the roster scan using the memoised device list.

Closes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)