### PR TITLE
fix(ui): merge account writes into storage and tolerate malformed account ids

### DIFF
--- a/ui/src/lib/stores/accounts.svelte.test.ts
+++ b/ui/src/lib/stores/accounts.svelte.test.ts
@@ -1,16 +1,153 @@
 // Copyright 2026 The Swarm Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 /**
- * Pins the signed-out invariants of the live `Account` class: `accessMethod`
- * only exists while the vault does, and neither a getter read nor a late
- * `setAccess` (e.g. a change-method ceremony finishing after a cross-tab
- * sign-out) may act on — or resurrect — a wiped vault.
+ * Two suites over the accounts store and its live `Account` class:
+ *
+ * - Store-level: the persist read-merge-write (two-tab race) and tolerance of
+ *   a malformed (tampered) current-account id.
+ * - Class-level: the signed-out invariants — `accessMethod` only exists while
+ *   the vault does, and neither a getter read nor a late `setAccess` (e.g. a
+ *   change-method ceremony finishing after a cross-tab sign-out) may act on —
+ *   or resurrect — a wiped vault.
  */
 import { EthAddress } from '@ethersphere/bee-js'
-import type { SignedInAccount, SignedOutAccount } from '@snaha/swarm-id'
-import { describe, expect, it } from 'vitest'
+import {
+  type Account as AccountRecord,
+  type SignedInAccount,
+  type SignedOutAccount,
+  createAccountsStorageManager,
+} from '@snaha/swarm-id'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { Account } from './accounts.svelte'
+import { Account, accountsStore } from './accounts.svelte'
+
+// The store module reads `browser` and (indirectly, via the lib storage
+// manager) `window.localStorage` at import time — install both before it loads.
+// `browser: false` keeps the boot-time load and the storage listener off; every
+// test builds its state explicitly through `accountsStore.add()`.
+vi.mock('$app/environment', () => ({ browser: false }))
+
+vi.hoisted(() => {
+  const backing = new Map<string, string>()
+  const localStorageStub = {
+    getItem: (key: string) => backing.get(key) ?? null,
+    setItem: (key: string, value: string) => void backing.set(key, value),
+    removeItem: (key: string) => void backing.delete(key),
+    clear: () => backing.clear(),
+  }
+  Object.assign(globalThis, {
+    window: {
+      localStorage: localStorageStub,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      dispatchEvent: () => true,
+    },
+    localStorage: localStorageStub,
+  })
+})
+
+const X_ID_HEX = 'a'.repeat(40)
+const Y_ID_HEX = 'b'.repeat(40)
+
+function record(idHex: string, name: string): AccountRecord {
+  return {
+    id: new EthAddress(idHex),
+    name,
+    createdAt: 1,
+    derivationKey: 'f'.repeat(64),
+    publicKey: '02' + 'ab'.repeat(32),
+    access: { type: 'password', kdfSalt: 'a'.repeat(32), kdfIterations: 1 },
+    encryptedSeed: 'ab'.repeat(44),
+    devices: [],
+    connectedApps: [],
+    postageStamps: [],
+  }
+}
+
+/** Read what is actually persisted, through an independent manager instance. */
+function stored(): AccountRecord[] {
+  return createAccountsStorageManager().load()
+}
+
+/**
+ * Simulate another tab writing account `idHex` with a new name: mutate storage
+ * through a separate manager instance. The store under test only refreshes on
+ * real cross-tab `storage` events (which never fire here), so it stays stale —
+ * exactly the interleaving window of the two-tab race.
+ */
+function otherTabRenames(idHex: string, name: string): void {
+  const manager = createAccountsStorageManager()
+  manager.save(
+    manager
+      .load()
+      .map((account) =>
+        account.id.equals(new EthAddress(idHex)) ? { ...account, name } : account,
+      ),
+  )
+}
+
+beforeEach(() => {
+  accountsStore.clear()
+})
+
+describe('persist read-merge-write (two-tab race)', () => {
+  it('a mutation keeps a concurrent write to ANOTHER account made by another tab', () => {
+    accountsStore.add(record(X_ID_HEX, 'x'))
+    accountsStore.add(record(Y_ID_HEX, 'y'))
+
+    otherTabRenames(Y_ID_HEX, 'y-from-tab2')
+    accountsStore.get(X_ID_HEX)?.rename('x-renamed')
+
+    const names = new Map(stored().map((account) => [account.id.toHex(), account.name]))
+    expect(names.get(new EthAddress(X_ID_HEX).toHex())).toBe('x-renamed')
+    expect(names.get(new EthAddress(Y_ID_HEX).toHex())).toBe('y-from-tab2')
+  })
+
+  it('add() keeps a concurrent write to another account', () => {
+    accountsStore.add(record(X_ID_HEX, 'x'))
+    otherTabRenames(X_ID_HEX, 'x-from-tab2')
+
+    accountsStore.add(record(Y_ID_HEX, 'y'))
+
+    const names = new Map(stored().map((account) => [account.id.toHex(), account.name]))
+    expect(names.get(new EthAddress(X_ID_HEX).toHex())).toBe('x-from-tab2')
+    expect(names.get(new EthAddress(Y_ID_HEX).toHex())).toBe('y')
+  })
+
+  it('remove() keeps a concurrent write to another account', () => {
+    accountsStore.add(record(X_ID_HEX, 'x'))
+    accountsStore.add(record(Y_ID_HEX, 'y'))
+    otherTabRenames(Y_ID_HEX, 'y-from-tab2')
+
+    accountsStore.remove(X_ID_HEX)
+
+    const records = stored()
+    expect(records).toHaveLength(1)
+    expect(records[0]?.name).toBe('y-from-tab2')
+  })
+
+  it('a mutation round-trips to storage (sanity)', () => {
+    accountsStore.add(record(X_ID_HEX, 'x'))
+    accountsStore.get(X_ID_HEX)?.rename('x-renamed')
+
+    expect(stored()[0]?.name).toBe('x-renamed')
+  })
+})
+
+describe('malformed account id (tampered current-account key)', () => {
+  it('get() returns undefined instead of throwing', () => {
+    accountsStore.add(record(X_ID_HEX, 'x'))
+
+    expect(accountsStore.get('not-a-valid-address')).toBeUndefined()
+  })
+
+  it('remove() is a no-op instead of throwing', () => {
+    accountsStore.add(record(X_ID_HEX, 'x'))
+
+    expect(() => accountsStore.remove('not-a-valid-address')).not.toThrow()
+    expect(accountsStore.accounts).toHaveLength(1)
+  })
+})
 
 const noCommit = () => {}
 

--- a/ui/src/lib/stores/accounts.svelte.ts
+++ b/ui/src/lib/stores/accounts.svelte.ts
@@ -497,11 +497,27 @@ const storageManager = createAccountsStorageManager()
 
 let accounts = $state<Account[]>([])
 
-/** Save the whole collection to storage — each live instance projects back onto
- * the record union (`toRecord`); the lib serializer converts the byte-class
- * fields to hex. No sync. */
-function persist(): void {
-  storageManager.save(accounts.map((account) => account.toRecord()))
+/**
+ * Persist one account by read-merge-write: re-read the stored collection and
+ * overwrite ONLY this account's record (the live instance projected back onto
+ * the record union via `toRecord`), so a save→save interleaving with another
+ * tab mutating a DIFFERENT account can't clobber that tab's write (in-memory
+ * convergence still comes from the cross-tab `storage` event).
+ * Accepted edge: merging by id means a mutation racing another tab's remove of
+ * the SAME account re-adds it — benign, last-writer-wins. No sync.
+ */
+function persistAccount(account: Account): void {
+  const record = account.toRecord()
+  const stored = storageManager.load()
+  const merged = stored.some((existing) => existing.id.equals(account.id))
+    ? stored.map((existing) => (existing.id.equals(account.id) ? record : existing))
+    : [...stored, record]
+  storageManager.save(merged)
+}
+
+/** Remove one account from storage by read-merge-write (see `persistAccount`). */
+function persistRemoval(id: EthAddress): void {
+  storageManager.save(storageManager.load().filter((record) => !record.id.equals(id)))
 }
 
 /**
@@ -511,7 +527,7 @@ function persist(): void {
  * each `Account` as its `#commit`.
  */
 function commitAccount(account: Account, options?: { skipSync?: boolean }): void {
-  persist()
+  persistAccount(account)
   if (!options?.skipSync) syncHook?.(account.id.toHex())
 }
 
@@ -547,10 +563,18 @@ if (browser) {
   })
 }
 
-function toEthAddress(id: string | EthAddress): EthAddress {
+function toEthAddress(id: string | EthAddress): EthAddress | undefined {
   // `EthAddress` parses a bare or `0x`-prefixed hex string, so a raw stored id
-  // and a caller's `.toHex()` both work.
-  return typeof id === 'string' ? new EthAddress(id) : id
+  // and a caller's `.toHex()` both work. `undefined` on malformed input: ids
+  // arrive from localStorage (`swarm-id-current-account-v2`) inside render-time
+  // `$derived`s, so a tampered value must fall through to the "no account"
+  // paths instead of white-screening every page.
+  if (typeof id !== 'string') return id
+  try {
+    return new EthAddress(id)
+  } catch {
+    return undefined
+  }
 }
 
 export const accountsStore = {
@@ -560,7 +584,7 @@ export const accountsStore = {
 
   get(id: string | EthAddress): Account | undefined {
     const ethId = toEthAddress(id)
-    return accounts.find((account) => account.id.equals(ethId))
+    return ethId && accounts.find((account) => account.id.equals(ethId))
   },
 
   /** Create — or replace, for sign-in / restore — an account; returns the live object. */
@@ -569,19 +593,20 @@ export const accountsStore = {
     if (existing) {
       // Reuse the instance so references held elsewhere keep working.
       existing.applyRecord(record)
-      persist()
+      persistAccount(existing)
       return existing
     }
     const account = hydrate(record)
     accounts = [...accounts, account]
-    persist()
+    persistAccount(account)
     return account
   },
 
   remove(id: string | EthAddress): void {
     const ethId = toEthAddress(id)
+    if (!ethId) return
     accounts = accounts.filter((account) => !account.id.equals(ethId))
-    persist()
+    persistRemoval(ethId)
   },
 
   // ----- Dev-only: consumed only by the /dev tooling (see the class banner) ---


### PR DESCRIPTION
Fixes the two accounts-store correctness bugs from #422, TDD-style (failing tests first).

## What changed

- **Persist race**: `persist()` saved the whole in-memory collection, so two tabs mutating *different* accounts could interleave save→save and silently lose one tab's write — below the sync layer's per-field LWW clocks. Every write is now read-merge-write scoped to exactly the account being changed: `persistAccount()` (commit + add) re-reads the stored collection and overwrites only that account's record; `persistRemoval()` (remove) filters only the removed id. In-memory convergence still comes from the existing cross-tab `storage`-event `refresh()`. Accepted edge (commented in code): a mutation racing another tab's remove of the *same* account re-adds it — benign LWW.
- **Render crash**: `toEthAddress()` did `new EthAddress(id)`, which throws on malformed input, inside render-time `$derived`s (`home`, `account/ready`, `connect/done`, `account/new/done`) — a tampered `swarm-id-current-account-v2` localStorage value white-screened every page. It now returns `undefined` on unparseable input; `get()` returns `undefined` and `remove()` no-ops, falling through to the existing `{#if account}` chooser path.

## Tests

New `ui/src/lib/stores/accounts.svelte.test.ts` (first vitest coverage of a runes store in `ui/`): the two-tab race for mutate/add/remove (simulated via a second storage-manager instance, deterministic — the store only refreshes on real cross-tab `storage` events), malformed-id tolerance for `get`/`remove`, and a persist round-trip sanity check. All six failed (except sanity) before the fix.

## Notes for review

- One expected conflict with #442, whichever lands second: its `persist()` → `toRecord()` hunk. Resolution is one line — merge `account.toRecord()` instead of the bare instance inside `persistAccount`.
- Verified: `pnpm check:all` green; runtime-checked the crash path in the browser (garbage `swarm-id-current-account-v2` + reload → account chooser renders, zero console errors).

Closes #422

🤖 Generated with [Claude Code](https://claude.com/claude-code)