### PR TITLE
chore: remove legacy ?agent connect flag

### DIFF
--- a/demo/src/lib/components/layout/sidebar-auth.svelte
+++ b/demo/src/lib/components/layout/sidebar-auth.svelte
@@ -12,7 +12,6 @@
   import InfoButton from '$lib/components/ui/tooltip/info-button.svelte'
   import { clientStore } from '$lib/stores/client.svelte'
 
-  let agentSignup = $state(false)
   let useSubsidisedGateway = $state(false)
   let popoverOpen = $state(false)
 
@@ -109,7 +108,7 @@
       </div>
       <Button
         onclick={() => {
-          clientStore.connect({ agent: agentSignup, useSubsidisedGateway })
+          clientStore.connect({ useSubsidisedGateway })
           popoverOpen = false
         }}
         size="sm"
@@ -139,14 +138,6 @@
 
     {#if !clientStore.authenticated}
       <Separator />
-
-      <!-- Agent sign-up -->
-      <div class="flex items-center gap-2">
-        <Checkbox bind:checked={agentSignup} id="popover-agent-signup" />
-        <Label for="popover-agent-signup" class="cursor-pointer text-xs text-muted-foreground">
-          Agent sign-up
-        </Label>
-      </div>
 
       <!-- Subsidised gateway -->
       <div class="flex items-center gap-2">

--- a/demo/src/lib/stores/client.svelte.ts
+++ b/demo/src/lib/stores/client.svelte.ts
@@ -299,7 +299,7 @@ export const clientStore = {
     }
   },
 
-  async connect(options?: { agent?: boolean; useSubsidisedGateway?: boolean }) {
+  async connect(options?: { useSubsidisedGateway?: boolean }) {
     const useSubsidised = options?.useSubsidisedGateway ?? true
     const subsidisedUrl = useSubsidised ? DEFAULT_BEE_NODE_URL : undefined
 
@@ -321,7 +321,7 @@ export const clientStore = {
     if (status.authenticated) {
       await client.disconnect()
     } else {
-      await client.connect({ agent: options?.agent })
+      await client.connect()
     }
   },
 

--- a/docs-site/src/content/docs/api/index.mdx
+++ b/docs-site/src/content/docs/api/index.mdx
@@ -250,9 +250,6 @@ await client.connect()
 
 // Open as popup window
 await client.connect({ popupMode: 'popup' })
-
-// Open with agent sign-up option visible
-await client.connect({ agent: true })
 ```
 
 **When to use `connect()`:**
@@ -310,14 +307,12 @@ This method creates the same authentication URL as used by the iframe proxy and 
 | ------------------- | --------------------- | -------- | ------------------------------------------------------------------------------ |
 | `options`           | `ConnectOptions`      | No       | Configuration options for the authentication window                            |
 | `options.popupMode` | `"window" \| "popup"` | No       | Whether to open as a popup window ("popup") or full window ("window", default) |
-| `options.agent`     | `boolean`             | No       | Whether to show the agent sign-up option on the authentication page            |
 
 **ConnectOptions Interface:**
 
 ```typescript
 interface ConnectOptions {
   popupMode?: 'popup' | 'window' // Default: "window"
-  agent?: boolean // Shows agent sign-up option
 }
 ```
 
@@ -339,9 +334,6 @@ await client.connect()
 
 // Open as popup window
 await client.connect({ popupMode: 'popup' })
-
-// Open with agent sign-up option visible
-await client.connect({ agent: true })
 ```
 
 ---

--- a/lib/src/swarm-id-client.test.ts
+++ b/lib/src/swarm-id-client.test.ts
@@ -59,17 +59,6 @@ describe("SwarmIdClient connect()", () => {
         "_blank",
       )
     })
-
-    it("should include agent param in auth URL", async () => {
-      vi.spyOn(client, "ensureReady").mockImplementation(() => {})
-
-      await client.connect({ agent: true })
-
-      expect(window.open).toHaveBeenCalledWith(
-        expect.stringContaining("agent="),
-        "_blank",
-      )
-    })
   })
 
   describe("WebKit (Safari/iOS)", () => {
@@ -92,27 +81,6 @@ describe("SwarmIdClient connect()", () => {
       expect(sendRequestSpy).toHaveBeenCalledWith(
         expect.objectContaining({
           type: "connect",
-          agent: undefined,
-        }),
-      )
-    })
-
-    it("should send agent flag to proxy", async () => {
-      vi.spyOn(client, "ensureReady").mockImplementation(() => {})
-      const sendRequestSpy = vi
-        .spyOn(client as never, "sendRequest")
-        .mockResolvedValue({
-          type: "connectResponse",
-          requestId: "test",
-          success: true,
-        })
-
-      await client.connect({ agent: true })
-
-      expect(sendRequestSpy).toHaveBeenCalledWith(
-        expect.objectContaining({
-          type: "connect",
-          agent: true,
         }),
       )
     })

--- a/lib/src/swarm-id-client.ts
+++ b/lib/src/swarm-id-client.ts
@@ -848,7 +848,6 @@ export class SwarmIdClient {
    * For Safari details, see https://github.com/snaha/swarm-id/issues/167
    *
    * @param options - Configuration options for the connect flow
-   * @param options.agent - When true, shows the agent sign-up option on the connect page
    * @throws {Error} If the client is not initialized or the popup fails to open
    *
    * @example
@@ -858,9 +857,6 @@ export class SwarmIdClient {
    *
    * // Open authentication page
    * await client.connect()
-   *
-   * // Open with agent sign-up option visible
-   * await client.connect({ agent: true })
    * ```
    */
   async connect(options: ConnectOptions = {}): Promise<void> {
@@ -876,7 +872,6 @@ export class SwarmIdClient {
       }>({
         type: "connect",
         requestId,
-        agent: options.agent,
         popupMode: options.popupMode,
       })
       if (!response.success) {
@@ -891,7 +886,6 @@ export class SwarmIdClient {
         this.iframeOrigin + basePath,
         window.location.origin,
         this.metadata,
-        { agent: options.agent },
       )
 
       const effectivePopupMode = options.popupMode ?? this.popupMode

--- a/lib/src/swarm-id-proxy.ts
+++ b/lib/src/swarm-id-proxy.ts
@@ -1971,13 +1971,11 @@ export class SwarmIdProxy {
     message: {
       type: "connect"
       requestId: string
-      agent?: boolean
       popupMode?: "popup" | "window"
     },
     event: MessageEvent,
   ): void {
     const success = this.openAuthPopup({
-      agent: message.agent,
       popupMode: message.popupMode,
     })
     this.postMessage(event, {
@@ -1991,10 +1989,7 @@ export class SwarmIdProxy {
    * Open the authentication popup window.
    * Returns true if popup was opened, false if parent origin is not set.
    */
-  private openAuthPopup(options?: {
-    agent?: boolean
-    popupMode?: "popup" | "window"
-  }): boolean {
+  private openAuthPopup(options?: { popupMode?: "popup" | "window" }): boolean {
     if (!this.parentOrigin) {
       console.error("[Proxy] Cannot open auth window - parent origin not set")
       return false
@@ -2012,7 +2007,7 @@ export class SwarmIdProxy {
       window.location.origin + basePath,
       this.parentOrigin,
       this.appMetadata,
-      { challenge, agent: options?.agent },
+      { challenge },
     )
 
     // Open as popup or full window based on popupMode (per-call override takes precedence)

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -1024,7 +1024,6 @@ export const GetPostageBatchMessageSchema = z.object({
 export const ConnectMessageSchema = z.object({
   type: z.literal("connect"),
   requestId: z.string(),
-  agent: z.boolean().optional(),
   popupMode: z.enum(["popup", "window"]).optional(),
 })
 
@@ -1685,11 +1684,6 @@ export interface AuthOptions {
  * Configuration options for the connect() method.
  */
 export interface ConnectOptions {
-  /**
-   * When true, shows the agent sign-up option on the connect page.
-   * Agents are automated services that can perform operations on behalf of users.
-   */
-  agent?: boolean
   /**
    * Override popup mode for this connect call.
    * "popup" opens a sized popup window, "window" opens a full browser tab.

--- a/lib/src/utils/url.test.ts
+++ b/lib/src/utils/url.test.ts
@@ -82,40 +82,6 @@ describe("buildAuthUrl", () => {
     )
   })
 
-  it("should include agent parameter when option is true", () => {
-    const url = buildAuthUrl(
-      "https://swarm-id.example.com",
-      "https://myapp.example.com",
-      { name: "Test App" },
-      { agent: true },
-    )
-
-    expect(url).toContain("agent=")
-  })
-
-  it("should not include agent parameter when option is false", () => {
-    const url = buildAuthUrl(
-      "https://swarm-id.example.com",
-      "https://myapp.example.com",
-      { name: "Test App" },
-      { agent: false },
-    )
-
-    expect(url).not.toContain("agent")
-  })
-
-  it("should include challenge and agent when both options are set", () => {
-    const url = buildAuthUrl(
-      "https://swarm-id.example.com",
-      "https://myapp.example.com",
-      { name: "Test App" },
-      { agent: true, challenge: "test-challenge-123" },
-    )
-
-    expect(url).toContain("challenge=test-challenge-123")
-    expect(url).toContain("agent=")
-  })
-
   it("should include challenge when provided", () => {
     const url = buildAuthUrl(
       "https://swarm-id.example.com",

--- a/lib/src/utils/url.ts
+++ b/lib/src/utils/url.ts
@@ -31,11 +31,6 @@ export function isHttpUrl(value: string): boolean {
  */
 export interface BuildAuthUrlOptions {
   /**
-   * When true, shows the agent sign-up option on the connect page.
-   * Agents are automated services that can perform operations on behalf of users.
-   */
-  agent?: boolean
-  /**
    * Challenge string for storage partitioning detection. When present, the popup checks
    * if it can read this challenge from localStorage to determine whether
    * storage is partitioned.
@@ -87,10 +82,6 @@ export function buildAuthUrl(
 
   if (options?.challenge) {
     params.set("challenge", options.challenge)
-  }
-
-  if (options?.agent) {
-    params.set("agent", "")
   }
 
   return `${baseUrl}/connect#${params.toString()}`

--- a/ui/src/lib/stores/connect.svelte.ts
+++ b/ui/src/lib/stores/connect.svelte.ts
@@ -13,8 +13,6 @@ export interface ConnectRequest {
   appName: string
   appDescription?: string
   appIcon?: string
-  /** Agent (automated service) sign-up requested by the dApp. */
-  agent: boolean
   /**
    * Set when the proxy iframe could not share localStorage with this popup
    * (storage partitioning). The app secret then goes back to the iframe via
@@ -79,7 +77,6 @@ export const connectStore = {
       appName: params.get('appName') ?? deriveAppName(appOrigin),
       appDescription: params.get('appDescription') ?? undefined,
       appIcon: params.get('appIcon') ?? undefined,
-      agent: params.has('agent'),
       partitionChallenge,
     }
     return true


### PR DESCRIPTION
Removes the dead \`?agent\` connect flag end-to-end. Its only real consumer was the legacy \`swarm-ui\` (removed in #465); the new ui parsed it but never read it — the unified BIP-39 seed model made a separate agent flow unnecessary (#310).

- **lib**: drop \`ConnectOptions.agent\`, the \`agent\` field on the connect message schema, proxy plumbing, and the \`agent\` auth-URL param (+ their tests)
- **ui**: drop the unread \`agent\` field from the connect store's \`ConnectRequest\`
- **demo**: remove the "Agent sign-up" checkbox and its threading into \`connect()\`
- **docs**: remove \`options.agent\` from the API reference

Remaining \`agent\` mentions in the repo are the unrelated legacy *account-type* concept (schema history comment, account-snapshot test name, design docs), not the connect flag. Note: removing \`ConnectOptions.agent\` is a breaking change to the \`@snaha/swarm-id\` client API.

Verified in the running apps: the demo connect popover no longer offers agent sign-up, and the popup URL carries only \`origin\`/\`appName\`/\`appDescription\`/\`appIcon\`. \`pnpm check:all\` passes.

Closes #428

🤖 Generated with [Claude Code](https://claude.com/claude-code)