### PR TITLE
fix(ui): unify the create and connect done pages

### DIFF
--- a/.github/workflows/playwright.yaml
+++ b/.github/workflows/playwright.yaml
@@ -1,0 +1,47 @@
+name: Playwright Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  playwright-tests:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/playwright:v1.57.0-noble
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build lib dependency
+        working-directory: ./lib
+        run: pnpm build
+
+      - name: Run Playwright tests
+        working-directory: ./ui
+        run: pnpm test:e2e
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: ui/playwright-report/
+          retention-days: 7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       '@lucide/svelte':
         specifier: ^0.561.0
         version: 0.561.0(svelte@5.48.2)
+      '@playwright/test':
+        specifier: 1.57.0
+        version: 1.57.0
       '@sveltejs/adapter-static':
         specifier: 3.0.10
         version: 3.0.10(@sveltejs/kit@2.50.1(@sveltejs/vite-plugin-svelte@6.2.1(svelte@5.48.2)(vite@7.2.6(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)))(svelte@5.48.2)(typescript@5.8.3)(vite@7.2.6(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.1)))
@@ -1392,6 +1395,11 @@ packages:
     resolution: {integrity: sha512-NkT+YAdgS2FPCn8mIA9bQhiBs+xmniMGq1LFPDhcFn0+2yIUEiIG06t7bsZlhdjknEQRTSdT7YitP6fC5qwP0g==}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.57.0':
+    resolution: {integrity: sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -2836,6 +2844,11 @@ packages:
     engines: {node: '>=18.3.0'}
     hasBin: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3779,6 +3792,16 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  playwright-core@1.57.0:
+    resolution: {integrity: sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.57.0:
+    resolution: {integrity: sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-load-config@3.1.4:
     resolution: {integrity: sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==}
@@ -5647,6 +5670,10 @@ snapshots:
   '@pagefind/windows-x64@1.4.0':
     optional: true
 
+  '@playwright/test@1.57.0':
+    dependencies:
+      playwright: 1.57.0
+
   '@polka/url@1.0.0-next.29': {}
 
   '@rollup/plugin-commonjs@29.0.0(rollup@4.53.3)':
@@ -7302,6 +7329,9 @@ snapshots:
     dependencies:
       fd-package-json: 2.0.0
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -8574,6 +8604,14 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  playwright-core@1.57.0: {}
+
+  playwright@1.57.0:
+    dependencies:
+      playwright-core: 1.57.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-load-config@3.1.4(postcss@8.5.6):
     dependencies:

--- a/ui/package.json
+++ b/ui/package.json
@@ -13,11 +13,13 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "lint": "prettier --check . && eslint .",
     "format": "prettier --write . && eslint . --fix",
-    "test": "vitest run --passWithNoTests"
+    "test": "vitest run --passWithNoTests",
+    "test:e2e": "playwright test"
   },
   "devDependencies": {
     "@eslint/js": "9.39.1",
     "@lucide/svelte": "^0.561.0",
+    "@playwright/test": "1.57.0",
     "@sveltejs/adapter-static": "3.0.10",
     "@sveltejs/kit": "2.50.1",
     "@sveltejs/vite-plugin-svelte": "6.2.1",

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,0 +1,59 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'html',
+  timeout: 30000,
+  expect: {
+    timeout: 5000,
+  },
+  use: {
+    baseURL: 'http://localhost:5500',
+    trace: 'on-first-retry',
+    actionTimeout: 5000,
+    navigationTimeout: 10000,
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        launchOptions: {
+          args: [
+            '--disable-dev-shm-usage',
+            '--no-sandbox',
+            '--disable-setuid-sandbox',
+            '--disable-gpu',
+            '--disable-popup-blocking',
+          ],
+        },
+      },
+    },
+  ],
+
+  webServer: [
+    {
+      command: 'pnpm dev',
+      port: 5500,
+      reuseExistingServer: !process.env.CI,
+      timeout: 30000,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+    {
+      command: 'pnpm -C .. dev:demo',
+      port: 3500,
+      reuseExistingServer: !process.env.CI,
+      timeout: 30000,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    },
+  ],
+})

--- a/ui/src/lib/components/account-done.svelte
+++ b/ui/src/lib/components/account-done.svelte
@@ -1,0 +1,102 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<script lang="ts">
+  import { onMount } from 'svelte'
+
+  import CircleCheck from '@lucide/svelte/icons/circle-check'
+
+  import AppHeader from '$lib/components/app-header.svelte'
+  import DriveAddDialog from '$lib/components/drive-add-dialog.svelte'
+  import Polycon from '$lib/components/polycon.svelte'
+  import Toast from '$lib/components/toast.svelte'
+  import { Button } from '$lib/components/ui/button'
+  import type { Account } from '$lib/types'
+
+  interface Props {
+    account: Account
+    /** Initial toast message; auto-dismissed. */
+    toast: string
+    /** Label of the finish button (e.g. "Stay local for now", "Continue to app"). */
+    finishLabel: string
+    /** Body text when the account already has a drive and the pitch is skipped. */
+    doneMessage: string
+    /** Called by the finish button and after a drive is added. */
+    onFinish: () => void
+  }
+
+  const { account, toast, finishLabel, doneMessage, onFinish }: Props = $props()
+
+  const TOAST_DURATION_MS = 4000
+  const IDENTICON_SIZE = 80
+
+  const hasDrive = $derived(account.postageStamps.length > 0)
+
+  let toastMessage = $state<string | undefined>(undefined)
+  let addDriveOpen = $state(false)
+
+  onMount(() => {
+    toastMessage = toast
+    const timer = setTimeout(() => (toastMessage = undefined), TOAST_DURATION_MS)
+    return () => clearTimeout(timer)
+  })
+</script>
+
+<div class="flex min-h-svh flex-col">
+  <AppHeader />
+
+  <main class="flex w-full flex-1 flex-col items-center justify-center px-8 pb-24">
+    <div class="flex w-full max-w-96 flex-col items-center gap-8">
+      <div class="flex flex-col items-center gap-4">
+        <Polycon
+          value={account.id.toHex()}
+          size={IDENTICON_SIZE}
+          class="shrink-0 overflow-hidden rounded-lg"
+        />
+        <p class="text-sm font-bold">{account.name}</p>
+      </div>
+
+      {#if hasDrive}
+        <div class="flex flex-col items-center gap-2 text-center">
+          <CircleCheck class="size-5" />
+          <p class="text-sm font-bold">All set!</p>
+          <p class="text-sm">{doneMessage}</p>
+        </div>
+
+        <Button class="w-full" onclick={onFinish}>{finishLabel}</Button>
+      {:else}
+        <div class="flex w-full flex-col gap-4">
+          <p class="text-center text-sm">
+            Your Swarm ID is ready! You can browse and view content on this device straight away.
+          </p>
+
+          <div class="bg-muted flex w-full flex-col items-center rounded-lg p-2 text-center">
+            <p class="text-sm font-bold">Want the full experience?</p>
+            <p class="text-sm">
+              Upload data and sync your Swarm ID across devices with a Swarm drive.
+            </p>
+          </div>
+        </div>
+
+        <div class="flex w-full flex-col items-center gap-4">
+          <div class="flex w-full flex-col items-center gap-2">
+            <Button class="w-full" onclick={() => (addDriveOpen = true)}>Set up a drive</Button>
+            <Button variant="outline" class="w-full" onclick={onFinish}>{finishLabel}</Button>
+          </div>
+
+          <p class="text-muted-foreground text-center text-xs">
+            Local accounts are limited to viewing content and cannot be used on other devices.
+          </p>
+        </div>
+      {/if}
+    </div>
+  </main>
+
+  {#if addDriveOpen}
+    <DriveAddDialog {account} onClose={() => (addDriveOpen = false)} onAdded={onFinish} />
+  {/if}
+
+  <Toast message={toastMessage} />
+</div>

--- a/ui/src/routes/account/new/done/+page.svelte
+++ b/ui/src/routes/account/new/done/+page.svelte
@@ -9,86 +9,28 @@
   import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'
 
-  import AppHeader from '$lib/components/app-header.svelte'
-  import DriveAddDialog from '$lib/components/drive-add-dialog.svelte'
-  import Polycon from '$lib/components/polycon.svelte'
-  import Toast from '$lib/components/toast.svelte'
-  import { Button } from '$lib/components/ui/button'
+  import AccountDone from '$lib/components/account-done.svelte'
   import routes from '$lib/routes'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
-
-  const TOAST_DURATION_MS = 4000
-  const IDENTICON_SIZE = 80
 
   const account = $derived(
     sessionStore.currentAccountId ? accountsStore.get(sessionStore.currentAccountId) : undefined,
   )
 
-  let toastMessage = $state<string | undefined>('Account created successfully!')
-  let addDriveOpen = $state(false)
-
-  function onDriveAdded() {
-    goto(resolve(routes.ROOT))
-  }
-
   onMount(() => {
     if (!account) {
       goto(resolve(routes.ROOT))
-      return
     }
-    const timer = setTimeout(() => (toastMessage = undefined), TOAST_DURATION_MS)
-    return () => clearTimeout(timer)
   })
 </script>
 
-<div class="flex min-h-svh flex-col">
-  <AppHeader />
-
-  {#if account}
-    <main class="flex w-full flex-1 flex-col items-center justify-center px-8 pb-24">
-      <div class="flex w-full max-w-96 flex-col items-center gap-8">
-        <div class="flex flex-col items-center gap-4">
-          <Polycon
-            value={account.id.toHex()}
-            size={IDENTICON_SIZE}
-            class="shrink-0 overflow-hidden rounded-lg"
-          />
-          <p class="text-sm font-bold">{account.name}</p>
-        </div>
-
-        <div class="flex w-full flex-col gap-4">
-          <p class="text-center text-sm">
-            Your Swarm ID is ready! You can browse and view content on this device straight away.
-          </p>
-
-          <div class="bg-muted flex w-full flex-col items-center rounded-lg p-2 text-center">
-            <p class="text-sm font-bold">Want the full experience?</p>
-            <p class="text-sm">
-              Upload data and sync your Swarm ID across devices with a Swarm drive.
-            </p>
-          </div>
-        </div>
-
-        <div class="flex w-full flex-col items-center gap-4">
-          <div class="flex w-full flex-col items-center gap-2">
-            <Button class="w-full" onclick={() => (addDriveOpen = true)}>Set up a drive</Button>
-            <Button variant="outline" class="w-full" href={resolve(routes.ROOT)}>
-              Stay local for now
-            </Button>
-          </div>
-
-          <p class="text-muted-foreground text-center text-xs">
-            Local accounts are limited to viewing content and cannot be used on other devices.
-          </p>
-        </div>
-      </div>
-    </main>
-
-    {#if addDriveOpen}
-      <DriveAddDialog {account} onClose={() => (addDriveOpen = false)} onAdded={onDriveAdded} />
-    {/if}
-  {/if}
-
-  <Toast message={toastMessage} />
-</div>
+{#if account}
+  <AccountDone
+    {account}
+    toast="Account created successfully!"
+    finishLabel="Stay local for now"
+    doneMessage="Your Swarm ID is ready."
+    onFinish={() => goto(resolve(routes.ROOT))}
+  />
+{/if}

--- a/ui/src/routes/connect/done/+page.svelte
+++ b/ui/src/routes/connect/done/+page.svelte
@@ -6,20 +6,14 @@
 <script lang="ts">
   import { onMount } from 'svelte'
 
-  import CircleCheck from '@lucide/svelte/icons/circle-check'
-
   import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'
 
-  import AppHeader from '$lib/components/app-header.svelte'
-  import Polycon from '$lib/components/polycon.svelte'
-  import { Button } from '$lib/components/ui/button'
+  import AccountDone from '$lib/components/account-done.svelte'
   import routes from '$lib/routes'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { connectStore } from '$lib/stores/connect.svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
-
-  const IDENTICON_SIZE = 80
 
   const account = $derived(
     sessionStore.currentAccountId ? accountsStore.get(sessionStore.currentAccountId) : undefined,
@@ -38,29 +32,12 @@
   }
 </script>
 
-<div class="flex min-h-svh flex-col">
-  <AppHeader />
-
-  {#if account && request}
-    <main class="flex w-full flex-1 flex-col items-center justify-center px-8 pb-24">
-      <div class="flex w-full max-w-96 flex-col items-center gap-8">
-        <div class="flex flex-col items-center gap-4">
-          <Polycon
-            value={account.id.toHex()}
-            size={IDENTICON_SIZE}
-            class="shrink-0 overflow-hidden rounded-lg"
-          />
-          <p class="text-sm font-bold">{account.name}</p>
-        </div>
-
-        <div class="flex flex-col items-center gap-2 text-center">
-          <CircleCheck class="size-5" />
-          <p class="text-sm font-bold">All set!</p>
-          <p class="text-sm">Your account is connected to {request.appName}.</p>
-        </div>
-
-        <Button class="w-full" onclick={continueToApp}>Continue to app</Button>
-      </div>
-    </main>
-  {/if}
-</div>
+{#if account && request}
+  <AccountDone
+    {account}
+    toast="Connected to {request.appName}!"
+    finishLabel="Continue to app"
+    doneMessage="Your account is connected to {request.appName}."
+    onFinish={continueToApp}
+  />
+{/if}

--- a/ui/tests/done-page.test.ts
+++ b/ui/tests/done-page.test.ts
@@ -1,0 +1,129 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { type Page, expect, test } from '@playwright/test'
+
+const DEMO_URL = 'http://localhost:3500'
+const PASSWORD = 'testpassword123'
+const APP_NAME = 'Swarm ID Demo'
+// The mocked drive purchase settles after a simulated widget delay.
+const DRIVE_SETTLE_TIMEOUT_MS = 15000
+
+/**
+ * Drives the account-creation wizard from /account/new to completion using the
+ * Password access method (needs no WebAuthn/wallet test infra). Where the flow
+ * lands afterwards depends on the entry point: the done page when standalone,
+ * /connect/done inside a connect popup.
+ */
+async function completeCreateFlow(page: Page) {
+  await page.getByRole('link', { name: 'Create a new account' }).click()
+  await expect(page).toHaveURL(/\/account\/new$/)
+  // Name is prefilled with a generated one.
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await expect(page).toHaveURL(/\/account\/new\/phrase$/)
+  await page.getByRole('button', { name: 'Reveal' }).click()
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await expect(page).toHaveURL(/\/account\/new\/access$/)
+  await page.getByRole('tab', { name: 'Password' }).click()
+  await page.locator('#new-password').fill(PASSWORD)
+  await page.locator('#verify-password').fill(PASSWORD)
+  await page.getByRole('button', { name: 'Confirm' }).click()
+}
+
+/** Asserts the shared done view's drive pitch (the no-drive branch). */
+async function expectDrivePitch(page: Page) {
+  await expect(page.getByText('Your Swarm ID is ready!')).toBeVisible()
+  await expect(page.getByText('Want the full experience?')).toBeVisible()
+  await expect(page.getByRole('button', { name: 'Set up a drive' })).toBeVisible()
+}
+
+/** Opens the demo's connect popup and returns the popup page. */
+async function openConnectPopup(page: Page) {
+  await page.getByRole('button', { name: 'Connect Swarm ID' }).click()
+  // The lib renders the iframe button once the client is initialized — before
+  // that, the popover's Connect click is a silent no-op (clientStore.connect
+  // bails while `client` is undefined).
+  await expect(page.locator('#swarm-id-button iframe')).toBeVisible({ timeout: 10000 })
+  let popup: Page | undefined
+  await expect(async () => {
+    const popupPromise = page.waitForEvent('popup', { timeout: 5000 }).catch(() => undefined)
+    await page.getByRole('button', { name: 'Connect', exact: true }).click()
+    popup = await popupPromise
+    if (!popup) {
+      // Clicking Connect closes the popover — reopen it for the retry.
+      await page.getByRole('button', { name: 'Connect Swarm ID' }).click()
+      throw new Error('connect popup did not open')
+    }
+  }).toPass({ timeout: 30000 })
+  await popup!.waitForLoadState()
+  return popup!
+}
+
+test('create flow ends on the done page with the drive pitch', async ({ page }) => {
+  await page.goto('/')
+  // A first visit lands on the product page; "Get started" opts into the
+  // account chooser (/?signin).
+  await page.getByRole('link', { name: 'Get started' }).first().click()
+  await completeCreateFlow(page)
+
+  await expect(page).toHaveURL(/\/account\/new\/done$/)
+  await expect(page.getByText('Account created successfully!')).toBeVisible()
+  await expectDrivePitch(page)
+  await expect(page.getByRole('button', { name: 'Stay local for now' })).toBeVisible()
+
+  await page.getByRole('button', { name: 'Stay local for now' }).click()
+  await expect(page).toHaveURL(/\/$/)
+})
+
+test('connect flow shows the same done page and closes the popup', async ({ page }) => {
+  await page.goto(DEMO_URL)
+
+  // Fresh profile: create the account inside the connect popup.
+  let popup = await openConnectPopup(page)
+  await completeCreateFlow(popup)
+
+  await expect(popup).toHaveURL(/\/connect\/done$/)
+  await expect(popup.getByText(`Connected to ${APP_NAME}!`)).toBeVisible()
+  await expectDrivePitch(popup)
+  await expect(popup.getByRole('button', { name: 'Continue to app' })).toBeVisible()
+  await expect(popup.getByRole('button', { name: 'Stay local for now' })).not.toBeVisible()
+
+  await popup.getByRole('button', { name: 'Continue to app' }).click()
+  await expect.poll(() => popup.isClosed()).toBe(true)
+
+  // The demo picked up the session — the sidebar shows the account.
+  const accountButton = page.getByRole('button', { name: /0x|[0-9a-f]{6}\.\.\./ }).first()
+  await expect(accountButton).toBeVisible({ timeout: 10000 })
+
+  // Give the account a drive via the mocked Add-drive flow (dev default:
+  // mock enabled, no widget popup).
+  await page.goto('/')
+  await page.getByRole('tab', { name: 'Storage' }).click()
+  await page.getByRole('button', { name: 'Add drive' }).click()
+  await page.getByRole('dialog').getByRole('combobox').nth(1).selectOption({ index: 1 })
+  await page.getByRole('button', { name: 'Proceed' }).click()
+  // Drive cards are labelled "Drive <4 hex chars>" (batch-ID-derived name).
+  await expect(page.getByText(/^Drive [0-9a-f]{4}$/)).toBeVisible({
+    timeout: DRIVE_SETTLE_TIMEOUT_MS,
+  })
+
+  // Disconnect and reconnect: the account now has a drive, so the done page
+  // skips the pitch and shows the "All set!" branch.
+  await page.goto(DEMO_URL)
+  await accountButton.click()
+  await page.getByRole('button', { name: 'Disconnect', exact: true }).click()
+
+  popup = await openConnectPopup(page)
+  await popup.getByRole('button', { name: /Signed out/ }).click()
+  await popup.getByRole('textbox', { name: 'Account password' }).fill(PASSWORD)
+  await popup.getByRole('button', { name: 'Confirm' }).click()
+
+  await expect(popup).toHaveURL(/\/connect\/done$/)
+  await expect(popup.getByText('All set!')).toBeVisible()
+  await expect(popup.getByText(`Your account is connected to ${APP_NAME}.`)).toBeVisible()
+  await expect(popup.getByRole('button', { name: 'Set up a drive' })).not.toBeVisible()
+
+  await popup.getByRole('button', { name: 'Continue to app' }).click()
+  await expect.poll(() => popup.isClosed()).toBe(true)
+})


### PR DESCRIPTION
## Summary

- Extract the done view shared by the create and connect flows into `account-done.svelte` — both now show the identical drive-pitch layout (Polycon + name, "Your Swarm ID is ready!", "Set up a drive")
- Flow differences are props only: the create flow finishes with "Stay local for now" → home, the connect flow with "Continue to app" → `window.close()` back to the dApp
- When the connecting account already has a drive, the pitch is skipped for a compact "All set!" confirmation

## Playwright e2e tests

Bootstraps the e2e setup removed with swarm-ui in #465 (part of #466): `ui/playwright.config.ts` with `webServer` entries for the identity UI (:5500) and demo (:3500), a `test:e2e` script, and a restored (simplified) Playwright CI workflow running in the `mcr.microsoft.com/playwright` container.

Two tests cover this change's flows end-to-end:
1. **Create flow** — account creation with the Password access method lands on the done page with toast + drive pitch; "Stay local for now" returns home
2. **Connect flow** — demo popup → create account → same done view with "Continue to app" closing the popup; then a mocked drive purchase + reconnect asserts the "All set!" branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)