### PR TITLE
fix(lib): use random chunk-encryption padding like Bee

### DIFF
--- a/lib/src/chunk/encrypted-cac.test.ts
+++ b/lib/src/chunk/encrypted-cac.test.ts
@@ -76,8 +76,11 @@ describe("makeEncryptedContentAddressedChunk", () => {
       expect(chunk1.encryptionKey).not.toEqual(chunk2.encryptionKey)
     })
 
-    it("should produce same encrypted data with same key", () => {
-      const payload = new Uint8Array([1, 2, 3, 4, 5])
+    it("should produce same encrypted data with same key (full-size payload)", () => {
+      // A full 4096-byte payload has no random padding, so the ciphertext and
+      // address are fully deterministic — the property batch-utilization
+      // relies on for dedup. Smaller payloads get random padding.
+      const payload = new Uint8Array(4096).fill(7)
       const key = generateRandomKey()
 
       const chunk1 = makeEncryptedContentAddressedChunk(payload, key)

--- a/lib/src/chunk/encryption.test.ts
+++ b/lib/src/chunk/encryption.test.ts
@@ -78,7 +78,26 @@ describe("Encryption class", () => {
       const encrypted1 = encrypter1.encrypt(data)
       const encrypted2 = encrypter2.encrypt(data)
 
-      expect(encrypted1).toEqual(encrypted2)
+      // Only the ciphertext of the actual data is deterministic;
+      // padding beyond it is random (like Bee)
+      expect(encrypted1.slice(0, data.length)).toEqual(
+        encrypted2.slice(0, data.length),
+      )
+    })
+
+    it("should pad with random bytes unrelated to the keystream (#409)", () => {
+      const key = generateRandomKey()
+      const data = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])
+      const padding = 4096
+
+      const encrypted1 = new Encryption(key, padding, 0).encrypt(data)
+      const encrypted2 = new Encryption(key, padding, 0).encrypt(data)
+
+      // Same key + data → padding must still differ: it is random, not a
+      // deterministic function of the key (which leaked plaintext length)
+      expect(encrypted1.slice(data.length)).not.toEqual(
+        encrypted2.slice(data.length),
+      )
     })
 
     it("should produce different ciphertext with different keys", () => {
@@ -109,8 +128,10 @@ describe("Encryption class", () => {
       encrypter.reset()
       const encrypted2 = encrypter.encrypt(data)
 
-      // Should produce same result after reset
-      expect(encrypted1).toEqual(encrypted2)
+      // Should produce same ciphertext after reset (padding is random)
+      expect(encrypted1.slice(0, data.length)).toEqual(
+        encrypted2.slice(0, data.length),
+      )
     })
 
     it("should encrypt without padding when padding is 0", () => {

--- a/lib/src/chunk/encryption.ts
+++ b/lib/src/chunk/encryption.ts
@@ -110,10 +110,7 @@ export class Encryption implements EncryptionInterface {
     }
 
     // Pad the rest if out is longer
-    // Use deterministic padding based on encryption key
-    if (out.length > inLength) {
-      padDeterministic(out.subarray(inLength), this.encryptionKey, inLength)
-    }
+    getRandomValues(out.subarray(inLength))
   }
 
   /**
@@ -141,14 +138,7 @@ export class Encryption implements EncryptionInterface {
     }
 
     // Insert padding if out is longer
-    // Use deterministic padding based on encryption key
-    if (out.length > inLength) {
-      padDeterministic(
-        out.subarray(inLength),
-        this.encryptionKey,
-        i * this.keyLen + inLength,
-      )
-    }
+    getRandomValues(out.subarray(inLength))
   }
 }
 
@@ -161,41 +151,6 @@ function getRandomValues(buffer: Uint8Array): void {
 
   // Use Web Crypto API for secure random bytes
   crypto.getRandomValues(buffer)
-}
-
-/**
- * Fills buffer with pseudo-random data derived from a key
- * This makes padding deterministic for testing purposes
- *
- * @param buffer Buffer to fill with padding
- * @param key Encryption key to use as seed for deterministic padding
- * @param offset Offset within the logical data stream (for uniqueness)
- */
-function padDeterministic(buffer: Uint8Array, key: Key, offset: number): void {
-  if (buffer.length === 0) return
-
-  // Generate deterministic padding by hashing key + offset
-  let filled = 0
-  let counter = offset
-
-  while (filled < buffer.length) {
-    // Hash: key || counter
-    const counterBytes = new Uint8Array(4)
-    new DataView(counterBytes.buffer).setUint32(0, counter, true)
-
-    const seedData = new Uint8Array(key.length + counterBytes.length)
-    seedData.set(key)
-    seedData.set(counterBytes, key.length)
-
-    const hash = Binary.keccak256(seedData)
-
-    // Copy as many bytes as needed from the hash
-    const toCopy = Math.min(hash.length, buffer.length - filled)
-    buffer.set(hash.subarray(0, toCopy), filled)
-
-    filled += toCopy
-    counter++
-  }
 }
 
 /**

--- a/lib/src/proxy/soc.test.ts
+++ b/lib/src/proxy/soc.test.ts
@@ -215,15 +215,22 @@ describe("SOC upload signature validation", () => {
       const unencryptedCAC = makeContentAddressedChunk(data)
       expect(captured!.body).not.toEqual(unencryptedCAC.data)
 
-      // Create the same encrypted chunk using the returned key
+      // Re-encrypting with the returned key reproduces the ciphertext of the
+      // data itself (padding beyond it is random, so compare only the prefix:
+      // 8-byte encrypted span + data.length encrypted bytes)
       const encryptedChunk = makeEncryptedContentAddressedChunk(
         data,
         result.encryptionKey,
       )
-      expect(captured!.body).toEqual(encryptedChunk.data)
+      expect(captured!.body.slice(0, 8 + data.length)).toEqual(
+        encryptedChunk.data.slice(0, 8 + data.length),
+      )
 
       // Verify: signature was computed over hash(identifier + encrypted_chunk_address)
-      const expectedAddress = encryptedChunk.address.toUint8Array()
+      // where the address is the BMT hash of the body actually sent
+      const expectedAddress = calculateChunkAddress(
+        captured!.body,
+      ).toUint8Array()
       const toSign = Binary.concatBytes(
         identifier.toUint8Array(),
         expectedAddress,
@@ -299,9 +306,12 @@ describe("SOC upload signature validation", () => {
       const captured = capturingFetch.getCaptured()
       expect(captured).toBeDefined()
 
-      // Create expected encrypted chunk with the custom key
+      // Create expected encrypted chunk with the custom key; padding is
+      // random, so compare only the encrypted span + data prefix
       const encryptedChunk = makeEncryptedContentAddressedChunk(data, customKey)
-      expect(captured!.body).toEqual(encryptedChunk.data)
+      expect(captured!.body.slice(0, 8 + data.length)).toEqual(
+        encryptedChunk.data.slice(0, 8 + data.length),
+      )
     })
   })
 

--- a/lib/src/sync/partition-state.test.ts
+++ b/lib/src/sync/partition-state.test.ts
@@ -64,13 +64,13 @@ vi.mock("../proxy/upload", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../proxy/upload")>()
   return {
     ...actual,
-    uploadData: vi.fn(actual.uploadData),
+    uploadChunk: vi.fn(actual.uploadChunk),
     uploadSOC: vi.fn(actual.uploadSOC),
   }
 })
 
 import { statePointerAddress, writePartitionState } from "./partition-state"
-import { uploadData, uploadSOC } from "../proxy/upload"
+import { uploadChunk, uploadSOC } from "../proxy/upload"
 import {
   intentEpochBucket,
   partitionOccupancyAddress,
@@ -254,7 +254,7 @@ describe("writePartitionState — two-phase publish (pointer after chunks)", () 
     // pointer referencing chunks Bee never stored bricks every future takeover
     // (readFailed → read-only until batch expiry), since there is no
     // older-pointer fallback. See #414.
-    vi.mocked(uploadData).mockRejectedValueOnce(new Error("chunk PUT failed"))
+    vi.mocked(uploadChunk).mockRejectedValueOnce(new Error("chunk PUT failed"))
     vi.mocked(uploadSOC).mockClear()
 
     await expect(

--- a/lib/src/sync/partition-state.ts
+++ b/lib/src/sync/partition-state.ts
@@ -44,7 +44,7 @@ import {
   downloadDataWithChunkAPI,
   downloadEncryptedSOC,
 } from "../proxy/download-data"
-import { uploadData, uploadSOC, type UploadTarget } from "../proxy/upload"
+import { uploadChunk, uploadSOC, type UploadTarget } from "../proxy/upload"
 import { TimeoutError, withTimeout } from "../utils/promise"
 import { makeEncryptedContentAddressedChunk } from "../chunk"
 import {
@@ -920,7 +920,7 @@ export async function writePartitionState(opts: {
     const picked = pickReservedChunkKey(plaintext, claimedBuckets)
     references[i] = picked.reference
     reserve?.markReservedUtilizationChunk(picked.address, partition)
-    return { plaintext, key: picked.key }
+    return { data: picked.data }
   })
 
   // The reference chunk lists every ref (N·64 bytes; ≤ 4096 even at N=64).
@@ -970,18 +970,14 @@ export async function writePartitionState(opts: {
   // before another starts. If a future change introduces an await inside those
   // branches, concurrent stamps would race on the shared `buckets` array —
   // serialize the PUTs (or guard the slot) before doing so.
+  // Upload the EXACT encrypted bytes picked above — re-encrypting here would
+  // randomize the padding (sub-4096 plaintexts, e.g. the reference chunk) and
+  // land the chunk at a different address than the one already reserved and
+  // written into `references` / the pointer.
   const publishStart = Date.now()
   await Promise.all([
-    ...prepared.map((p) =>
-      uploadData(target, p.plaintext, {
-        encryptionKey: p.key,
-        deferred: false,
-      }),
-    ),
-    uploadData(target, referenceChunk, {
-      encryptionKey: refPicked.key,
-      deferred: false,
-    }),
+    ...prepared.map((p) => uploadChunk(target, p.data, { deferred: false })),
+    uploadChunk(target, refPicked.data, { deferred: false }),
   ])
   await writeStatePointer({
     bee,
@@ -1041,14 +1037,16 @@ function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
 /**
  * Pick a random encryption key whose encrypted address lands in a bucket not
  * yet claimed (reserved chunks share one slot, so each must occupy a distinct
- * bucket), claim that bucket, and return the address + key + 64-byte reference.
- * CPU only — the upload happens later, batched. The bucket-distinctness retry
+ * bucket), claim that bucket, and return the address + 64-byte reference +
+ * encrypted chunk bytes. CPU only — the upload happens later, batched, and
+ * must PUT these exact bytes: encryption padding is random, so re-encrypting
+ * the plaintext would yield a different address. The bucket-distinctness retry
  * is why addresses are chosen in one synchronous pass before any PUT.
  */
 function pickReservedChunkKey(
   plaintext: Uint8Array,
   claimedBuckets: Set<number>,
-): { address: Uint8Array; key: Uint8Array; reference: Uint8Array } {
+): { address: Uint8Array; reference: Uint8Array; data: Uint8Array } {
   let encrypted = makeEncryptedContentAddressedChunk(plaintext)
   while (claimedBuckets.has(toBucket(encrypted.address.toUint8Array()))) {
     encrypted = makeEncryptedContentAddressedChunk(plaintext)
@@ -1057,7 +1055,7 @@ function pickReservedChunkKey(
   claimedBuckets.add(toBucket(address))
   return {
     address,
-    key: encrypted.encryptionKey,
     reference: encrypted.reference.toUint8Array(),
+    data: encrypted.data,
   }
 }

--- a/lib/src/utils/batch-utilization.ts
+++ b/lib/src/utils/batch-utilization.ts
@@ -32,7 +32,7 @@ import {
 } from "../chunk"
 import { Binary, type Chunk as CafeChunk } from "cafe-utility"
 import type { UtilizationStoreDB } from "../storage/utilization-store"
-import { uploadData, type UploadTarget } from "../proxy/upload"
+import { uploadChunk, type UploadTarget } from "../proxy/upload"
 import { tryCreateTag } from "./tag"
 import { lockSocAddress } from "./lock-soc"
 import { deriveSecret } from "./key-derivation"
@@ -603,9 +603,10 @@ export async function uploadUtilizationChunk(
     stamper,
   }
 
-  // Upload using unified interface (with deferred: false for fast return)
-  await uploadData(target, data, {
-    encryptionKey,
+  // Upload the exact encrypted bytes the reference was computed from —
+  // re-encrypting would randomize the padding of sub-4096 plaintexts and
+  // change the address (deferred: false for fast return)
+  await uploadChunk(target, encryptedChunk.data, {
     deferred: false,
     tag,
   })


### PR DESCRIPTION
## Problem

`padDeterministic` filled encryption padding with `keccak(key ‖ uint32LE(counter))` — the same construction as the keystream's inner round hash. Span encryption uses `initCtr = 128`, so for any small payload the padding sequence contained the span-keystream preimage: an attacker keccaks candidate padding blocks, XORs against the encrypted span, and recovers the exact plaintext length — defeating the length-hiding the padding exists to provide.

## Fix

Match Bee exactly: pad with cryptographically random bytes (`bee/pkg/encryption/encryption.go` `pad()` = `crypto/rand`). Verified line-by-line against upstream — the padding function was the **only** divergence from Bee's construction (keystream, initCtr, hash, chunk split all already match).

### Partition-state / utilization chunks: encrypt once, upload those bytes

The exact address of a partition chunk doesn't matter — addresses are deliberately random, and `pickReservedChunkKey` re-rolls the encryption key until the address lands in an unclaimed bucket. What must hold is that the **one** picked address agrees across (1) the reserved-slot bucket claim that routes `stamp()`, (2) the 64-byte reference recorded for readers (reference chunk → pointer SOC), and (3) the address Bee stores the uploaded bytes at.

Two call sites encrypted twice — once to pick the address, again inside `uploadData` at PUT time — so (3) matched (1)+(2) only *by coincidence of deterministic padding*. They now upload the exact ciphertext the address was computed from (`uploadChunk`), making the invariant hold by construction:

- **partition-state publish**: the reference chunk (N·64 B < 4096) would otherwise land at a different address than the one the pointer names → `readFailed` on every takeover
- **`uploadUtilizationChunk`**: latent only (utilization plaintexts are always a full 4096 B, which never pads), but the encrypt-twice shape is removed — also saves a redundant encryption per chunk

## Tests

- New: same key + data → identical ciphertext prefix, **different** padding (fails against the old deterministic padding)
- Determinism-of-padded-output assertions updated to what still holds (prefix equality / full-size payloads)
- The 75 partition-lease integration tests caught the double-encrypt address mismatch and now pass
- E2E: encrypted chunk with random padding uploaded to a local Bee 2.7.1 node — Bee computes the identical address, payload round-trips, same-key re-encrypt lands at a different address

Closes #409

🤖 Generated with [Claude Code](https://claude.com/claude-code)
