### PR TITLE
feat(ui): add account deletion flow

### DIFF
--- a/ui/src/lib/components/delete-account-dialog.svelte
+++ b/ui/src/lib/components/delete-account-dialog.svelte
@@ -1,0 +1,146 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<!--
+  Delete an account from THIS device. Unlike sign-out (which keeps a tombstone
+  row and can be reversed with the recovery phrase), delete hard-removes the
+  record via `accountsStore.remove`. Because it is destructive and irreversible
+  for a local account, it is gated on the account's own access method: the user
+  must re-confirm with their passkey, wallet, or password (`unlockAccount`)
+  before the record is dropped. The decrypted seed is proof-of-control only and
+  is zeroed immediately.
+-->
+<script lang="ts">
+  import LoaderCircle from '@lucide/svelte/icons/loader-circle'
+
+  import { Button } from '$lib/components/ui/button'
+  import { Dialog } from '$lib/components/ui/dialog'
+  import { Input } from '$lib/components/ui/input'
+  import { unlockAccount } from '$lib/crypto/unlock'
+  import { accountsStore } from '$lib/stores/accounts.svelte'
+  import { sessionStore } from '$lib/stores/session.svelte'
+  import { toastStore } from '$lib/stores/toast.svelte'
+  import type { Account } from '$lib/types'
+
+  interface Props {
+    account: Account
+    onClose: () => void
+  }
+
+  let { account, onClose }: Props = $props()
+
+  // The Account tab only renders for the signed-in current account, so the
+  // access method is always present (`accessMethod` asserts it).
+  const access = $derived(account.accessMethod)
+
+  let password = $state('')
+  let busy = $state(false)
+  // Passkey/wallet prompt in flight — swaps to the centered pending body.
+  let pending = $state(false)
+  let error = $state<string | undefined>(undefined)
+  // Bumped on cancel/close so a passkey/wallet prompt that resolves after the
+  // user dismissed the dialog does not go on to delete the account.
+  let attempt = 0
+
+  const confirmLabel = $derived(
+    access.type === 'passkey'
+      ? 'Confirm delete with passkey'
+      : access.type === 'eth-wallet'
+        ? 'Confirm delete with ETH wallet'
+        : 'Confirm delete with password',
+  )
+
+  function cancel() {
+    attempt++
+    onClose()
+  }
+
+  async function confirm() {
+    if (busy) {
+      return
+    }
+    const myAttempt = ++attempt
+    error = undefined
+    busy = true
+    if (access.type !== 'password') {
+      pending = true
+    }
+    try {
+      const seed = await unlockAccount(account, access.type === 'password' ? password : undefined)
+      // Deletion needs proof-of-control, not the seed itself. Zero it, and bail
+      // if the dialog was dismissed while the prompt was open (an approval of a
+      // cancelled prompt must not delete the account).
+      seed.fill(0)
+      if (myAttempt !== attempt) {
+        return
+      }
+      const target = account
+      accountsStore.remove(target.id)
+      if (sessionStore.currentAccountId === target.id.toHex()) {
+        sessionStore.clearCurrentAccount()
+      }
+      toastStore.show('Account deleted')
+      onClose()
+    } catch (caught) {
+      if (myAttempt === attempt) {
+        error = caught instanceof Error ? caught.message : 'Could not delete the account.'
+        busy = false
+        pending = false
+      }
+    }
+  }
+</script>
+
+{#if pending}
+  <Dialog onclose={cancel} dismissable={false}>
+    <div class="flex flex-col items-center gap-2 py-2">
+      <LoaderCircle class="size-5 animate-spin" />
+      <div class="flex flex-col items-center text-center">
+        <p class="text-sm font-bold">
+          {access.type === 'eth-wallet' ? 'Confirm with wallet' : 'Confirm with passkey'}
+        </p>
+        <p class="text-sm">
+          {access.type === 'eth-wallet'
+            ? 'Approve the request in your Ethereum wallet.'
+            : 'Follow the prompts on your device.'}
+        </p>
+      </div>
+    </div>
+    <Button variant="outline" class="w-full" onclick={cancel}>Cancel</Button>
+  </Dialog>
+{:else}
+  <Dialog onclose={cancel} title="Delete account">
+    <p class="text-sm">
+      This permanently deletes <span class="font-medium">{account.name}</span> from this device. Your
+      account and its data may not be recoverable.
+    </p>
+
+    {#if access.type === 'password'}
+      <Input
+        type="password"
+        bind:value={password}
+        placeholder="Account password"
+        autocomplete="current-password"
+        onkeydown={(event: KeyboardEvent) => event.key === 'Enter' && confirm()}
+      />
+    {/if}
+
+    {#if error}
+      <p class="text-destructive text-xs">{error}</p>
+    {/if}
+
+    <Button
+      variant="destructive"
+      class="w-full"
+      disabled={busy || (access.type === 'password' && password.length === 0)}
+      onclick={confirm}
+    >
+      {#if busy}
+        <LoaderCircle class="animate-spin" />
+      {/if}
+      {confirmLabel}
+    </Button>
+  </Dialog>
+{/if}

--- a/ui/src/lib/components/home-account.svelte
+++ b/ui/src/lib/components/home-account.svelte
@@ -22,6 +22,7 @@
   import Wallet from '@lucide/svelte/icons/wallet'
   import { type AccessMethod, uint8ArrayToHex } from '@snaha/swarm-id'
 
+  import DeleteAccountDialog from '$lib/components/delete-account-dialog.svelte'
   import DriveAddDialog from '$lib/components/drive-add-dialog.svelte'
   import PhraseGrid from '$lib/components/phrase-grid.svelte'
   import Polycon from '$lib/components/polycon.svelte'
@@ -44,7 +45,7 @@
   import { unlockAccount } from '$lib/crypto/unlock'
   import { toastStore } from '$lib/stores/toast.svelte'
   import type { Account } from '$lib/types'
-  import { copyToClipboard, notImplemented, truncateAddress } from '$lib/utils'
+  import { copyToClipboard, truncateAddress } from '$lib/utils'
 
   const MIN_PASSWORD_LENGTH = 8
   const MASKED_KEY = '•'.repeat(66)
@@ -79,6 +80,7 @@
   let addDriveOpen = $state(false)
   let keysDetailOpen = $state(false)
   let signingOut = $state(false)
+  let deleting = $state(false)
   // Reveals cache only their derived display value — never the raw seed, which
   // is zeroed the moment each ceremony finishes with it (issue #412).
   let revealedPrivateKey = $state<string | undefined>(undefined)
@@ -591,7 +593,7 @@
     {:else}
       <Button variant="outline" onclick={() => (signingOut = true)}>Sign out</Button>
     {/if}
-    <Button variant="destructive" onclick={notImplemented}>Delete account</Button>
+    <Button variant="destructive" onclick={() => (deleting = true)}>Delete account</Button>
   </div>
 </div>
 
@@ -742,4 +744,8 @@
 
 {#if signingOut}
   <SignOutDialog {account} onClose={() => (signingOut = false)} />
+{/if}
+
+{#if deleting}
+  <DeleteAccountDialog {account} onClose={() => (deleting = false)} />
 {/if}


### PR DESCRIPTION
Wires the **Account** tab's "Delete account" button (previously a not-implemented stub) to a destructive confirmation modal, matching the [Figma design](https://www.figma.com/design/bKZOK59S2KIedkN1Idrkfy/SwarmID-MVP--Copy-?node-id=254-17961).

> [!IMPORTANT]
> **This removes the account from _this device only_. It does NOT dilute the postage stamps for a synced account's drives, and runs NO on-chain teardown.**
>
> For a synced account, "delete" hard-removes the local record — but the account and its drives keep living on the Swarm network, and the paid postage batches are left funded and un-diluted. Nothing is settled on-chain and no Ethereum wallet transaction is required. In effect this is a device-local delete, not a full account teardown.
>
> That on-chain part — diluting stamps for every drive and requiring a connected wallet to execute the transaction — is exactly what #433 asks for, is not in the linked design, and (with stamp settlement still mocked) is out of scope here. **So this PR intentionally does NOT close issue #433**; it only ships the device-local delete + access-method gate the design specifies. The dilution / wallet teardown is a separate follow-up.

## What changed

- **New** `delete-account-dialog.svelte`: a destructive confirm modal — title "Delete account", the hedged copy from the design ("…may not be recoverable."), and a full-width destructive confirm button.
- Deletion is **gated on the account's own access method**: the user re-confirms with their passkey, wallet, or password (reusing the existing `unlockAccount` ceremony) before the record is removed. The button label and body adapt to the method — *"Confirm delete with ETH wallet / passkey / password"* — matching the Figma variants; password accounts get an inline password field.
- On confirm, `accountsStore.remove()` **hard-removes** the local record (unlike sign-out's reversible tombstone) and clears the session if it was the current account.

## Scope — what this deliberately does NOT do

- **No stamp dilution.** A synced account's postage batches (drives) are untouched; the paid BZZ/storage is not reclaimed or diluted. See the callout above — this is why the PR references #433 rather than closing it.
- **No on-chain transaction / connected wallet.** Delete never touches the chain; it only edits device-local storage.
- **Device-local, not global.** For a synced account the record still exists on Swarm and on other devices, so this "delete" is recoverable by signing back in with the Secret Recovery Phrase — the same effective reach as sign-out, just without a local tombstone.

## Screenshots

Account tab — the destructive **Delete account** button (a local, view-only account shows no Sign out):

![Account tab](https://raw.githubusercontent.com/snaha/swarm-id/assets/account-deletion-screenshots/01-account-tab.png)

Confirmation modal (password variant — passkey/ETH-wallet accounts show "Confirm delete with passkey / ETH wallet" and no password field):

![Delete account modal](https://raw.githubusercontent.com/snaha/swarm-id/assets/account-deletion-screenshots/02-delete-modal.png)

Wrong password is rejected and the account is kept:

![Wrong password](https://raw.githubusercontent.com/snaha/swarm-id/assets/account-deletion-screenshots/03-wrong-password.png)

## Notes for reviewers

- The decrypted seed is proof-of-control only and is zeroed immediately; deletion never uses it.
- An `attempt` guard prevents a late passkey/wallet approval (after the dialog was dismissed mid-prompt) from deleting the account — same pattern as `home-account`'s unlock ceremonies.
- Screenshots are hosted on the `assets/account-deletion-screenshots` branch (kept out of this PR's diff).

## Verification

`pnpm check:all` passes. Verified end-to-end in the browser with a password account:
1. Button opens the modal (matches design).
2. Wrong password → "Wrong password.", dialog stays, account intact.
3. Correct password → account removed from storage, session cleared, returned to the product page.

Refs #433 — **does not close it** (see the callout above; the synced-account dilution / on-chain teardown is a separate follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
