### PR TITLE
fix(ui): match network settings dialog to design

### DIFF
--- a/.github/workflows/deploy-main-pages.yml
+++ b/.github/workflows/deploy-main-pages.yml
@@ -25,9 +25,10 @@ on:
 permissions:
   contents: write
 
-# Share the gh-pages lock with itself so concurrent main pushes serialise.
+# Serialise all gh-pages pushes (shared with deploy-preview.yml) so
+# concurrent main pushes and PR preview deploys never race each other.
 concurrency:
-  group: pages-main
+  group: gh-pages
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -215,6 +215,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [detect-changes, build-id, build-demo, build-docs]
+    # Serialize all gh-pages pushes (across PRs and against deploy-main-pages)
+    # to prevent "fetch first" rejections when two workflows push concurrently.
+    concurrency:
+      group: gh-pages
+      cancel-in-progress: false
     if: |
       always() &&
       github.event.action != 'closed' &&

--- a/ui/src/lib/components/network-settings-dialog.svelte
+++ b/ui/src/lib/components/network-settings-dialog.svelte
@@ -48,7 +48,7 @@
 
 <Dialog title="Network settings" {onclose}>
   <div class="flex w-full flex-col gap-2">
-    <label for="bee-node-url" class="text-sm font-medium">Bee node URL</label>
+    <label for="bee-node-url" class="text-sm font-medium">Bee address</label>
     <Input
       id="bee-node-url"
       bind:value={beeNodeUrl}
@@ -62,7 +62,7 @@
   </div>
 
   <div class="flex w-full flex-col gap-2">
-    <label for="gnosis-rpc-url" class="text-sm font-medium">Gnosis RPC endpoint</label>
+    <label for="gnosis-rpc-url" class="text-sm font-medium">RPC endpoint</label>
     <Input
       id="gnosis-rpc-url"
       bind:value={gnosisRpcUrl}
@@ -76,7 +76,8 @@
   </div>
 
   <div class="flex w-full items-center gap-2">
-    <Button class="flex-1" disabled={!canSave} onclick={save}>Save settings</Button>
-    <Button variant="outline" onclick={resetToDefaults}>Reset to defaults</Button>
+    <Button disabled={!canSave} onclick={save}>Save</Button>
+    <Button variant="outline" onclick={onclose}>Cancel</Button>
+    <Button variant="ghost" class="ml-auto" onclick={resetToDefaults}>Reset</Button>
   </div>
 </Dialog>

--- a/ui/src/lib/components/settings-menu.svelte
+++ b/ui/src/lib/components/settings-menu.svelte
@@ -7,7 +7,6 @@
   import Check from '@lucide/svelte/icons/check'
   import Contrast from '@lucide/svelte/icons/contrast'
   import History from '@lucide/svelte/icons/history'
-  import Menu from '@lucide/svelte/icons/menu'
   import Moon from '@lucide/svelte/icons/moon'
   import Settings from '@lucide/svelte/icons/settings'
   import Sun from '@lucide/svelte/icons/sun'
@@ -69,14 +68,14 @@
 
 <div bind:this={container} class="relative">
   <Button
-    variant="ghost"
+    variant="outline"
     size="icon"
-    aria-label="Menu"
+    aria-label="Settings"
     aria-haspopup="menu"
     aria-expanded={open}
     onclick={() => (open = !open)}
   >
-    <Menu />
+    <Settings />
   </Button>
 
   {#if open}

--- a/ui/src/lib/components/settings-menu.svelte
+++ b/ui/src/lib/components/settings-menu.svelte
@@ -4,8 +4,11 @@
 -->
 
 <script lang="ts">
+  import BookOpen from '@lucide/svelte/icons/book-open'
   import Check from '@lucide/svelte/icons/check'
   import Contrast from '@lucide/svelte/icons/contrast'
+  import ExternalLink from '@lucide/svelte/icons/external-link'
+  import Globe from '@lucide/svelte/icons/globe'
   import History from '@lucide/svelte/icons/history'
   import Moon from '@lucide/svelte/icons/moon'
   import Settings from '@lucide/svelte/icons/settings'
@@ -24,6 +27,9 @@
     { value: 'light', label: 'Light', icon: Sun },
     { value: 'dark', label: 'Dark', icon: Moon },
   ] as const
+
+  const PRODUCT_PAGE_URL = 'https://swarm-id.snaha.net'
+  const DOCUMENTATION_URL = 'https://swarm.snaha.net/docs'
 
   const ITEM_CLASS =
     'flex h-7 w-full cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-1 text-left text-sm outline-none hover:bg-muted focus-visible:bg-muted'
@@ -92,6 +98,33 @@
         <History class="size-4 shrink-0" />
         <span class="flex-1 whitespace-nowrap">Restore account from backup</span>
       </button>
+
+      <div class="bg-border -mx-1 my-1 h-px"></div>
+
+      <a
+        href={PRODUCT_PAGE_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        role="menuitem"
+        class={ITEM_CLASS}
+        onclick={close}
+      >
+        <Globe class="size-4 shrink-0" />
+        <span class="flex-1 whitespace-nowrap">Product page</span>
+        <ExternalLink class="text-muted-foreground size-3.5 shrink-0" />
+      </a>
+      <a
+        href={DOCUMENTATION_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        role="menuitem"
+        class={ITEM_CLASS}
+        onclick={close}
+      >
+        <BookOpen class="size-4 shrink-0" />
+        <span class="flex-1 whitespace-nowrap">Documentation</span>
+        <ExternalLink class="text-muted-foreground size-3.5 shrink-0" />
+      </a>
 
       <div class="bg-border -mx-1 my-1 h-px"></div>
 


### PR DESCRIPTION
Updates the network settings surface to match the Figma design — the [dialog](https://www.figma.com/design/bKZOK59S2KIedkN1Idrkfy/SwarmID-MVP--Copy-?node-id=223-11961&m=dev) and its [trigger button](https://www.figma.com/design/bKZOK59S2KIedkN1Idrkfy/SwarmID-MVP--Copy-?node-id=2001-4807&m=dev) — and makes the product page and documentation reachable from the menu while signed in.

Closes #300
Closes #435

## Changes

**Network settings dialog**

- Relabel fields: **Bee node URL → Bee address**, **Gnosis RPC endpoint → RPC endpoint**
- Rework the action row into **Save / Cancel / Reset**:
  - `Save` (primary) and `Cancel` (outline) grouped on the left
  - `Reset` (ghost) pushed to the right
  - `Cancel` closes the dialog; `Reset` fills the fields with defaults (persisted only on Save)

**Settings menu trigger**

- Swap the ghost hamburger for an **outline gear (settings) icon** button

**Product page & documentation links** (#300)

- Add **Product page** (`https://swarm-id.snaha.net`) and **Documentation** (`https://swarm.snaha.net/docs`) links to the settings menu, each opening in a new tab with an external-link icon
- The menu is the same component shown before and after sign-in, so these — plus Network settings, Restore account and Appearance — are all available once signed in (#435)

## Screenshots

### Settings menu

![Settings menu](https://raw.githubusercontent.com/snaha/swarm-id/pr-476-assets/network-settings/settings-menu-light.png?v=2)

### Network settings dialog

| Light | Dark |
| --- | --- |
| ![Network settings — light](https://raw.githubusercontent.com/snaha/swarm-id/pr-476-assets/network-settings/network-settings-light.png?v=2) | ![Network settings — dark](https://raw.githubusercontent.com/snaha/swarm-id/pr-476-assets/network-settings/network-settings-dark.png?v=2) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)