### PR TITLE
fix(lib): confirm absent roster slots via GET /soc when /chunks 500s

### DIFF
--- a/lib/src/sync/device-roster.test.ts
+++ b/lib/src/sync/device-roster.test.ts
@@ -363,6 +363,214 @@ describe("readRoster / ensureInRoster — inconclusive is not empty", () => {
   })
 })
 
+/**
+ * #457 — on a small cluster, Bee's `/chunks` answers an ABSENT chunk with a
+ * persistent 500 ("read chunk failed"), never 404, so the `/chunks`-based SOC
+ * read alone can never confirm an empty slot. `readRosterEntry` must then ask
+ * `GET /soc/{owner}/{id}` (raw fetch — bee-js has no GET wrapper), whose
+ * authoritative JSON 404 confirms absence. Only that validated 404 may stop the
+ * scan; a route-missing 404 (the public gateway's plain-text "Not Found"), any
+ * other status, or a network failure stays inconclusive (#438 fencing).
+ */
+describe("readRoster — /soc absence probe on an inconclusive /chunks read (#457)", () => {
+  const BEE_URL = "http://bee.test"
+
+  // Factories (a Response body is single-use; the retry round re-fetches).
+  type SocProbeResponse = () => Response | Error | "hang"
+
+  /**
+   * Small-cluster fake: `makeSOCReader` (the `/chunks` path) throws 500 for
+   * every slot NOT in `chunksPresent`; the stubbed global fetch serves
+   * `GET /soc/{owner}/{id}` from `socResponses` by roster index (defaulting to
+   * bee's authoritative JSON 404). Returns the fetch spy for call assertions.
+   */
+  function fakeSmallClusterBee(opts: {
+    chunksPresent?: Set<number>
+    socResponses?: Map<number, SocProbeResponse>
+  }) {
+    const topic = rosterTopic(ACCOUNT_ID)
+    const identToIndex = new Map<string, number>()
+    for (let i = 0; i < 64; i++) {
+      identToIndex.set(rosterIdentifier(topic, BigInt(i)).toHex(), i)
+    }
+    const fetchSpy = vi.fn(async (url: string | URL) => {
+      const match = /\/soc\/[0-9a-f]+\/([0-9a-f]+)$/.exec(String(url))
+      const index = match ? identToIndex.get(match[1]) : undefined
+      if (index === undefined) throw new Error(`unexpected fetch: ${url}`)
+      const response = (opts.socResponses?.get(index) ?? beeJson404)()
+      if (response === "hang") return new Promise<Response>(() => {})
+      if (response instanceof Error) throw response
+      return response
+    })
+    vi.stubGlobal("fetch", fetchSpy)
+    const bee = {
+      url: BEE_URL,
+      makeSOCReader: () => ({
+        download: async (identifier: { toHex(): string }) => {
+          const index = identToIndex.get(identifier.toHex())
+          if (index === undefined || !opts.chunksPresent?.has(index)) {
+            throw serverError500() // small cluster: absent chunk = 500, never 404
+          }
+          return { payload: { toUint8Array: () => refForIndex(index) } }
+        },
+      }),
+      downloadChunk: vi.fn(async () => {
+        throw serverError500()
+      }),
+    }
+    return { bee, fetchSpy }
+  }
+
+  /** Bee's authoritative absent-slot answer on `GET /soc`. */
+  function beeJson404(): Response {
+    return new Response(
+      JSON.stringify({
+        code: 404,
+        message: "requested chunk cannot be retrieved",
+      }),
+      {
+        status: 404,
+        headers: { "content-type": "application/json; charset=utf-8" },
+      },
+    )
+  }
+
+  /** A router that doesn't know the /soc route (the public gateway). */
+  function routeMiss404(): Response {
+    return new Response("Not Found", {
+      status: 404,
+      headers: { "content-type": "text/plain; charset=utf-8" },
+    })
+  }
+
+  function socPayload200(index: number): Response {
+    return new Response(new Uint8Array(refForIndex(index)), { status: 200 })
+  }
+
+  beforeEach(() => {
+    mockDownloadData.mockReset()
+    mockDownloadData.mockImplementation((_bee: unknown, refHex: string) => {
+      const index = parseInt(refHex.slice(0, 2), 16)
+      return new TextEncoder().encode(JSON.stringify(makeDevice(index)))
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it("confirms an empty roster via /soc 404s: returns [] instead of throwing", async () => {
+    // The #457 deadlock: fresh account, every /chunks probe 500s. The /soc
+    // probe's JSON 404 confirms every slot empty → [] (today: inconclusive →
+    // RosterScanInconclusiveError → bootstrap never happens).
+    const { bee } = fakeSmallClusterBee({})
+    await expect(
+      readRoster({ bee: bee as never, accountId: ACCOUNT_ID, owner: OWNER }),
+    ).resolves.toEqual([])
+  })
+
+  it("lets ensureInRoster proceed to the bootstrap append on a confirmed-empty roster", async () => {
+    // Mirror of the "skips the append" test: with /soc confirming empty, the
+    // append must START (its sequential finder reads via downloadChunk).
+    const { bee } = fakeSmallClusterBee({})
+    await ensureInRoster({
+      bee: bee as never,
+      accountKey: new PrivateKey("11".repeat(32)),
+      owner: OWNER,
+      encryptionKey: "00".repeat(32),
+      accountId: ACCOUNT_ID,
+      device: makeDevice(0),
+      target: { mode: "subsidised" } as never, // append stops before uploading
+    })
+    expect(bee.downloadChunk).toHaveBeenCalled()
+  })
+
+  it("folds a device the /chunks blip hid when /soc serves the slot (200)", async () => {
+    // Slot 0 present but its /chunks read 500s; /soc returns the payload → the
+    // device is recovered, and the clean /soc 404 on the next window ends the scan.
+    const { bee } = fakeSmallClusterBee({
+      socResponses: new Map([[0, () => socPayload200(0)]]),
+    })
+    const devices = await readRoster({
+      bee: bee as never,
+      accountId: ACCOUNT_ID,
+      owner: OWNER,
+    })
+    expect(devices.map((d) => d.deviceId)).toEqual(["dev-0"])
+  })
+
+  it("treats a route-missing plain-text 404 as inconclusive, not absent", async () => {
+    // A gateway that doesn't route GET /soc 404s EVERY probe. Trusting it would
+    // read a mid-outage roster as empty (truncation → clobber); it must stay
+    // inconclusive and surface as a scan failure when nothing folded.
+    const { bee } = fakeSmallClusterBee({
+      socResponses: new Map(
+        Array.from({ length: 64 }, (_, i) => [i, routeMiss404] as const),
+      ),
+    })
+    await expect(
+      readRoster({ bee: bee as never, accountId: ACCOUNT_ID, owner: OWNER }),
+    ).rejects.toBeInstanceOf(RosterScanInconclusiveError)
+  })
+
+  it("treats a /soc network error as inconclusive", async () => {
+    const { bee } = fakeSmallClusterBee({
+      socResponses: new Map(
+        Array.from(
+          { length: 64 },
+          (_, i) => [i, () => new TypeError("fetch failed")] as const,
+        ),
+      ),
+    })
+    await expect(
+      readRoster({ bee: bee as never, accountId: ACCOUNT_ID, owner: OWNER }),
+    ).rejects.toBeInstanceOf(RosterScanInconclusiveError)
+  })
+
+  it("treats a hanging /soc probe as inconclusive (timeout)", async () => {
+    vi.useFakeTimers()
+    try {
+      const { bee } = fakeSmallClusterBee({
+        socResponses: new Map(
+          Array.from(
+            { length: 64 },
+            (_, i) => [i, () => "hang" as const] as const,
+          ),
+        ),
+      })
+      const promise = readRoster({
+        bee: bee as never,
+        accountId: ACCOUNT_ID,
+        owner: OWNER,
+      })
+      const assertion = expect(promise).rejects.toBeInstanceOf(
+        RosterScanInconclusiveError,
+      )
+      // First round + the one retry, each bounded by the per-read timeout.
+      await vi.advanceTimersByTimeAsync(ROSTER_READ_TIMEOUT_MS)
+      await vi.advanceTimersByTimeAsync(ROSTER_READ_TIMEOUT_MS)
+      await assertion
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it("never touches /soc when /chunks answers (present slots and clean 404s)", async () => {
+    // The production-gateway hot path: /chunks 200s for present slots and the
+    // fakeBee helper's clean 404 ends the scan — the raw probe must not fire.
+    const fetchSpy = vi.fn()
+    vi.stubGlobal("fetch", fetchSpy)
+    const bee = fakeBee(new Set([0, 1]))
+    const devices = await readRoster({
+      bee: bee as never,
+      accountId: ACCOUNT_ID,
+      owner: OWNER,
+    })
+    expect(devices).toHaveLength(2)
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})
+
 describe("readRoster — known-length memo (#400)", () => {
   const scan = (present: Set<number>, probed?: number[]) =>
     readRoster({

--- a/lib/src/sync/device-roster.ts
+++ b/lib/src/sync/device-roster.ts
@@ -155,6 +155,43 @@ export function rosterIdentifier(topic: Topic, index: bigint): Identifier {
   )
 }
 
+const HTTP_NOT_FOUND = 404
+
+/**
+ * Ask Bee's `GET /soc/{owner}/{id}` (raw request — bee-js has no GET wrapper)
+ * whether a roster slot is present. Used only after the `/chunks`-based read
+ * failed ambiguously: a small cluster answers an ABSENT chunk on `/chunks` with
+ * a persistent 500, never 404 (#457), so `/soc` is the only endpoint whose 404
+ * is authoritative there. Returns the SOC payload when present, `undefined` for
+ * a validated absent slot, or {@link ROSTER_READ_INCONCLUSIVE}.
+ *
+ * Only Bee's OWN 404 (a JSON body with `code: 404`) confirms absence: an
+ * endpoint that doesn't route `GET /soc` at all (the public gateway) 404s every
+ * probe with a plain-text "Not Found" — trusting that would read a mid-outage
+ * roster as empty and truncate it (device clobber).
+ */
+async function probeSocSlot(opts: {
+  bee: Bee
+  owner: EthAddress
+  identifier: Identifier
+}): Promise<Uint8Array | undefined | typeof ROSTER_READ_INCONCLUSIVE> {
+  const url = `${opts.bee.url}/soc/${opts.owner.toHex()}/${opts.identifier.toHex()}`
+  try {
+    const response = await withTimeout(
+      fetch(url),
+      ROSTER_READ_TIMEOUT_MS,
+      "roster /soc probe timed out",
+    )
+    if (response.ok) return new Uint8Array(await response.arrayBuffer())
+    if (response.status !== HTTP_NOT_FOUND) return ROSTER_READ_INCONCLUSIVE
+    const body = (await response.json()) as { code?: unknown }
+    return body.code === HTTP_NOT_FOUND ? undefined : ROSTER_READ_INCONCLUSIVE
+  } catch {
+    // Network failure, timeout, or a non-JSON 404 body — all inconclusive.
+    return ROSTER_READ_INCONCLUSIVE
+  }
+}
+
 /**
  * Read one roster entry (the device record) at `index`. Returns the `Device`
  * when present, `undefined` for a clean 404 / garbage blob (a confirmed-empty
@@ -178,10 +215,21 @@ async function readRosterEntry(opts: {
     )
     refBytes = soc.payload.toUint8Array()
   } catch (error) {
-    // Bee's `/soc` returns a clean 404 for a genuinely-absent slot (end-of-feed);
-    // a timeout / 5xx / network error is inconclusive (retried at the stop
-    // boundary) — NOT a confirmed empty slot.
-    return isNotFoundError(error) ? undefined : ROSTER_READ_INCONCLUSIVE
+    // A clean 404 from the `/chunks` read is a genuinely-absent slot
+    // (end-of-feed). Anything else is ambiguous THERE — on a small cluster an
+    // absent chunk 500s persistently (#457) — so ask `GET /soc`, whose 404 is
+    // authoritative, before surfacing the read as inconclusive.
+    if (isNotFoundError(error)) return undefined
+    const probe = await probeSocSlot({
+      bee: opts.bee,
+      owner: opts.owner,
+      identifier,
+    })
+    if (probe instanceof Uint8Array) {
+      refBytes = probe
+    } else {
+      return probe
+    }
   }
   // Split the blob download from the parse: a download failure is a read outcome
   // (404 = empty, else = inconclusive), whereas a parse failure is a genuinely


### PR DESCRIPTION
## Problem

`readRosterEntry` probes roster slots only through bee-js `makeSOCReader().download()`, which issues `GET /chunks/{addr}`. On a small cluster an **absent** chunk answers a persistent **500** ("read chunk failed"), never 404 — so #438's fencing (404 = confirmed-empty, 5xx = inconclusive) can never confirm an empty slot. Fresh account: every slot-0 probe is inconclusive → `readRoster` throws → `ensureInRoster` skips the bootstrap append → **permanent deadlock** (`foldAccountFromSwarm`/`restoreAccountFromSwarm` always fail for that account).

## Why not `/soc`-first (deviation from the issue's suggested fix)

Probing `GET /soc/{owner}/{id}` as the *primary* read is not viable — measured live:

| Endpoint | Public gateway | Local cluster (bee 2.7.1) |
| --- | --- | --- |
| `GET /soc/{owner}/{id}` absent | plain-text `Not Found` 404 — **route not proxied** | authoritative JSON 404 in ~3ms |
| `GET /chunks/{addr}` absent | clean JSON 404 | JSON **500** "read chunk failed" |

On the gateway every `/soc` GET 404s (present or absent), so `/soc`-first would either read present slots as confirmed-empty (roster truncation = device clobber) or pay a wasted round-trip per probe on the production hot path.

## Fix: `/chunks` first, `/soc` as the absence oracle

The `/chunks` read stays exactly as it is. Only when it fails **non-404** (today's inconclusive branch) does `probeSocSlot` ask `GET /soc/{owner}/{id}` raw:

- **200** → slot present; body is the SOC payload (verified byte-identical to bee-js `soc.payload`) — also recovers a device a `/chunks` blip hid
- **404 with Bee's JSON body** (`code: 404`) → authoritative absent → confirmed-empty
- anything else (plain-text 404 route-miss, other status, network error, timeout) → still `ROSTER_READ_INCONCLUSIVE` — #438's fencing is unchanged

The gateway hot path is **byte-identical to before** unless `/chunks` 5xxes, so no latency regression by construction. Epoch finder / `SyncSequentialFinder` stay out of scope per the issue.

## Verification

- **TDD**: 7 new unit tests (small-cluster empty-roster bootstrap, `/soc` 200 recovery, route-miss 404 stays inconclusive, network error/timeout stay inconclusive, hot path never touches `/soc`); the 3 positive ones failed on the old code with exactly the #457 deadlock.
- **Live, local cluster** (bug's habitat): fresh-account bootstrap — pre-fix `readRoster` throws `RosterScanInconclusiveError` (deadlock reproduced); post-fix `readRoster → []` (120ms), `ensureInRoster` appends, device visible, `GET /soc` body === `soc.payload` (64B), absent slot answers `{"code":404}`.
- **Live latency, public gateway, 10 runs each** (pre-fix numbers measured from a pristine `main` worktree):

| metric (ms) | before (main) | after (this PR) |
| --- | --- | --- |
| acquire mean / median | 1341 / 1313.5 | 1391 / 1141.5 |
| total mean / median | 2015 / 1809 | 1829 / 1615 |
| roster-fold mean | 799 | 782 |
| fold mean / median (fold-latency, 10 folds) | 1655 / 1103 | 1729 / 1174 |

Differences are gateway variance (the after-run acquire mean carries one 3338ms cold first run; its median is lower than before's). The hot path is untouched by construction — `/soc` is only consulted after a non-404 `/chunks` failure.

Closes #457

🤖 Generated with [Claude Code](https://claude.com/claude-code)
