### PR TITLE
fix(lib): validate parentIdentify and require it to come from the parent window

### DIFF
--- a/lib/src/swarm-id-proxy.test.ts
+++ b/lib/src/swarm-id-proxy.test.ts
@@ -1,0 +1,115 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// Rollup-only virtual module (see rollup.config.js) — not resolvable in vitest
+vi.mock("virtual:stamp-worker-code", () => ({ default: "" }))
+
+import { SwarmIdProxy } from "./swarm-id-proxy"
+
+const PARENT_ORIGIN = "https://dapp.example.com"
+const ATTACKER_ORIGIN = "https://evil.example.com"
+
+type MessageListener = (event: MessageEvent) => Promise<void>
+
+describe("SwarmIdProxy parentIdentify security (#410)", () => {
+  let parentWindow: { postMessage: ReturnType<typeof vi.fn> }
+  let attackerWindow: { postMessage: ReturnType<typeof vi.fn> }
+  let messageListener: MessageListener
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+
+    parentWindow = { postMessage: vi.fn() }
+    attackerWindow = { postMessage: vi.fn() }
+
+    const listeners: Record<string, unknown> = {}
+    const mockWindow = {
+      addEventListener: vi.fn((type: string, listener: unknown) => {
+        listeners[type] = listener
+      }),
+      removeEventListener: vi.fn(),
+      parent: parentWindow,
+      location: { origin: "https://id.example.com" },
+    }
+    vi.stubGlobal("window", mockWindow)
+
+    new SwarmIdProxy()
+    messageListener = listeners["message"] as MessageListener
+  })
+
+  const identifyMessage = (overrides: Record<string, unknown> = {}) => ({
+    type: "parentIdentify",
+    requestId: "r1",
+    metadata: { name: "Test App" },
+    ...overrides,
+  })
+
+  const dispatch = (data: unknown, origin: string, source: unknown) =>
+    messageListener({ data, origin, source } as MessageEvent)
+
+  const proxyReadyCalls = (win: { postMessage: ReturnType<typeof vi.fn> }) =>
+    win.postMessage.mock.calls.filter(
+      ([message]) => message?.type === "proxyReady",
+    )
+
+  it("rejects parentIdentify when event.source is not window.parent", async () => {
+    await dispatch(identifyMessage(), ATTACKER_ORIGIN, attackerWindow)
+
+    expect(proxyReadyCalls(attackerWindow)).toHaveLength(0)
+
+    // Parent must not be bound: a follow-up message from the attacker is ignored
+    await dispatch(
+      { type: "checkAuth", requestId: "r2" },
+      ATTACKER_ORIGIN,
+      attackerWindow,
+    )
+    expect(attackerWindow.postMessage).not.toHaveBeenCalled()
+  })
+
+  it("does not let a non-parent window pre-bind before the real parent", async () => {
+    await dispatch(
+      identifyMessage({ subsidisedGatewayUrl: "https://evil-gateway.example" }),
+      ATTACKER_ORIGIN,
+      attackerWindow,
+    )
+    await dispatch(identifyMessage(), PARENT_ORIGIN, parentWindow)
+
+    expect(attackerWindow.postMessage).not.toHaveBeenCalled()
+    const ready = proxyReadyCalls(parentWindow)
+    expect(ready).toHaveLength(1)
+    expect(ready[0][0]).toMatchObject({
+      type: "proxyReady",
+      parentOrigin: PARENT_ORIGIN,
+    })
+  })
+
+  it("rejects a schema-invalid parentIdentify from the real parent", async () => {
+    // Missing required metadata
+    await dispatch(
+      { type: "parentIdentify", requestId: "r1" },
+      PARENT_ORIGIN,
+      parentWindow,
+    )
+    // Malformed subsidisedGatewayUrl
+    await dispatch(
+      identifyMessage({ subsidisedGatewayUrl: "not-a-url" }),
+      PARENT_ORIGIN,
+      parentWindow,
+    )
+
+    expect(proxyReadyCalls(parentWindow)).toHaveLength(0)
+  })
+
+  it("accepts a valid parentIdentify from window.parent", async () => {
+    await dispatch(identifyMessage(), PARENT_ORIGIN, parentWindow)
+
+    const ready = proxyReadyCalls(parentWindow)
+    expect(ready).toHaveLength(1)
+    expect(ready[0][0]).toMatchObject({
+      type: "proxyReady",
+      parentOrigin: PARENT_ORIGIN,
+    })
+  })
+})

--- a/lib/src/swarm-id-proxy.ts
+++ b/lib/src/swarm-id-proxy.ts
@@ -3,6 +3,7 @@
 
 import type {
   ParentToIframeMessage,
+  ParentIdentifyMessage,
   IframeToParentMessage,
   ButtonStyles,
   ButtonConfig,
@@ -47,6 +48,7 @@ import type {
 } from "./types"
 import {
   ParentToIframeMessageSchema,
+  ParentIdentifyMessageSchema,
   PopupToIframeMessageSchema,
   STORAGE_CHALLENGE_KEY,
   leaseCacheStorageKey,
@@ -863,9 +865,20 @@ export class SwarmIdProxy {
     window.addEventListener("message", async (event: MessageEvent) => {
       const { type } = event.data
 
-      // Handle parent identification (must come first)
+      // Handle parent identification (must come first). Only the embedding
+      // parent window may identify itself — any co-embedded iframe can obtain
+      // our WindowProxy and race the real parent otherwise (#410).
       if (type === "parentIdentify") {
-        await this.handleParentIdentify(event)
+        if (event.source !== window.parent) {
+          console.warn("[Proxy] Rejected parentIdentify from non-parent window")
+          return
+        }
+        const result = ParentIdentifyMessageSchema.safeParse(event.data)
+        if (!result.success) {
+          console.warn("[Proxy] Invalid parentIdentify message:", result.error)
+          return
+        }
+        await this.handleParentIdentify(result.data, event)
         return
       }
 
@@ -927,15 +940,16 @@ export class SwarmIdProxy {
   /**
    * Handle parent identification
    */
-  private async handleParentIdentify(event: MessageEvent): Promise<void> {
+  private async handleParentIdentify(
+    message: ParentIdentifyMessage,
+    event: MessageEvent,
+  ): Promise<void> {
     // Prevent parent from changing after first identification
     if (this.parentIdentified) {
       console.error("[Proxy] Parent already identified! Ignoring duplicate.")
       return
     }
 
-    // Parse the message to get optional parameters
-    const message = event.data
     const parentPopupMode = message.popupMode
     const parentMetadata = message.metadata
     const parentButtonConfig = message.buttonConfig


### PR DESCRIPTION
## Problem

The proxy's message listener handled `parentIdentify` before Zod validation, with no `event.source === window.parent` check, and binding is first-come-permanent. A third-party iframe co-embedded on the dApp page could obtain the proxy's WindowProxy, race the real parent, become the trusted parent (dropping the legitimate `parentIdentify`), and inject an arbitrary `subsidisedGatewayUrl` — which later becomes both the upload and download endpoint.

## Fix

- Reject `parentIdentify` unless `event.source === window.parent`
- Validate with the existing `ParentIdentifyMessageSchema` before accepting; `handleParentIdentify` now receives the parsed message instead of reading raw `event.data`
- First-come-permanent binding stays — with only the real parent able to bind, the race is gone

## Tests (TDD)

New `lib/src/swarm-id-proxy.test.ts` (written first, 3/4 failing pre-fix):

- rejects `parentIdentify` from a non-parent window, and the sender stays unidentified for follow-up messages
- a non-parent window cannot pre-bind before the real parent
- rejects schema-invalid payloads from the real parent (missing metadata, malformed `subsidisedGatewayUrl`)
- happy path: valid identify from `window.parent` still gets `proxyReady`

Closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)