### PR TITLE
fix(lib): validate ECDH public keys and replace hand-rolled secp256k1

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -51,6 +51,7 @@
   },
   "dependencies": {
     "@ethersphere/bee-js": "^11.1.1",
+    "@noble/curves": "1.2.0",
     "cafe-utility": "33.3.2",
     "zod": "4.1.13"
   },

--- a/lib/src/proxy/act/crypto.test.ts
+++ b/lib/src/proxy/act/crypto.test.ts
@@ -109,6 +109,41 @@ describe("ecdhSharedSecret", () => {
       ecdhSharedSecret(validPriv, pubKey.x, new Uint8Array(16)),
     ).toThrow()
   })
+
+  it("should reject a point that is not on the curve (invalid-curve attack)", () => {
+    const privKey = new Uint8Array(32)
+    privKey[31] = 7
+
+    // (1, 1) is not on secp256k1: 1² ≠ 1³ + 7
+    const offCurveX = new Uint8Array(32)
+    offCurveX[31] = 1
+    const offCurveY = new Uint8Array(32)
+    offCurveY[31] = 1
+
+    expect(() => ecdhSharedSecret(privKey, offCurveX, offCurveY)).toThrow()
+  })
+
+  it("should reject the all-zero point (point at infinity encoding)", () => {
+    const privKey = new Uint8Array(32)
+    privKey[31] = 7
+
+    expect(() =>
+      ecdhSharedSecret(privKey, new Uint8Array(32), new Uint8Array(32)),
+    ).toThrow()
+  })
+
+  it("should match known-answer vector: priv=2 with G gives x(2G)", () => {
+    const privKey = new Uint8Array(32)
+    privKey[31] = 2
+
+    const shared = ecdhSharedSecret(privKey, GENERATOR_X, GENERATOR_Y)
+    const hex = Array.from(shared)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("")
+    expect(hex).toBe(
+      "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5",
+    )
+  })
 })
 
 describe("deriveKeys", () => {
@@ -332,6 +367,14 @@ describe("publicKeyFromCompressed", () => {
   it("should throw error for invalid length", () => {
     expect(() => publicKeyFromCompressed(new Uint8Array(32))).toThrow()
     expect(() => publicKeyFromCompressed(new Uint8Array(34))).toThrow()
+  })
+
+  it("should throw error when x has no valid y on the curve", () => {
+    // x=5: 5³+7 = 132 is a quadratic non-residue mod p — no point exists
+    const invalid = new Uint8Array(33)
+    invalid[0] = 0x02
+    invalid[32] = 5
+    expect(() => publicKeyFromCompressed(invalid)).toThrow()
   })
 
   it("should roundtrip through compress/decompress", () => {

--- a/lib/src/proxy/act/crypto.ts
+++ b/lib/src/proxy/act/crypto.ts
@@ -1,21 +1,8 @@
 // Copyright 2026 The Swarm Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+import { secp256k1 } from "@noble/curves/secp256k1"
 import { Binary } from "cafe-utility"
-
-// secp256k1 curve parameters
-const SECP256K1_P = BigInt(
-  "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEFFFFFC2F",
-)
-const SECP256K1_N = BigInt(
-  "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141",
-)
-const SECP256K1_GX = BigInt(
-  "0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798",
-)
-const SECP256K1_GY = BigInt(
-  "0x483ADA7726A3C4655DA4FBFC0E1108A8FD17B448A68554199C47D08FFB10D4B8",
-)
 
 // Key derivation nonces
 const LOOKUP_KEY_NONCE = 0x00
@@ -25,136 +12,9 @@ const ACCESS_KEY_DECRYPTION_NONCE = 0x01
 const PRIVATE_KEY_SIZE = 32
 const PUBLIC_KEY_COORD_SIZE = 32
 const COMPRESSED_PUBLIC_KEY_SIZE = 33
+const UNCOMPRESSED_PREFIX = 0x04
 const KEY_SIZE = 32
 const COUNTER_SIZE = 4
-
-/**
- * Modular arithmetic: a mod p (always positive)
- */
-function mod(a: bigint, p: bigint): bigint {
-  const result = a % p
-  return result >= 0n ? result : result + p
-}
-
-/**
- * Extended Euclidean algorithm for modular inverse
- */
-function modInverse(a: bigint, p: bigint): bigint {
-  let [oldR, r] = [mod(a, p), p]
-  let [oldS, s] = [1n, 0n]
-
-  while (r !== 0n) {
-    const quotient = oldR / r
-    ;[oldR, r] = [r, oldR - quotient * r]
-    ;[oldS, s] = [s, oldS - quotient * s]
-  }
-
-  if (oldR !== 1n) {
-    throw new Error("Modular inverse does not exist")
-  }
-
-  return mod(oldS, p)
-}
-
-/**
- * Elliptic curve point addition on secp256k1
- * Returns null for point at infinity
- */
-function ellipticAdd(
-  x1: bigint,
-  y1: bigint,
-  x2: bigint,
-  y2: bigint,
-): [bigint, bigint] | null {
-  // Handle point at infinity cases
-  if (x1 === 0n && y1 === 0n) return [x2, y2]
-  if (x2 === 0n && y2 === 0n) return [x1, y1]
-
-  // If points are inverses, return point at infinity
-  if (x1 === x2 && mod(y1 + y2, SECP256K1_P) === 0n) {
-    return null
-  }
-
-  let slope: bigint
-  if (x1 === x2 && y1 === y2) {
-    // Point doubling
-    const numerator = mod(3n * x1 * x1, SECP256K1_P)
-    const denominator = mod(2n * y1, SECP256K1_P)
-    slope = mod(numerator * modInverse(denominator, SECP256K1_P), SECP256K1_P)
-  } else {
-    // Point addition
-    const numerator = mod(y2 - y1, SECP256K1_P)
-    const denominator = mod(x2 - x1, SECP256K1_P)
-    slope = mod(numerator * modInverse(denominator, SECP256K1_P), SECP256K1_P)
-  }
-
-  const x3 = mod(slope * slope - x1 - x2, SECP256K1_P)
-  const y3 = mod(slope * (x1 - x3) - y1, SECP256K1_P)
-
-  return [x3, y3]
-}
-
-/**
- * Elliptic curve point doubling (special case of addition)
- */
-function ellipticDouble(x: bigint, y: bigint): [bigint, bigint] | null {
-  return ellipticAdd(x, y, x, y)
-}
-
-/**
- * Scalar multiplication using double-and-add algorithm
- */
-function scalarMultiply(
-  px: bigint,
-  py: bigint,
-  scalar: bigint,
-): [bigint, bigint] | null {
-  if (scalar === 0n) return null
-
-  let result: [bigint, bigint] | null = null
-  let current: [bigint, bigint] | null = [px, py]
-
-  let s = mod(scalar, SECP256K1_N)
-  while (s > 0n) {
-    if (s & 1n) {
-      if (result === null) {
-        result = current
-      } else if (current !== null) {
-        result = ellipticAdd(result[0], result[1], current[0], current[1])
-      }
-    }
-    if (current !== null) {
-      current = ellipticDouble(current[0], current[1])
-    }
-    s >>= 1n
-  }
-
-  return result
-}
-
-/**
- * Convert Uint8Array to bigint (big-endian)
- */
-function uint8ArrayToBigInt(bytes: Uint8Array): bigint {
-  let result = 0n
-  for (const byte of bytes) {
-    result = (result << 8n) | BigInt(byte)
-  }
-  return result
-}
-
-/**
- * Convert bigint to Uint8Array (big-endian, fixed size)
- */
-function bigIntToUint8Array(value: bigint, size: number): Uint8Array {
-  const result = new Uint8Array(size)
-  let v = value
-  for (let i = size - 1; i >= 0; i--) {
-    result[i] = Number(v & 0xffn)
-    v >>= 8n
-  }
-  return result
-}
 
 /**
  * Derive public key from private key
@@ -167,21 +27,21 @@ export function publicKeyFromPrivate(privKey: Uint8Array): {
     throw new Error(`Private key must be ${PRIVATE_KEY_SIZE} bytes`)
   }
 
-  const scalar = uint8ArrayToBigInt(privKey)
-  const point = scalarMultiply(SECP256K1_GX, SECP256K1_GY, scalar)
-
-  if (point === null) {
-    throw new Error("Invalid private key")
-  }
+  const point = secp256k1.getPublicKey(privKey, false)
 
   return {
-    x: bigIntToUint8Array(point[0], PUBLIC_KEY_COORD_SIZE),
-    y: bigIntToUint8Array(point[1], PUBLIC_KEY_COORD_SIZE),
+    x: point.slice(1, 1 + PUBLIC_KEY_COORD_SIZE),
+    y: point.slice(1 + PUBLIC_KEY_COORD_SIZE),
   }
 }
 
 /**
  * Compute ECDH shared secret (x-coordinate of shared point)
+ *
+ * The public key point is validated to be on secp256k1 (rejects off-curve
+ * points and the point at infinity) before multiplying — feeding an
+ * unvalidated point to scalar multiplication would enable an invalid-curve
+ * attack on the private key.
  */
 export function ecdhSharedSecret(
   privKey: Uint8Array,
@@ -200,16 +60,14 @@ export function ecdhSharedSecret(
     )
   }
 
-  const scalar = uint8ArrayToBigInt(privKey)
-  const px = uint8ArrayToBigInt(pubX)
-  const py = uint8ArrayToBigInt(pubY)
+  const pubKey = new Uint8Array(1 + 2 * PUBLIC_KEY_COORD_SIZE)
+  pubKey[0] = UNCOMPRESSED_PREFIX
+  pubKey.set(pubX, 1)
+  pubKey.set(pubY, 1 + PUBLIC_KEY_COORD_SIZE)
 
-  const point = scalarMultiply(px, py, scalar)
-  if (point === null) {
-    throw new Error("ECDH computation resulted in point at infinity")
-  }
-
-  return bigIntToUint8Array(point[0], PUBLIC_KEY_COORD_SIZE)
+  // getSharedSecret validates the point and rejects the point at infinity;
+  // compressed output is prefix || x, so slice off the prefix byte
+  return secp256k1.getSharedSecret(privKey, pubKey, true).slice(1)
 }
 
 /**
@@ -305,26 +163,12 @@ export function publicKeyFromCompressed(compressed: Uint8Array): {
     throw new Error("Invalid compressed public key prefix")
   }
 
-  const x = uint8ArrayToBigInt(compressed.slice(1))
-
-  // y² = x³ + 7 (mod p)
-  const ySquared = mod(x * x * x + 7n, SECP256K1_P)
-
-  // Compute modular square root using Tonelli-Shanks
-  // For secp256k1, p ≡ 3 (mod 4), so y = (y²)^((p+1)/4) mod p
-  const exponent = (SECP256K1_P + 1n) / 4n
-  let y = modPow(ySquared, exponent, SECP256K1_P)
-
-  // Check parity and adjust if needed
-  const isEven = (y & 1n) === 0n
-  const shouldBeEven = prefix === 0x02
-  if (isEven !== shouldBeEven) {
-    y = SECP256K1_P - y
-  }
+  // fromHex validates the point is on the curve (rejects x with no valid y)
+  const point = secp256k1.ProjectivePoint.fromHex(compressed).toRawBytes(false)
 
   return {
-    x: bigIntToUint8Array(x, PUBLIC_KEY_COORD_SIZE),
-    y: bigIntToUint8Array(y, PUBLIC_KEY_COORD_SIZE),
+    x: point.slice(1, 1 + PUBLIC_KEY_COORD_SIZE),
+    y: point.slice(1 + PUBLIC_KEY_COORD_SIZE),
   }
 }
 
@@ -341,30 +185,11 @@ export function compressPublicKey(x: Uint8Array, y: Uint8Array): Uint8Array {
     )
   }
 
-  const yBigInt = uint8ArrayToBigInt(y)
-  const prefix = (yBigInt & 1n) === 0n ? 0x02 : 0x03
+  const prefix = (y[y.length - 1] & 1) === 0 ? 0x02 : 0x03
 
   const result = new Uint8Array(COMPRESSED_PUBLIC_KEY_SIZE)
   result[0] = prefix
   result.set(x, 1)
-
-  return result
-}
-
-/**
- * Modular exponentiation using square-and-multiply
- */
-function modPow(base: bigint, exponent: bigint, modulus: bigint): bigint {
-  let result = 1n
-  base = mod(base, modulus)
-
-  while (exponent > 0n) {
-    if (exponent & 1n) {
-      result = mod(result * base, modulus)
-    }
-    exponent >>= 1n
-    base = mod(base * base, modulus)
-  }
 
   return result
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       '@ethersphere/bee-js':
         specifier: ^11.1.1
         version: 11.1.1
+      '@noble/curves':
+        specifier: 1.2.0
+        version: 1.2.0
       cafe-utility:
         specifier: 33.3.2
         version: 33.3.2
@@ -4677,6 +4680,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0


### PR DESCRIPTION
Closes #407

## Problem
`ecdhSharedSecret` fed caller-supplied grantee coordinates straight into a hand-rolled `scalarMultiply` with no on-curve check — a crafted off-curve "grantee key" in a grantee list could leak residues of the publisher's private key via published lookup keys (invalid-curve attack). The double-and-add loop was also variable-time (timing side channel) and returned `null`. Bonus: `publicKeyFromCompressed` silently returned a garbage point when `x³+7` had no square root.

## Fix
Swap the ~150 lines of hand-rolled bigint EC for audited `@noble/curves` (v1.2.0, already in the lockfile transitively):

- `ecdhSharedSecret` → `secp256k1.getSharedSecret` — validates the point is on the curve, rejects the point at infinity and out-of-range scalars
- `publicKeyFromPrivate` → `secp256k1.getPublicKey`
- `publicKeyFromCompressed` → `ProjectivePoint.fromHex` — now rejects x with no valid y
- Deleted `mod`/`modInverse`/`ellipticAdd`/`ellipticDouble`/`scalarMultiply`/`modPow` and the `null` returns with them

Public signatures unchanged — no caller changes. secp256k1 has cofactor 1, so no low-order points exist on the curve; on-curve validation fully covers the small-subgroup case.

## Tests (TDD)
Added first and confirmed failing against the old code:
- off-curve point `(1, 1)` rejected by `ecdhSharedSecret` (previously computed happily)
- all-zero point (infinity encoding) rejected (previously returned an all-zero secret)
- compressed key with non-residue x=5 rejected (previously garbage)
- known-answer vector: `ecdh(2, G) = x(2G)` pinning behavior across the swap

Full lib suite (952 tests, incl. `bee-compat.test.ts` vectors) and `pnpm check:all` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)