### PR TITLE
test(ui): landing smoke + passkey/password access e2e

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -35,8 +35,15 @@ pnpm --filter @swarm-id/ui build    # outputs to ./build
 ```bash
 pnpm --filter @swarm-id/ui check:all   # prettier + eslint + svelte-check + knip
 pnpm --filter @swarm-id/ui test        # vitest unit tests
+pnpm --filter @swarm-id/ui test:e2e    # Playwright end-to-end tests (tests/)
 pnpm --filter @swarm-id/ui format      # prettier --write + eslint --fix
 ```
+
+`test:e2e` starts the UI (`:5500`) and demo (`:3500`) dev servers itself and drives them
+with Playwright. First run locally needs the browser once:
+`pnpm --filter @swarm-id/ui exec playwright install chromium` (CI runs in the
+`mcr.microsoft.com/playwright` image, which ships them). Append `--ui` for the interactive
+runner, or a path (e.g. `tests/home.test.ts`) to run a single spec.
 
 Conventions:
 

--- a/ui/tests/home.test.ts
+++ b/ui/tests/home.test.ts
@@ -1,0 +1,19 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { expect, test } from '@playwright/test'
+
+// A fresh browser context has empty localStorage, so a first visit lands on the
+// product page. "Get started" (→ /?signin) opts into the account chooser.
+test('fresh profile lands on the product page and can reach the account chooser', async ({
+  page,
+}) => {
+  await page.goto('/')
+
+  await expect(page.getByRole('heading', { name: 'The Identity Layer on Swarm' })).toBeVisible()
+
+  await page.getByRole('link', { name: 'Get started' }).first().click()
+
+  await expect(page).toHaveURL(/\?signin$/)
+  await expect(page.getByRole('link', { name: 'Create a new account' })).toBeVisible()
+  await expect(page.getByRole('link', { name: 'I already have an account' })).toBeVisible()
+})

--- a/ui/tests/passkey-access.test.ts
+++ b/ui/tests/passkey-access.test.ts
@@ -1,0 +1,53 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { type Page, expect, test } from '@playwright/test'
+
+// Installs a Chrome virtual WebAuthn authenticator so the passkey ceremony
+// resolves without real hardware. It must expose the PRF extension (hmac-secret)
+// and be a resident-key, user-verifying platform authenticator — passkey.ts
+// derives the seed-encryption key from PRF output and requires all three.
+async function installVirtualAuthenticator(page: Page) {
+  const client = await page.context().newCDPSession(page)
+  await client.send('WebAuthn.enable')
+  await client.send('WebAuthn.addVirtualAuthenticator', {
+    options: {
+      protocol: 'ctap2',
+      ctap2Version: 'ctap2_1',
+      transport: 'internal',
+      hasResidentKey: true,
+      hasUserVerification: true,
+      hasPrf: true,
+      // Auto-satisfy user presence/verification so create() needs no interaction.
+      automaticPresenceSimulation: true,
+      isUserVerified: true,
+    },
+  })
+}
+
+test('passkey happy path creates a usable local account', async ({ page }) => {
+  await installVirtualAuthenticator(page)
+
+  await page.goto('/')
+  await page.getByRole('link', { name: 'Get started' }).first().click()
+  await page.getByRole('link', { name: 'Create a new account' }).click()
+
+  await expect(page).toHaveURL(/\/account\/new$/)
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await expect(page).toHaveURL(/\/account\/new\/phrase$/)
+  await page.getByRole('button', { name: 'Reveal' }).click()
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  // The access step defaults to the Passkey tab; the virtual authenticator
+  // answers the ceremony automatically.
+  await expect(page).toHaveURL(/\/account\/new\/access$/)
+  await page.getByRole('button', { name: 'Confirm with passkey' }).click()
+
+  await expect(page).toHaveURL(/\/account\/new\/done$/)
+  await expect(page.getByText('Account created successfully!')).toBeVisible()
+
+  // Staying local drops into the app shell for the freshly created account.
+  await page.getByRole('button', { name: 'Stay local for now' }).click()
+  await expect(page).toHaveURL(/\/$/)
+  await expect(page.getByRole('tab', { name: 'Account' })).toBeVisible()
+})

--- a/ui/tests/password-access.test.ts
+++ b/ui/tests/password-access.test.ts
@@ -1,0 +1,68 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { type Page, expect, test } from '@playwright/test'
+
+// At least MIN_PASSWORD_LENGTH (8) characters.
+const PASSWORD = 'test-password-123'
+const SHORT_PASSWORD = 'short'
+
+// Walks a fresh profile through the create wizard to the access step and
+// selects the Password tab, leaving the account un-finalized. Name and phrase
+// use their generated defaults — this file is about the password step itself.
+async function gotoPasswordAccessStep(page: Page) {
+  await page.goto('/')
+  await page.getByRole('link', { name: 'Get started' }).first().click()
+  await page.getByRole('link', { name: 'Create a new account' }).click()
+
+  await expect(page).toHaveURL(/\/account\/new$/)
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await expect(page).toHaveURL(/\/account\/new\/phrase$/)
+  await page.getByRole('button', { name: 'Reveal' }).click()
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await expect(page).toHaveURL(/\/account\/new\/access$/)
+  await page.getByRole('tab', { name: 'Password' }).click()
+}
+
+test('password step keeps Confirm disabled until the input is valid', async ({ page }) => {
+  await gotoPasswordAccessStep(page)
+
+  const newPassword = page.locator('#new-password')
+  const verifyPassword = page.locator('#verify-password')
+  const confirm = page.getByRole('button', { name: 'Confirm', exact: true })
+
+  await expect(confirm).toBeDisabled()
+
+  // Too short: the field flags invalid and Confirm stays disabled.
+  await newPassword.fill(SHORT_PASSWORD)
+  await expect(newPassword).toHaveAttribute('aria-invalid', 'true')
+  await expect(confirm).toBeDisabled()
+
+  // Long enough but the verify field disagrees: mismatch shown, still disabled.
+  await newPassword.fill(PASSWORD)
+  await verifyPassword.fill(`${PASSWORD}-typo`)
+  await expect(page.getByText('Passwords do not match')).toBeVisible()
+  await expect(confirm).toBeDisabled()
+
+  // Matching and long enough: the guardrails clear and Confirm enables.
+  await verifyPassword.fill(PASSWORD)
+  await expect(page.getByText('Passwords do not match')).toBeHidden()
+  await expect(confirm).toBeEnabled()
+})
+
+test('password step can reveal the typed password', async ({ page }) => {
+  await gotoPasswordAccessStep(page)
+
+  const newPassword = page.locator('#new-password')
+  await newPassword.fill(PASSWORD)
+  await expect(newPassword).toHaveAttribute('type', 'password')
+
+  // Two identical toggles (new + verify); the first belongs to #new-password.
+  await page.getByRole('button', { name: 'Show password' }).first().click()
+  await expect(newPassword).toHaveAttribute('type', 'text')
+  await expect(newPassword).toHaveValue(PASSWORD)
+
+  await page.getByRole('button', { name: 'Hide password' }).first().click()
+  await expect(newPassword).toHaveAttribute('type', 'password')
+})


### PR DESCRIPTION
Extends the e2e coverage with the access methods that `done-page.test.ts` doesn't already cover (it drives create-with-password → done + the connect/drive flows).

## Changes

- **`ui/tests/home.test.ts`** — a fresh profile lands on the product page (`The Identity Layer on Swarm`), and "Get started" (`/?signin`) reaches the account chooser.
- **`ui/tests/passkey-access.test.ts`** — the **Passkey** access method end to end via a Chrome virtual WebAuthn authenticator (CDP), configured with the PRF extension + resident key + user verification that `passkey.ts` requires. This is the only access method with no browser-level coverage.
- **`ui/tests/password-access.test.ts`** — the **Password** access step's guardrails: Confirm stays disabled until the password is long enough and both fields match, and the show/hide toggle reveals the typed password. (The password *success* path is already covered by `done-page.test.ts`, so it's not duplicated here.)
- **`ui/README.md`** — notes on running the suite (`test:e2e`), the one-time local browser install, and the `--ui` / single-spec flags.

## Verification

- `pnpm --filter @swarm-id/ui exec playwright test tests/home.test.ts tests/passkey-access.test.ts tests/password-access.test.ts` — all green.
- `pnpm --filter @swarm-id/ui check:all` — prettier + eslint + svelte-check + knip, all green.

Refs #466