### PR TITLE
fix(ui): bail unlock ceremonies when the account signs out mid-flight

### DIFF
--- a/ui/src/lib/components/home-account.svelte
+++ b/ui/src/lib/components/home-account.svelte
@@ -177,7 +177,12 @@
         account,
         access.type === 'password' ? password : undefined,
       )
-      if (myAttempt !== attempt) {
+      // Bail if this ceremony was superseded (cancel/retry) or the account was
+      // signed out mid-flight (e.g. cross-tab): the sign-out unmounts this
+      // component but not this continuation, and completing would still
+      // download a backup (export) or stage the seed for a change-method
+      // `setAccess` — acting on a vault the sign-out just wiped.
+      if (myAttempt !== attempt || account.isSignedOut) {
         unlocked.fill(0)
         return
       }
@@ -252,6 +257,15 @@
         }
       }
       if (myAttempt !== attempt) {
+        return
+      }
+      if (account.isSignedOut) {
+        // Signed out mid-ceremony (e.g. cross-tab): `setAccess` would re-arm
+        // the vault the sign-out just wiped. This is the live attempt, so the
+        // held seed is ours to destroy — a superseded attempt must NOT touch
+        // it, since a retry's seed lives in the same variable.
+        changeMethodSeed.fill(0)
+        changeMethodSeed = undefined
         return
       }
       account.setAccess(access, await encryptSeed(changeMethodSeed, key))

--- a/ui/src/lib/components/home-account.svelte
+++ b/ui/src/lib/components/home-account.svelte
@@ -99,15 +99,12 @@
   let verifyNewPassword = $state('')
 
   const isLocal = $derived(account.isLocal)
-  // The Account tab only renders for the signed-in current account, but the
-  // vault fields are optional on the record — fall back to an empty label.
-  const accessLabel = $derived(account.access ? methodLabel(account.access.type) : '')
+  // The Account tab only renders for the signed-in current account, so the
+  // access method is always present (`accessMethod` asserts it).
+  const access = $derived(account.accessMethod)
+  const accessLabel = $derived(methodLabel(access.type))
   const AccessIcon: Component = $derived(
-    account.access?.type === 'passkey'
-      ? Fingerprint
-      : account.access?.type === 'eth-wallet'
-        ? Wallet
-        : KeyRound,
+    access.type === 'passkey' ? Fingerprint : access.type === 'eth-wallet' ? Wallet : KeyRound,
   )
   const publicKeyDisplay = $derived(prefix0x(account.publicKey))
   const newPasswordTooShort = $derived(
@@ -172,13 +169,13 @@
     const myAttempt = ++attempt
     dialogError = undefined
     busy = true
-    if (account.access?.type !== 'password') {
+    if (access.type !== 'password') {
       dialog = { kind: 'unlock', target, pending: true }
     }
     try {
       const unlocked = await unlockAccount(
         account,
-        account.access?.type === 'password' ? password : undefined,
+        access.type === 'password' ? password : undefined,
       )
       if (myAttempt !== attempt) {
         unlocked.fill(0)
@@ -588,8 +585,8 @@
   {#if dialog.pending}
     <Dialog onclose={closeDialog} dismissable={false}>
       {@render pendingBody(
-        account.access?.type === 'eth-wallet' ? 'Confirm with wallet' : 'Confirm with passkey',
-        account.access?.type === 'eth-wallet'
+        access.type === 'eth-wallet' ? 'Confirm with wallet' : 'Confirm with passkey',
+        access.type === 'eth-wallet'
           ? 'Approve the request in your Ethereum wallet.'
           : 'Follow the prompts on your device.',
       )}
@@ -616,7 +613,7 @@
         {/if}
       </p>
 
-      {#if account.access?.type === 'password'}
+      {#if access.type === 'password'}
         <Input
           type="password"
           bind:value={password}
@@ -632,15 +629,15 @@
 
       <Button
         class="w-full"
-        disabled={busy || (account.access?.type === 'password' && password.length === 0)}
+        disabled={busy || (access.type === 'password' && password.length === 0)}
         onclick={confirmUnlock}
       >
         {#if busy}
           <LoaderCircle class="animate-spin" />
         {/if}
-        {account.access?.type === 'passkey'
+        {access.type === 'passkey'
           ? 'Confirm with passkey'
-          : account.access?.type === 'eth-wallet'
+          : access.type === 'eth-wallet'
             ? 'Confirm with wallet'
             : 'Confirm'}
       </Button>

--- a/ui/src/lib/components/unlock-dialog.svelte
+++ b/ui/src/lib/components/unlock-dialog.svelte
@@ -10,6 +10,8 @@
   error thrown from `onunlocked` is shown in the dialog for a retry.
 -->
 <script lang="ts">
+  import { untrack } from 'svelte'
+
   import LoaderCircle from '@lucide/svelte/icons/loader-circle'
 
   import { Button } from '$lib/components/ui/button'
@@ -28,6 +30,14 @@
 
   let { account, title, description, onunlocked, onclose }: Props = $props()
 
+  // The unlock ceremony only runs for a signed-in account, so the method is
+  // present at mount. Read ONCE via `untrack` (not `$derived`): the method is
+  // fixed for a ceremony, and an untracked read can never be re-triggered by a
+  // mid-ceremony sign-out (e.g. cross-tab) — so the dialog cannot re-read
+  // `accessMethod` on a wiped vault and throw. `unlockAccount` still rejects a
+  // wiped vault at confirm, surfacing it as a dialog error rather than a crash.
+  const access = untrack(() => account.accessMethod)
+
   let password = $state('')
   let busy = $state(false)
   let pendingCeremony = $state(false)
@@ -42,13 +52,13 @@
     const myAttempt = ++attempt
     error = undefined
     busy = true
-    if (account.access?.type !== 'password') {
+    if (access.type !== 'password') {
       pendingCeremony = true
     }
     try {
       const entropy = await unlockAccount(
         account,
-        account.access?.type === 'password' ? password : undefined,
+        access.type === 'password' ? password : undefined,
       )
       if (myAttempt !== attempt) {
         return
@@ -79,10 +89,10 @@
     <div class="flex flex-col items-center gap-2 py-4 text-center">
       <LoaderCircle class="size-5 animate-spin" />
       <p class="text-sm font-bold">
-        {account.access?.type === 'eth-wallet' ? 'Confirm with wallet' : 'Confirm with passkey'}
+        {access.type === 'eth-wallet' ? 'Confirm with wallet' : 'Confirm with passkey'}
       </p>
       <p class="text-sm">
-        {account.access?.type === 'eth-wallet'
+        {access.type === 'eth-wallet'
           ? 'Approve the request in your Ethereum wallet.'
           : 'Follow the prompts on your device.'}
       </p>
@@ -93,7 +103,7 @@
   <Dialog onclose={close} {title}>
     <p class="text-sm">{description}</p>
 
-    {#if account.access?.type === 'password'}
+    {#if access.type === 'password'}
       <Input
         type="password"
         bind:value={password}
@@ -109,15 +119,15 @@
 
     <Button
       class="w-full"
-      disabled={busy || (account.access?.type === 'password' && password.length === 0)}
+      disabled={busy || (access.type === 'password' && password.length === 0)}
       onclick={confirm}
     >
       {#if busy}
         <LoaderCircle class="animate-spin" />
       {/if}
-      {account.access?.type === 'passkey'
+      {access.type === 'passkey'
         ? 'Confirm with passkey'
-        : account.access?.type === 'eth-wallet'
+        : access.type === 'eth-wallet'
           ? 'Confirm with wallet'
           : 'Confirm'}
     </Button>

--- a/ui/src/lib/components/unlock-dialog.svelte
+++ b/ui/src/lib/components/unlock-dialog.svelte
@@ -60,7 +60,13 @@
         account,
         access.type === 'password' ? password : undefined,
       )
-      if (myAttempt !== attempt) {
+      // Bail if this ceremony was superseded (cancel/retry) or the account was
+      // signed out mid-flight (e.g. cross-tab): a passkey/wallet unlock can take
+      // seconds, and `unlockAccount` captured the vault before the wipe so it
+      // still resolves — but completing the connection with a now-signed-out
+      // account would re-arm app session material the sign-out just cleared.
+      if (myAttempt !== attempt || account.isSignedOut) {
+        entropy.fill(0)
         return
       }
       await onunlocked(entropy)

--- a/ui/src/lib/stores/accounts.svelte.test.ts
+++ b/ui/src/lib/stores/accounts.svelte.test.ts
@@ -1,0 +1,73 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Pins the signed-out invariants of the live `Account` class: `accessMethod`
+ * only exists while the vault does, and neither a getter read nor a late
+ * `setAccess` (e.g. a change-method ceremony finishing after a cross-tab
+ * sign-out) may act on — or resurrect — a wiped vault.
+ */
+import { EthAddress } from '@ethersphere/bee-js'
+import type { SignedInAccount, SignedOutAccount } from '@snaha/swarm-id'
+import { describe, expect, it } from 'vitest'
+
+import { Account } from './accounts.svelte'
+
+const noCommit = () => {}
+
+function signedInRecord(): SignedInAccount {
+  return {
+    id: new EthAddress('a'.repeat(40)),
+    name: 'Test Account',
+    createdAt: 1700000000000,
+    derivationKey: 'f'.repeat(64),
+    publicKey: '02' + 'ab'.repeat(32),
+    devices: [],
+    connectedApps: [],
+    postageStamps: [],
+    access: { type: 'password', kdfSalt: '00', kdfIterations: 100000 },
+    encryptedSeed: 'aabbccdd',
+  }
+}
+
+function signedOutRecord(): SignedOutAccount {
+  const { access: _access, encryptedSeed: _encryptedSeed, ...synced } = signedInRecord()
+  return { ...synced, signedOutAt: 1700000000001 }
+}
+
+describe('Account.accessMethod', () => {
+  it('returns the vault access method while signed in', () => {
+    const account = new Account(signedInRecord(), noCommit)
+    expect(account.accessMethod.type).toBe('password')
+  })
+
+  it('throws for an account loaded as signed out', () => {
+    const account = new Account(signedOutRecord(), noCommit)
+    expect(account.isSignedOut).toBe(true)
+    expect(() => account.accessMethod).toThrow(/signed out/)
+  })
+
+  it('throws once signOut() wipes the vault', () => {
+    const account = new Account(signedInRecord(), noCommit)
+    account.signOut()
+    expect(() => account.accessMethod).toThrow(/signed out/)
+  })
+})
+
+describe('Account.setAccess', () => {
+  it('swaps the vault while signed in', () => {
+    const account = new Account(signedInRecord(), noCommit)
+    account.setAccess({ type: 'passkey', credentialId: 'cred' }, 'bbccddee')
+    expect(account.accessMethod.type).toBe('passkey')
+  })
+
+  it('throws on a signed-out account instead of re-arming the vault', () => {
+    const account = new Account(signedInRecord(), noCommit)
+    account.signOut()
+    expect(() =>
+      account.setAccess({ type: 'password', kdfSalt: '11', kdfIterations: 100000 }, 'bbccddee'),
+    ).toThrow(/signed out/)
+    // The sign-out survived: still no vault, and the record projects signed out.
+    expect(account.isSignedOut).toBe(true)
+    expect(account.toRecord()).toMatchObject({ signedOutAt: expect.any(Number) })
+  })
+})

--- a/ui/src/lib/stores/accounts.svelte.ts
+++ b/ui/src/lib/stores/accounts.svelte.ts
@@ -183,11 +183,13 @@ export class Account {
    * surfacing a routing bug rather than silently reading `undefined`.
    */
   get accessMethod(): AccessMethod {
-    const access = this.#deviceAuth.vault?.access
-    if (access === undefined) {
-      throw new Error('accessMethod read on a signed-out account')
+    const vault = this.#deviceAuth.vault
+    if (vault === undefined) {
+      throw new Error(
+        'Cannot read the access method: this account is signed out on this device (its seed vault was wiped). Read `accessMethod` only in signed-in-only UI; guard with `isSignedOut` otherwise.',
+      )
     }
-    return access
+    return vault.access
   }
 
   /** When `signOut()` wiped the vault; `undefined` while signed in. */

--- a/ui/src/lib/stores/accounts.svelte.ts
+++ b/ui/src/lib/stores/accounts.svelte.ts
@@ -173,9 +173,21 @@ export class Account {
     return this.#deviceAuth.vault
   }
 
-  /** How the seed is unlocked on this device; `undefined` when signed out. */
-  get access(): AccessMethod | undefined {
-    return this.#deviceAuth.vault?.access
+  /**
+   * How the seed is unlocked on this device, asserted present. The unlock
+   * ceremonies and the whole signed-in account UI (`HomeAccount`,
+   * `UnlockDialog`) only ever render for a signed-in account — `routes/+page`
+   * maps a signed-out current account to no session — so those callers read
+   * the method directly instead of `?`-chaining a union getter. Two-state
+   * callers use `isSignedOut` / `vault` instead. Throws if the vault was wiped,
+   * surfacing a routing bug rather than silently reading `undefined`.
+   */
+  get accessMethod(): AccessMethod {
+    const access = this.#deviceAuth.vault?.access
+    if (access === undefined) {
+      throw new Error('accessMethod read on a signed-out account')
+    }
+    return access
   }
 
   /** When `signOut()` wiped the vault; `undefined` while signed in. */

--- a/ui/src/lib/stores/accounts.svelte.ts
+++ b/ui/src/lib/stores/accounts.svelte.ts
@@ -210,8 +210,19 @@ export class Account {
     this.#commit()
   }
 
-  /** Swap the unlock method: new access metadata + seed re-encrypted for it. */
+  /**
+   * Swap the unlock method: new access metadata + seed re-encrypted for it.
+   * Throws on a signed-out account — sign-out wiped the vault, and a late
+   * change-method ceremony re-arming it here would silently undo the
+   * sign-out. Signing back in replaces the whole record through the import
+   * flow (`accountsStore.add`) instead.
+   */
   setAccess(access: AccessMethod, encryptedSeed: string) {
+    if (this.isSignedOut) {
+      throw new Error(
+        'Cannot set an access method: this account is signed out on this device (its seed vault was wiped). Signing back in requires the recovery phrase, not a method change.',
+      )
+    }
     this.#deviceAuth = { vault: { access, encryptedSeed } }
     this.lastModified = Date.now()
     this.#commit()

--- a/ui/src/routes/connect/+page.svelte
+++ b/ui/src/routes/connect/+page.svelte
@@ -181,7 +181,11 @@
   </main>
 </div>
 
-{#if unlocking}
+<!-- Drop the unlock dialog if this account is signed out from another tab mid-
+     ceremony (`unlocking` is a captured reference, not session-derived): the
+     account then reads as signed-out in the list and selecting it routes to
+     import, matching the chooser. -->
+{#if unlocking && !unlocking.isSignedOut}
   <UnlockDialog
     account={unlocking}
     title="Connect as {unlocking.name}"


### PR DESCRIPTION
A cross-tab sign-out that lands while an unlock ceremony is pending used to be silently undone — the suspended continuation survived the component unmount and completed against the account whose vault the sign-out had just wiped.

## Fixes

- **Connect**: a passkey/wallet unlock resolving after the sign-out still completed the connection — persisting a fresh `appSecret` (and posting it to the dApp opener), re-arming exactly what `signOut()` cleared. The confirm path now bails (zeroing the entropy), and the connect page drops the dialog the moment the account reads signed-out (`!unlocking.isSignedOut`).
- **Account tab**: `confirmUnlock` / `confirmNewMethod` had the same hole — completing could still download a backup or, worse, `setAccess` would re-arm the vault, resurrecting the account as signed-in. Both now bail, and `setAccess` throws on a signed-out account as the seam-level backstop.

## Refactor: asserted access-method getter

The local-account record is a `SignedInAccount | SignedOutAccount` union, so the seed vault (`access` / `encryptedSeed`) reads as possibly-`undefined` wherever the live `Account` object is held — which forced optional chaining on the access method throughout the signed-in account UI. The live class can't be a discriminated union, so it exposes an asserted accessor instead. No schema or wire-format change.

- `Account` gains an `accessMethod` getter (replacing the optional `access` getter) that returns the method or throws on a wiped vault.
- `HomeAccount` reads it via `$derived` — it only renders for the signed-in current account (`routes/+page` resolves a signed-out current account to no session), so the parent drops it on sign-out before the derived re-runs.
- `UnlockDialog` reads it once via `untrack`, not `$derived`: a ceremony's method is fixed, and an untracked read can never be re-triggered by a mid-ceremony sign-out.

Drops ~18 `access?.type` sites. Unit tests pin the `accessMethod` / `setAccess` signed-out contracts.

## Verification

- `pnpm check:all` passes (includes the new `accounts.svelte.test.ts` unit tests).
- Browser: create password account → Account tab renders the method via `accessMethod` → password unlock succeeds. Zero console errors.
- Cross-tab sign-out races driven via `StorageEvent` on both the Account tab and the connect unlock dialog: the app falls back cleanly (chooser / account list with a "Signed out" badge) with no thrown error.
- The change-method resurrection race driven in the browser: Confirm clicked, then a simulated cross-tab sign-out dispatched while the new-password KDF was in flight — the vault stays wiped, the app falls back to the chooser, zero console errors. The happy-path method change still completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
