### PR TITLE
fix: converge dApp-only devices on peer account changes

### DIFF
--- a/lib/src/utils/versioned-storage.test.ts
+++ b/lib/src/utils/versioned-storage.test.ts
@@ -1,0 +1,118 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest"
+import { z } from "zod"
+import {
+  VersionedStorageManager,
+  MemoryStorageAdapter,
+  createZodParser,
+  type StorageAdapter,
+} from "./versioned-storage"
+
+interface Item {
+  name: string
+}
+
+const ItemsSchema = z.array(z.object({ name: z.string() }))
+
+function makeManager(
+  storage: StorageAdapter,
+  key = "test-key",
+): VersionedStorageManager<Item> {
+  return new VersionedStorageManager<Item>({
+    key,
+    currentVersion: 1,
+    storage,
+    parsers: { 1: createZodParser(ItemsSchema) },
+  })
+}
+
+describe("VersionedStorageManager — same-window change notification", () => {
+  // The browser's `storage` event only fires in OTHER windows. Two manager
+  // instances living in the SAME window (e.g. the ui accounts store and the
+  // SwarmIdProxy inside the proxy iframe) must still see each other's writes,
+  // so `save()` broadcasts a window-scoped event that other instances relay
+  // to their subscribers.
+  beforeEach(() => {
+    vi.stubGlobal("window", new EventTarget())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("notifies another instance's subscribers on save", () => {
+    const storage = new MemoryStorageAdapter()
+    const writer = makeManager(storage)
+    const reader = makeManager(storage)
+
+    const seen: Item[][] = []
+    reader.subscribe((data) => seen.push(data))
+
+    writer.save([{ name: "x" }])
+
+    expect(seen).toEqual([[{ name: "x" }]])
+  })
+
+  it("does not notify the writing instance's own subscribers", () => {
+    const storage = new MemoryStorageAdapter()
+    const writer = makeManager(storage)
+
+    const seen: Item[][] = []
+    writer.subscribe((data) => seen.push(data))
+
+    writer.save([{ name: "x" }])
+
+    expect(seen).toEqual([])
+  })
+
+  it("does not notify subscribers of a different key", () => {
+    const storage = new MemoryStorageAdapter()
+    const writer = makeManager(storage, "key-a")
+    const reader = makeManager(storage, "key-b")
+
+    const seen: Item[][] = []
+    reader.subscribe((data) => seen.push(data))
+
+    writer.save([{ name: "x" }])
+
+    expect(seen).toEqual([])
+  })
+
+  it("notifies other instances on clear", () => {
+    const storage = new MemoryStorageAdapter()
+    const writer = makeManager(storage)
+    const reader = makeManager(storage)
+    writer.save([{ name: "x" }])
+
+    const seen: Item[][] = []
+    reader.subscribe((data) => seen.push(data))
+
+    writer.clear()
+
+    expect(seen).toEqual([[]])
+  })
+
+  it("stops notifying after unsubscribe", () => {
+    const storage = new MemoryStorageAdapter()
+    const writer = makeManager(storage)
+    const reader = makeManager(storage)
+
+    const seen: Item[][] = []
+    const unsubscribe = reader.subscribe((data) => seen.push(data))
+    unsubscribe()
+
+    writer.save([{ name: "x" }])
+
+    expect(seen).toEqual([])
+  })
+
+  it("save does not throw outside a window environment", () => {
+    vi.unstubAllGlobals()
+    const storage = new MemoryStorageAdapter()
+    const writer = makeManager(storage)
+
+    expect(() => writer.save([{ name: "x" }])).not.toThrow()
+  })
+})

--- a/lib/src/utils/versioned-storage.ts
+++ b/lib/src/utils/versioned-storage.ts
@@ -130,12 +130,26 @@ export class MemoryStorageAdapter implements StorageAdapter {
 // ============================================================================
 
 /**
+ * Window-scoped event broadcast on `save()`/`clear()` so manager instances in
+ * the SAME window see each other's writes — the browser's `storage` event only
+ * fires in other windows.
+ */
+const SAME_WINDOW_WRITE_EVENT = "swarm-id-storage-write"
+
+interface SameWindowWriteDetail {
+  key: string
+  /** The writing manager, so it can skip notifying itself. */
+  source: object
+}
+
+/**
  * Generic versioned storage manager
  */
 export class VersionedStorageManager<T> {
   private options: VersionedStorageOptions<T>
   private listeners: Set<StorageChangeListener<T>> = new Set()
   private boundStorageHandler: ((event: StorageEvent) => void) | undefined
+  private boundSameWindowHandler: ((event: Event) => void) | undefined
 
   constructor(options: VersionedStorageOptions<T>) {
     this.options = options
@@ -183,16 +197,52 @@ export class VersionedStorageManager<T> {
     }
 
     window.addEventListener("storage", this.boundStorageHandler)
+
+    // Same-window writes by OTHER manager instances (the `storage` event never
+    // fires in the window that wrote).
+    this.boundSameWindowHandler = (event: Event) => {
+      const detail = (event as CustomEvent<SameWindowWriteDetail>).detail
+      if (!detail || detail.key !== this.options.key || detail.source === this)
+        return
+
+      const data = this.load()
+      this.notifyListeners(data)
+    }
+
+    window.addEventListener(
+      SAME_WINDOW_WRITE_EVENT,
+      this.boundSameWindowHandler,
+    )
   }
 
   /**
    * Clean up the storage event listener when no more subscribers
    */
   private cleanupStorageEventListener(): void {
-    if (this.boundStorageHandler && typeof window !== "undefined") {
+    if (typeof window === "undefined") return
+    if (this.boundStorageHandler) {
       window.removeEventListener("storage", this.boundStorageHandler)
       this.boundStorageHandler = undefined
     }
+    if (this.boundSameWindowHandler) {
+      window.removeEventListener(
+        SAME_WINDOW_WRITE_EVENT,
+        this.boundSameWindowHandler,
+      )
+      this.boundSameWindowHandler = undefined
+    }
+  }
+
+  /**
+   * Broadcast a write to other manager instances in this window.
+   */
+  private notifySameWindow(): void {
+    if (typeof window === "undefined") return
+    window.dispatchEvent(
+      new CustomEvent<SameWindowWriteDetail>(SAME_WINDOW_WRITE_EVENT, {
+        detail: { key: this.options.key, source: this },
+      }),
+    )
   }
 
   /**
@@ -268,6 +318,7 @@ export class VersionedStorageManager<T> {
       }
 
       this.options.storage.setItem(this.options.key, JSON.stringify(wrapped))
+      this.notifySameWindow()
     } catch (e) {
       console.error(`[${this.options.loggerName ?? "Storage"}] Save failed:`, e)
     }
@@ -278,6 +329,7 @@ export class VersionedStorageManager<T> {
    */
   clear(): void {
     this.options.storage.removeItem(this.options.key)
+    this.notifySameWindow()
   }
 }
 

--- a/ui/src/lib/dev/account-refresh.ts
+++ b/ui/src/lib/dev/account-refresh.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 The Swarm Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 /**
- * Background fold-back for the signed-in account: pull peer/node state from Swarm
+ * Background fold-back for local accounts: pull peer/node state from Swarm
  * into the local account (name, connected apps, stamps, and node truth like a
  * batch's real utilization / TTL). The publish direction is wired app-wide in the
  * root layout; this is the read direction.
@@ -17,6 +17,7 @@ import { runCoalescedAcrossTabs } from '@snaha/swarm-id'
 import { browser } from '$app/environment'
 
 import { refreshAccountFromSwarm } from '$lib/dev/refresh-account-from-swarm'
+import { accountsStore } from '$lib/stores/accounts.svelte'
 import { sessionStore } from '$lib/stores/session.svelte'
 
 // "Every few minutes" — the cross-tab window doubles as the interval, so with N
@@ -36,12 +37,11 @@ const foldCooldownKey = (accountId: string) => `${FOLD_COOLDOWN_KEY_PREFIX}${acc
 const inFlight = new Set<string>()
 
 /**
- * Fold the currently-active account. `force` bypasses the cross-tab cooldown
- * (page load / account switch); the periodic tick passes `false` so it coalesces.
+ * Fold one account. `force` bypasses the cross-tab cooldown (page load /
+ * account switch); the periodic tick passes `false` so it coalesces.
  */
-export async function foldCurrentAccount(force: boolean): Promise<void> {
-  const accountId = sessionStore.currentAccountId
-  if (!accountId || inFlight.has(accountId)) {
+async function foldAccount(accountId: string, force: boolean): Promise<void> {
+  if (inFlight.has(accountId)) {
     return
   }
   inFlight.add(accountId)
@@ -64,6 +64,25 @@ export async function foldCurrentAccount(force: boolean): Promise<void> {
   }
 }
 
+/** Fold the currently-active account (page load / account switch). */
+export async function foldCurrentAccount(force: boolean): Promise<void> {
+  const accountId = sessionStore.currentAccountId
+  if (!accountId) {
+    return
+  }
+  await foldAccount(accountId, force)
+}
+
+/**
+ * Fold EVERY local account, cooldown-respecting. The periodic tick uses this
+ * rather than the current account so a proxy iframe (where the dApp-connected
+ * account need not be the session-current one — or any current is set at all)
+ * still converges on peer changes (#338).
+ */
+async function foldAllAccounts(): Promise<void> {
+  await Promise.all(accountsStore.accounts.map((account) => foldAccount(account.id.toHex(), false)))
+}
+
 /**
  * Stamp the fold cooldown for `accountId` as "just folded". The import/sign-in
  * flow folds directly (not via `foldCurrentAccount`); calling this after it lets
@@ -82,6 +101,10 @@ export function startFoldInterval(): () => void {
   if (!browser) {
     return () => undefined
   }
-  const timer = setInterval(() => void foldCurrentAccount(false), FOLD_INTERVAL_MS)
+  // Immediate first pass so a freshly loaded page (notably a dApp's proxy
+  // iframe) converges right away instead of waiting a full interval. Not
+  // forced, so the cross-tab cooldown still collapses a burst of loads.
+  void foldAllAccounts()
+  const timer = setInterval(() => void foldAllAccounts(), FOLD_INTERVAL_MS)
   return () => clearInterval(timer)
 }


### PR DESCRIPTION
Part of #338 (read/pull triggers) — closes its last remaining gap.

## Problem

A device where the user only interacts through a dApp (the identity UI never opened after the first connect) never converged on peer changes: a rename, default-stamp change, or drive edit made on another device stayed invisible **forever**. Two root causes:

1. The fold engine only ever folded the *session-current* account. The root layout (and its 3-min fold tick) does mount inside the `/proxy` iframe, but the account connected to the dApp need not be the current one — and the fold never covered the rest.
2. Even when a fold ran inside the proxy iframe, the running `SwarmIdProxy` never saw it: `VersionedStorageManager.subscribe` relied solely on the browser `storage` event, which only fires in **other** windows. The proxy caches its auth/stamper and re-derives only via that subscription, so a same-window fold write was invisible to it.

## Changes

- **lib**: `VersionedStorageManager.save()`/`clear()` now broadcast a window-scoped `CustomEvent`; other manager instances for the same key in the same window relay it to their subscribers (the writing instance skips itself). Unit-tested (TDD).
- **ui**: the periodic fold tick now folds **every** local account (per-account cross-tab cooldown unchanged), and `startFoldInterval` runs one immediate cooldown-respecting pass so a freshly loaded page converges right away.

## Testing

- `pnpm check:all` green (941 lib tests incl. 6 new versioned-storage tests).
- E2E against the local bee cluster with a scripted "device A" peer (`scripts/publish-device-a.ts`, untracked) and Playwright as device B:
  1. **Fresh-device restore**: seed-phrase sign-in restored the published name, stamp (set as default), and peer device — not a blank account.
  2. **dApp-only convergence**: connected the demo dApp, closed all identity-UI tabs, renamed the account from the peer script → the proxy iframe's fold pulled the rename, the same-window notification woke the proxy, and the demo sidebar re-rendered to the new name live — no reload, no identity-UI visit.

## Pre-existing finding (not addressed here)

On a small dev cluster, bee answers *absent-chunk* retrievals with `500 no peer found` instead of `404`. `ensureInRoster` treats that as an inconclusive roster read and skips the bootstrap append — so a brand-new account can never write roster slot 0 against a local cluster (restore/fold then fail with `RosterScanInconclusiveError`). Worked around in the e2e by force-writing slot 0; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)