### PR TITLE
fix(lib): stop logging the decryption key of encrypted references

### DIFF
--- a/lib/src/proxy/download-data.test.ts
+++ b/lib/src/proxy/download-data.test.ts
@@ -1,0 +1,119 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Console hygiene for the download path.
+ *
+ * For an encrypted reference the trailing 32 bytes ARE the decryption key,
+ * and console output is routinely captured by extensions and error
+ * reporters. These tests upload encrypted data, download it, and assert the
+ * key half never reaches any console method — on success or on chunk-fetch
+ * failure.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest"
+import type { Bee, Stamper } from "@ethersphere/bee-js"
+import { uploadData, type UploadTarget } from "./upload"
+import { downloadDataWithChunkAPI } from "./download-data"
+import { CHUNK_SIZE } from "./chunking"
+import {
+  MockBee,
+  MockChunkStore,
+  createMockStamper,
+} from "./feeds/epochs/test-utils"
+
+const ENCRYPTED_REF_HEX_LEN = 128 // 32-byte address + 32-byte key
+const ADDRESS_HEX_LEN = 64
+
+/** Build `length` bytes with position-dependent variation so chunks differ. */
+function makeData(length: number): Uint8Array {
+  const data = new Uint8Array(length)
+  for (let i = 0; i < length; i++) {
+    data[i] = (i * 31 + 7) & 0xff
+  }
+  return data
+}
+
+function setup(): { bee: Bee; target: UploadTarget } {
+  const store = new MockChunkStore()
+  const bee = new MockBee(store) as unknown as Bee
+  const target: UploadTarget = {
+    mode: "stamper",
+    bee,
+    stamper: createMockStamper() as unknown as Stamper,
+  }
+  return { bee, target }
+}
+
+function spyOnConsole() {
+  return [
+    vi.spyOn(console, "log").mockImplementation(() => {}),
+    vi.spyOn(console, "info").mockImplementation(() => {}),
+    vi.spyOn(console, "warn").mockImplementation(() => {}),
+    vi.spyOn(console, "error").mockImplementation(() => {}),
+    vi.spyOn(console, "debug").mockImplementation(() => {}),
+  ]
+}
+
+/** Everything the spied console methods received, flattened to one string. */
+function consoleOutput(spies: ReturnType<typeof spyOnConsole>): string {
+  return spies
+    .flatMap((spy) => spy.mock.calls)
+    .flat()
+    .map((arg) => {
+      if (typeof arg === "string") return arg
+      if (arg instanceof Error) return `${arg.message}\n${arg.stack ?? ""}`
+      return JSON.stringify(arg) ?? String(arg)
+    })
+    .join("\n")
+    .toLowerCase()
+}
+
+async function uploadEncrypted(
+  target: UploadTarget,
+  data: Uint8Array,
+): Promise<{ reference: string; decryptionKeyHex: string }> {
+  const { reference } = await uploadData(target, data, {
+    encryptionKey: true,
+  })
+  expect(reference.length).toBe(ENCRYPTED_REF_HEX_LEN)
+  return {
+    reference,
+    decryptionKeyHex: reference.slice(ADDRESS_HEX_LEN).toLowerCase(),
+  }
+}
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("downloadDataWithChunkAPI console hygiene", () => {
+  it("never logs the decryption key of an encrypted reference", async () => {
+    const { bee, target } = setup()
+    const data = makeData(2 * CHUNK_SIZE) // root is an intermediate chunk
+
+    const { reference, decryptionKeyHex } = await uploadEncrypted(target, data)
+
+    const spies = spyOnConsole()
+    const downloaded = await downloadDataWithChunkAPI(bee, reference)
+
+    expect(downloaded).toEqual(data)
+    expect(consoleOutput(spies)).not.toContain(decryptionKeyHex)
+  })
+
+  it("never logs the decryption key when the chunk fetch fails", async () => {
+    const { bee, target } = setup()
+    const data = makeData(CHUNK_SIZE)
+
+    const { reference, decryptionKeyHex } = await uploadEncrypted(target, data)
+
+    vi.spyOn(bee, "downloadChunk").mockRejectedValue(new Error("fetch failed"))
+
+    const spies = spyOnConsole()
+    await expect(downloadDataWithChunkAPI(bee, reference)).rejects.toThrow(
+      "fetch failed",
+    )
+
+    expect(consoleOutput(spies)).not.toContain(decryptionKeyHex)
+  })
+})

--- a/lib/src/proxy/download-data.ts
+++ b/lib/src/proxy/download-data.ts
@@ -334,8 +334,10 @@ export async function downloadDataWithChunkAPI(
   const rootRef = parseReference(reference)
   const isEncrypted = rootRef.encryptionKey !== undefined
 
+  // Log only the address half: for encrypted references the trailing
+  // 32 bytes are the decryption key and must never reach the console.
   console.log(
-    `[DownloadData] start ref=${reference} encrypted=${isEncrypted} bee.url=${bee.url}`,
+    `[DownloadData] start addr=${Binary.uint8ArrayToHex(rootRef.address)} encrypted=${isEncrypted} bee.url=${bee.url}`,
   )
 
   // First, download root chunk to get span for progress estimation


### PR DESCRIPTION
## Problem

`downloadDataWithChunkAPI` logged the full Swarm reference at download start. For encrypted data the trailing 32 bytes of that reference **are** the decryption key, and console output is routinely captured by extensions and error reporters.

## Fix

- Truncate the start log to the 32-byte address half (matching the existing chunk-fetch-failure log, which already logs `addr=` only).
- Swept the other `console.*` calls named in the issue: the remaining calls in `download-data.ts`, plus all five in `batch-utilization.ts`, and the ones in `manifest-builder.ts` and the epoch finders, only log addresses, chunk indexes, lengths, or error objects — no key material.

## Tests

New `download-data.test.ts` uploads encrypted data through the existing `MockBee` harness, spies on every console method, and asserts the key half of the reference never appears in console output — for both a successful download and a failed chunk fetch. Both tests fail on `main` and pass with this change.

Closes #411

🤖 Generated with [Claude Code](https://claude.com/claude-code)