### PR TITLE
fix(ui): guard against non-deterministic wallet signatures at creation

### DIFF
--- a/ui/src/lib/components/home-account.svelte
+++ b/ui/src/lib/components/home-account.svelte
@@ -38,7 +38,7 @@
     encryptSeed,
     randomSalt,
   } from '$lib/crypto/encryption'
-  import { deriveWalletKey, requestWalletKeySource } from '$lib/crypto/eth-wallet'
+  import { createWalletKeySource, deriveWalletKey } from '$lib/crypto/eth-wallet'
   import { prefix0x } from '$lib/crypto/hex'
   import { phraseFromEntropy, privateKeyFromEntropy } from '$lib/crypto/mnemonic'
   import { createPasskeyKey } from '$lib/crypto/passkey'
@@ -242,7 +242,7 @@
         access = { type: 'passkey', credentialId: passkey.credentialId }
         key = passkey.key
       } else if (newMethod === 'eth-wallet') {
-        const source = await requestWalletKeySource()
+        const source = await createWalletKeySource()
         const salt = randomSalt()
         key = await deriveWalletKey(source, salt)
         access = {
@@ -665,7 +665,7 @@
       {@render pendingBody(
         newMethod === 'eth-wallet' ? 'Confirm with new wallet' : 'Confirm with new passkey',
         newMethod === 'eth-wallet'
-          ? 'Approve the request in your Ethereum wallet.'
+          ? 'Approve both signing requests in your Ethereum wallet.'
           : 'Follow the prompts on your device.',
       )}
     </Dialog>
@@ -678,7 +678,10 @@
           Unlock with your device&rsquo;s built-in authentication &mdash; fingerprint, face, or PIN.
         </p>
       {:else if newMethod === 'eth-wallet'}
-        <p class="text-sm">Unlock by signing a message with your Ethereum wallet.</p>
+        <p class="text-sm">
+          Unlock by signing a message with your Ethereum wallet. Setup asks you to sign twice to
+          confirm your wallet signs consistently.
+        </p>
       {:else}
         <div class="flex w-full flex-col gap-4">
           <div class="flex w-full flex-col gap-2">

--- a/ui/src/lib/crypto/eth-wallet.test.ts
+++ b/ui/src/lib/crypto/eth-wallet.test.ts
@@ -1,0 +1,90 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { Signature, Wallet } from 'ethers'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createWalletKeySource, requestWalletKeySource } from './eth-wallet'
+
+const { connectWallet } = vi.hoisted(() => ({ connectWallet: vi.fn() }))
+
+vi.mock('$lib/crypto/onboard', () => ({ onboard: { connectWallet } }))
+
+/** EIP-1193 provider stub whose personal_sign delegates to `sign`. */
+function walletProvider(sign: (message: string) => Promise<string>) {
+  return {
+    request: vi.fn(async ({ method, params }: { method: string; params?: unknown[] }) => {
+      expect(method).toBe('personal_sign')
+      return sign(params?.[0] as string)
+    }),
+  }
+}
+
+function connectAs(address: string, provider: unknown) {
+  connectWallet.mockResolvedValue([{ accounts: [{ address }], provider }])
+}
+
+beforeEach(() => {
+  connectWallet.mockReset()
+})
+
+describe('createWalletKeySource (new key material)', () => {
+  it('rejects a wallet that signs the same message differently', async () => {
+    const wallet = Wallet.createRandom()
+    const rogue = Wallet.createRandom()
+    // A non-RFC-6979 signer returns different bytes on each signing; simulate
+    // it by answering the second prompt with a different well-formed ECDSA
+    // signature. Trusting it would encrypt the seed under a key the wallet
+    // can never re-derive.
+    let signs = 0
+    const provider = walletProvider((message) =>
+      (signs++ === 0 ? wallet : rogue).signMessage(message),
+    )
+    connectAs(wallet.address, provider)
+
+    await expect(createWalletKeySource()).rejects.toThrow(/different signature each time/)
+    expect(provider.request).toHaveBeenCalledTimes(2)
+  })
+
+  it('accepts a deterministic wallet and returns the canonical key source', async () => {
+    const wallet = Wallet.createRandom()
+    let signature: string | undefined
+    const provider = walletProvider(async (message) => {
+      signature = await wallet.signMessage(message)
+      return signature
+    })
+    // Lowercased address from the provider: the source must checksum it.
+    connectAs(wallet.address.toLowerCase(), provider)
+
+    const source = await createWalletKeySource()
+
+    expect(provider.request).toHaveBeenCalledTimes(2)
+    expect(source.walletAddress).toBe(wallet.address)
+    expect(source.signature).toBe(Signature.from(signature as string).serialized)
+  })
+
+  it('rejects a non-recoverable signature before prompting a second time', async () => {
+    const wallet = Wallet.createRandom()
+    const contractSigner = Wallet.createRandom()
+    const provider = walletProvider((message) => contractSigner.signMessage(message))
+    connectAs(wallet.address, provider)
+
+    await expect(createWalletKeySource()).rejects.toThrow(/not supported/)
+    expect(provider.request).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('requestWalletKeySource (unlock)', () => {
+  it('signs once and matches the key source minted at creation', async () => {
+    const wallet = Wallet.createRandom()
+    const created = walletProvider((message) => wallet.signMessage(message))
+    connectAs(wallet.address, created)
+    const source = await createWalletKeySource()
+
+    const unlocked = walletProvider((message) => wallet.signMessage(message))
+    connectAs(wallet.address, unlocked)
+    const unlockSource = await requestWalletKeySource()
+
+    expect(unlocked.request).toHaveBeenCalledTimes(1)
+    expect(unlockSource).toEqual(source)
+  })
+})

--- a/ui/src/lib/crypto/eth-wallet.ts
+++ b/ui/src/lib/crypto/eth-wallet.ts
@@ -8,10 +8,13 @@
  * wallet holder can produce the signature — the stored salt and address alone
  * reveal nothing.
  *
- * Relies on deterministic ECDSA (RFC 6979, standard in wallets): the same
- * message and key must always produce the same signature. Smart-contract
- * wallets (ERC-1271) don't return a recoverable ECDSA signature and are
- * rejected up front.
+ * Relies on deterministic ECDSA (RFC 6979, standard in wallets but not
+ * enforced by any protocol): the same message and key must always produce the
+ * same signature. Smart-contract wallets (ERC-1271) don't return a
+ * recoverable ECDSA signature and are rejected up front; a random-nonce
+ * signer would produce valid but ever-changing signatures, so minting new key
+ * material signs twice and rejects the wallet on mismatch
+ * (createWalletKeySource).
  */
 import { hexToUint8Array } from '@snaha/swarm-id'
 import { Signature, getAddress, verifyMessage } from 'ethers'
@@ -51,14 +54,19 @@ async function connectWallet(): Promise<{ provider: EthereumProvider; walletAddr
   return { provider: wallet.provider as unknown as EthereumProvider, walletAddress }
 }
 
-/** Connect the wallet and obtain the deterministic message signature. */
-export async function requestWalletKeySource(): Promise<WalletKeySource> {
-  const { provider, walletAddress } = await connectWallet()
-
-  const signature = (await provider.request({
+/** Ask the wallet to personal_sign the fixed key-derivation message. */
+async function signKeyMessage(provider: EthereumProvider, walletAddress: string): Promise<string> {
+  return (await provider.request({
     method: 'personal_sign',
     params: [SIGNING_MESSAGE, walletAddress],
   })) as string
+}
+
+async function walletKeySource(
+  provider: EthereumProvider,
+  walletAddress: string,
+): Promise<WalletKeySource> {
+  const signature = await signKeyMessage(provider, walletAddress)
 
   // Reject non-ECDSA signatures (smart-contract wallets) — they can't be
   // reproduced for key derivation — and normalize the representation so
@@ -70,6 +78,37 @@ export async function requestWalletKeySource(): Promise<WalletKeySource> {
     walletAddress: getAddress(walletAddress),
     signature: Signature.from(signature).serialized,
   }
+}
+
+/**
+ * Connect the wallet and obtain the deterministic message signature. Signs
+ * once — for unlocking an existing account, where a signature that doesn't
+ * reproduce the creation-time bytes merely fails decryption.
+ */
+export async function requestWalletKeySource(): Promise<WalletKeySource> {
+  const { provider, walletAddress } = await connectWallet()
+  return walletKeySource(provider, walletAddress)
+}
+
+/**
+ * Connect the wallet and obtain the message signature for minting NEW key
+ * material (account creation, unlock-method change). Deterministic signing is
+ * a wallet convention, not a guarantee — a wallet signing with a random nonce
+ * would derive a different key on every unlock and permanently lock the user
+ * out. So before any seed is encrypted under the derived key, request a
+ * second signature and require byte-identical canonical results.
+ */
+export async function createWalletKeySource(): Promise<WalletKeySource> {
+  const { provider, walletAddress } = await connectWallet()
+  const source = await walletKeySource(provider, walletAddress)
+
+  const confirmation = await signKeyMessage(provider, walletAddress)
+  if (Signature.from(confirmation).serialized !== source.signature) {
+    throw new Error(
+      'This wallet produces a different signature each time it signs, so it cannot reliably secure an account. Use a different wallet or unlock method.',
+    )
+  }
+  return source
 }
 
 /** Derive the seed-encryption key for a wallet key source. */

--- a/ui/src/routes/account/new/access/+page.svelte
+++ b/ui/src/routes/account/new/access/+page.svelte
@@ -33,7 +33,7 @@
     encryptSeed,
     randomSalt,
   } from '$lib/crypto/encryption'
-  import { deriveWalletKey, requestWalletKeySource } from '$lib/crypto/eth-wallet'
+  import { createWalletKeySource, deriveWalletKey } from '$lib/crypto/eth-wallet'
   import { strip0x } from '$lib/crypto/hex'
   import { walletFromPhrase } from '$lib/crypto/mnemonic'
   import { createPasskeyKey } from '$lib/crypto/passkey'
@@ -179,7 +179,7 @@
     error = undefined
     pending = 'eth-wallet'
     try {
-      const source = await requestWalletKeySource()
+      const source = await createWalletKeySource()
       if (myAttempt !== attempt) {
         return
       }
@@ -251,7 +251,7 @@
             <p class="text-sm">
               {pending === 'passkey'
                 ? 'Follow the prompts on your device.'
-                : 'Approve the request in your Ethereum wallet.'}
+                : 'Approve both signing requests in your Ethereum wallet.'}
             </p>
           </div>
         </div>
@@ -286,7 +286,10 @@
                 or PIN.
               </p>
             {:else if method === 'eth-wallet'}
-              <p class="text-sm">Unlock by signing a message with your Ethereum wallet.</p>
+              <p class="text-sm">
+                Unlock by signing a message with your Ethereum wallet. Setup asks you to sign twice
+                to confirm your wallet signs consistently.
+              </p>
             {/if}
           </div>
 


### PR DESCRIPTION
The seed-encryption key is derived from a wallet signature over a fixed message, which relies on deterministic ECDSA (RFC 6979) — a wallet convention, not a protocol guarantee. A random-nonce signer would produce a valid but different signature on every unlock, silently deriving a different key and permanently locking the user out of the encrypted seed.

This adds the sign-twice-and-compare guard from the issue at the points where new key material is minted:

- **`createWalletKeySource()`** (new): connects, signs, runs the existing ERC-1271/recovery rejection, then requests a **second** signature and compares canonical serializations. On mismatch it throws an actionable error ("This wallet produces a different signature each time it signs, so it cannot reliably secure an account. Use a different wallet or unlock method.") before any seed is encrypted under the key. The second signature is compared by canonical bytes only — any divergence (different nonce, representation drift) means the wallet can't be trusted as entropy, regardless of why.
- **Creation call sites** switched to it: account creation (`account/new/access/+page.svelte`, also serving the connect/restore/sign-in flows) and unlock-method change (`home-account.svelte`).
- **Unlock is unchanged** (`requestWalletKeySource`, single prompt): a divergent signature there just fails decryption — no reason to double-prompt on every unlock.
- UI copy on the two creation surfaces now announces the two signing prompts, so the second wallet popup doesn't read as a glitch or an attack.

The wallet allow-list fast path suggested in the issue is deliberately skipped: wallet identity (rdns/UA) is spoofable and the list would rot; one extra prompt at onboarding only is cheap.

Tests (TDD, mocked EIP-1193 provider + @web3-onboard): a provider answering the re-sign with different bytes is rejected at creation; a deterministic provider passes and yields the canonical, checksummed key source; the recovery rejection fires before the second prompt; unlock still signs exactly once and matches the creation-time key source.

Closes #450

🤖 Generated with [Claude Code](https://claude.com/claude-code)
