### PR TITLE
fix(ui): dialog focus management and tabs keyboard contract

### DIFF
--- a/ui/src/lib/components/home-account.svelte
+++ b/ui/src/lib/components/home-account.svelte
@@ -635,6 +635,7 @@
           bind:value={password}
           placeholder="Account password"
           autocomplete="current-password"
+          data-autofocus
           onkeydown={(event: KeyboardEvent) => event.key === 'Enter' && confirmUnlock()}
         />
       {/if}

--- a/ui/src/lib/components/ui/dialog/dialog.svelte
+++ b/ui/src/lib/components/ui/dialog/dialog.svelte
@@ -3,8 +3,14 @@
   SPDX-License-Identifier: Apache-2.0
 -->
 
+<!--
+  Modal dialog implementing the WAI-ARIA dialog focus contract: on open, focus
+  moves into the dialog — to a `[data-autofocus]` element if the consumer marked
+  one, else the first focusable control, else the panel itself; Tab and
+  Shift+Tab wrap within the dialog; on close, focus returns to the opener.
+-->
 <script lang="ts">
-  import type { Snippet } from 'svelte'
+  import { type Snippet, onMount } from 'svelte'
 
   import X from '@lucide/svelte/icons/x'
 
@@ -23,9 +29,64 @@
 
   let { title, dismissable = true, onclose, class: className, children }: Props = $props()
 
+  let panel = $state<HTMLDivElement>()
+
+  const FOCUSABLE_SELECTOR = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled]):not([type="hidden"])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(', ')
+
+  function focusables(): HTMLElement[] {
+    return panel ? [...panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)] : []
+  }
+
+  onMount(() => {
+    const opener = document.activeElement
+    const autofocus = panel?.querySelector<HTMLElement>('[data-autofocus]')
+    const target = autofocus ?? focusables()[0] ?? panel
+    target?.focus()
+    return () => {
+      // The opener may be gone by now (e.g. swapping to a pending-state
+      // dialog unmounts the previous one while its trigger persists).
+      if (opener instanceof HTMLElement && opener.isConnected) {
+        opener.focus()
+      }
+    }
+  })
+
+  // Keep Tab cycling inside the dialog; also pulls focus back in if it ever
+  // lands outside (e.g. after a click on the overlay).
+  function trapTab(event: KeyboardEvent) {
+    const items = focusables()
+    if (items.length === 0) {
+      event.preventDefault()
+      panel?.focus()
+      return
+    }
+    const first = items[0]
+    const last = items[items.length - 1]
+    const active = document.activeElement
+    const inside = active instanceof HTMLElement && panel?.contains(active) === true
+    if (event.shiftKey) {
+      if (!inside || active === first) {
+        event.preventDefault()
+        last.focus()
+      }
+    } else if (!inside || active === last) {
+      event.preventDefault()
+      first.focus()
+    }
+  }
+
   function onWindowKeydown(event: KeyboardEvent) {
     if (event.key === 'Escape' && dismissable) {
       onclose()
+    } else if (event.key === 'Tab') {
+      trapTab(event)
     }
   }
 </script>
@@ -34,11 +95,13 @@
 
 <div class="bg-background/60 fixed inset-0 z-50 flex items-center justify-center backdrop-blur-sm">
   <div
+    bind:this={panel}
     role="dialog"
     aria-modal="true"
     aria-label={title}
+    tabindex="-1"
     class={cn(
-      'bg-popover flex w-96 max-w-[calc(100vw-4rem)] flex-col gap-4 rounded-lg border p-4 shadow-lg',
+      'bg-popover flex w-96 max-w-[calc(100vw-4rem)] flex-col gap-4 rounded-lg border p-4 shadow-lg outline-none',
       className,
     )}
   >

--- a/ui/src/lib/components/ui/dialog/dialog.svelte
+++ b/ui/src/lib/components/ui/dialog/dialog.svelte
@@ -5,9 +5,11 @@
 
 <!--
   Modal dialog implementing the WAI-ARIA dialog focus contract: on open, focus
-  moves into the dialog — to a `[data-autofocus]` element if the consumer marked
-  one, else the first focusable control, else the panel itself; Tab and
-  Shift+Tab wrap within the dialog; on close, focus returns to the opener.
+  moves into the dialog — to a visible `[data-autofocus]` element if the
+  consumer marked one, else the first visible focusable control, else the panel
+  itself (also on touch-primary devices when the target is a text field, so the
+  software keyboard stays down); Tab and Shift+Tab wrap within the dialog; on
+  close, focus returns to the opener.
 -->
 <script lang="ts">
   import { type Snippet, onMount } from 'svelte'
@@ -40,14 +42,37 @@
     '[tabindex]:not([tabindex="-1"])',
   ].join(', ')
 
+  // Text-entry controls summon the software keyboard when focused on touch devices.
+  const TEXT_ENTRY_SELECTOR = 'input, textarea, [contenteditable]'
+
+  // The selector alone also matches controls that are currently invisible
+  // (`display: none` or `visibility: hidden`, own or inherited); those are not
+  // focusable, so counting them would make focus() calls silently fail.
+  function isVisible(element: HTMLElement): boolean {
+    return element.getClientRects().length > 0 && getComputedStyle(element).visibility === 'visible'
+  }
+
   function focusables(): HTMLElement[] {
-    return panel ? [...panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)] : []
+    return panel
+      ? [...panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)].filter(isVisible)
+      : []
   }
 
   onMount(() => {
     const opener = document.activeElement
-    const autofocus = panel?.querySelector<HTMLElement>('[data-autofocus]')
-    const target = autofocus ?? focusables()[0] ?? panel
+    const autofocus = panel
+      ? [...panel.querySelectorAll<HTMLElement>('[data-autofocus]')].find(isVisible)
+      : undefined
+    let target: HTMLElement | undefined = autofocus ?? focusables()[0] ?? panel
+    // On touch-primary devices, focusing a text field on open would also pop
+    // the software keyboard over the opening dialog — too much movement at
+    // once — so land on the panel instead; the field is one tap away.
+    if (
+      target?.matches(TEXT_ENTRY_SELECTOR) === true &&
+      window.matchMedia('(pointer: coarse)').matches
+    ) {
+      target = panel
+    }
     target?.focus()
     return () => {
       // The opener may be gone by now (e.g. swapping to a pending-state

--- a/ui/src/lib/components/ui/tabs/tabs.svelte
+++ b/ui/src/lib/components/ui/tabs/tabs.svelte
@@ -20,17 +20,55 @@
   }
 
   let { tabs, value = $bindable(), class: className }: Props = $props()
+
+  const buttons: (HTMLButtonElement | undefined)[] = []
+
+  // Roving tabindex: the selected tab is the tablist's only Tab stop (falling
+  // back to the first tab should `value` match none).
+  const tabStop = $derived(
+    Math.max(
+      0,
+      tabs.findIndex((tab) => tab.value === value),
+    ),
+  )
+
+  // WAI-ARIA tabs keyboard contract with automatic activation: arrows move
+  // focus and selection together, wrapping at the ends.
+  function onKeydown(event: KeyboardEvent, index: number) {
+    let target: number
+    switch (event.key) {
+      case 'ArrowLeft':
+        target = (index - 1 + tabs.length) % tabs.length
+        break
+      case 'ArrowRight':
+        target = (index + 1) % tabs.length
+        break
+      case 'Home':
+        target = 0
+        break
+      case 'End':
+        target = tabs.length - 1
+        break
+      default:
+        return
+    }
+    event.preventDefault()
+    value = tabs[target].value
+    buttons[target]?.focus()
+  }
 </script>
 
 <div
   role="tablist"
   class={cn('bg-muted flex h-8 w-full items-center rounded-lg p-[3px]', className)}
 >
-  {#each tabs as tab (tab.value)}
+  {#each tabs as tab, index (tab.value)}
     <button
+      bind:this={buttons[index]}
       type="button"
       role="tab"
       aria-selected={value === tab.value}
+      tabindex={index === tabStop ? 0 : -1}
       class={cn(
         'h-full flex-1 cursor-pointer rounded-md border border-transparent px-1.5 text-sm font-medium transition-colors',
         value === tab.value
@@ -38,6 +76,7 @@
           : 'text-muted-foreground',
       )}
       onclick={() => (value = tab.value)}
+      onkeydown={(event) => onKeydown(event, index)}
     >
       {tab.label}
     </button>

--- a/ui/src/lib/components/unlock-dialog.svelte
+++ b/ui/src/lib/components/unlock-dialog.svelte
@@ -115,6 +115,7 @@
         bind:value={password}
         placeholder="Account password"
         autocomplete="current-password"
+        data-autofocus
         onkeydown={(event: KeyboardEvent) => event.key === 'Enter' && confirm()}
       />
     {/if}

--- a/ui/tests/dialog-a11y.test.ts
+++ b/ui/tests/dialog-a11y.test.ts
@@ -1,0 +1,93 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { type Page, expect, test } from '@playwright/test'
+
+// At least MIN_PASSWORD_LENGTH (8) characters.
+const PASSWORD = 'test-password-123'
+
+// The network settings dialog is reachable from a fresh profile through the
+// settings menu — no account required.
+async function openNetworkSettings(page: Page) {
+  await page.goto('/?signin')
+  // The first load on a cold dev server compiles the route on demand; give
+  // the shell extra time to appear before the default action timeout applies.
+  await expect(page.getByRole('button', { name: 'Settings' })).toBeVisible({ timeout: 15000 })
+  await page.getByRole('button', { name: 'Settings' }).click()
+  await page.getByRole('menuitem', { name: 'Network settings' }).click()
+  await expect(page.getByRole('dialog', { name: 'Network settings' })).toBeVisible()
+}
+
+// Creates a password-protected account and lands in the app shell, where the
+// Backup section holds a persistent opener for the unlock dialog.
+async function createPasswordAccount(page: Page) {
+  await page.goto('/')
+  const getStarted = page.getByRole('link', { name: 'Get started' }).first()
+  await expect(getStarted).toBeVisible({ timeout: 15000 })
+  await getStarted.click()
+  await page.getByRole('link', { name: 'Create a new account' }).click()
+
+  await expect(page).toHaveURL(/\/account\/new$/)
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await expect(page).toHaveURL(/\/account\/new\/phrase$/)
+  await page.getByRole('button', { name: 'Reveal' }).click()
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await expect(page).toHaveURL(/\/account\/new\/access$/)
+  await page.getByRole('tab', { name: 'Password' }).click()
+  await page.locator('#new-password').fill(PASSWORD)
+  await page.locator('#verify-password').fill(PASSWORD)
+  await page.getByRole('button', { name: 'Confirm', exact: true }).click()
+
+  await expect(page).toHaveURL(/\/account\/new\/done$/)
+  await page.getByRole('button', { name: 'Stay local for now' }).click()
+  await expect(page).toHaveURL(/\/$/)
+}
+
+test('dialog moves focus inside on open and wraps Tab at both ends', async ({ page }) => {
+  await openNetworkSettings(page)
+
+  const dialog = page.getByRole('dialog', { name: 'Network settings' })
+  const close = dialog.getByRole('button', { name: 'Close' })
+  const reset = dialog.getByRole('button', { name: 'Reset' })
+
+  // Initial focus lands on the dialog's first focusable control.
+  await expect(close).toBeFocused()
+
+  // Shift+Tab from the first control wraps to the last...
+  await page.keyboard.press('Shift+Tab')
+  await expect(reset).toBeFocused()
+
+  // ...and Tab from the last wraps back to the first — never the page behind.
+  await page.keyboard.press('Tab')
+  await expect(close).toBeFocused()
+})
+
+test('Escape closes the dialog', async ({ page }) => {
+  await openNetworkSettings(page)
+
+  await page.keyboard.press('Escape')
+  await expect(page.getByRole('dialog', { name: 'Network settings' })).toBeHidden()
+})
+
+test('unlock dialog autofocuses the password input and returns focus to its opener', async ({
+  page,
+}) => {
+  await createPasswordAccount(page)
+
+  await page.getByRole('tab', { name: 'Account' }).click()
+  await page.getByRole('button', { name: /^Backup/ }).click()
+  const opener = page.getByRole('button', { name: 'Export .swarmid file' })
+  await opener.click()
+
+  // `data-autofocus` beats the first-focusable default: the password input is
+  // ready to type into.
+  const dialog = page.getByRole('dialog', { name: 'Export backup' })
+  await expect(dialog).toBeVisible()
+  await expect(dialog.getByPlaceholder('Account password')).toBeFocused()
+
+  // Closing hands focus back to the opener.
+  await page.keyboard.press('Escape')
+  await expect(dialog).toBeHidden()
+  await expect(opener).toBeFocused()
+})

--- a/ui/tests/dialog-a11y.test.ts
+++ b/ui/tests/dialog-a11y.test.ts
@@ -5,13 +5,16 @@ import { type Page, expect, test } from '@playwright/test'
 // At least MIN_PASSWORD_LENGTH (8) characters.
 const PASSWORD = 'test-password-123'
 
-// The network settings dialog is reachable from a fresh profile through the
-// settings menu — no account required.
-async function openNetworkSettings(page: Page) {
+async function gotoSignin(page: Page) {
   await page.goto('/?signin')
   // The first load on a cold dev server compiles the route on demand; give
   // the shell extra time to appear before the default action timeout applies.
   await expect(page.getByRole('button', { name: 'Settings' })).toBeVisible({ timeout: 15000 })
+}
+
+// The network settings dialog is reachable from a fresh profile through the
+// settings menu — no account required.
+async function openNetworkSettings(page: Page) {
   await page.getByRole('button', { name: 'Settings' }).click()
   await page.getByRole('menuitem', { name: 'Network settings' }).click()
   await expect(page.getByRole('dialog', { name: 'Network settings' })).toBeVisible()
@@ -45,6 +48,7 @@ async function createPasswordAccount(page: Page) {
 }
 
 test('dialog moves focus inside on open and wraps Tab at both ends', async ({ page }) => {
+  await gotoSignin(page)
   await openNetworkSettings(page)
 
   const dialog = page.getByRole('dialog', { name: 'Network settings' })
@@ -64,10 +68,70 @@ test('dialog moves focus inside on open and wraps Tab at both ends', async ({ pa
 })
 
 test('Escape closes the dialog', async ({ page }) => {
+  await gotoSignin(page)
   await openNetworkSettings(page)
 
   await page.keyboard.press('Escape')
   await expect(page.getByRole('dialog', { name: 'Network settings' })).toBeHidden()
+})
+
+test('initial focus skips invisible controls', async ({ page }) => {
+  await gotoSignin(page)
+
+  // Hide the dialog's first focusable (the X) before it opens: initial focus
+  // must skip it — focusing an invisible element silently fails — and land on
+  // the first visible control instead.
+  await page.addStyleTag({
+    content: '[role="dialog"] button[aria-label="Close"] { visibility: hidden }',
+  })
+  await openNetworkSettings(page)
+
+  const dialog = page.getByRole('dialog', { name: 'Network settings' })
+  await expect(dialog.locator('#bee-node-url')).toBeFocused()
+})
+
+test('a hidden data-autofocus mark is skipped', async ({ page }) => {
+  await createPasswordAccount(page)
+
+  // Hide the marked password input before the dialog opens (`display: none`,
+  // the other way an element can be invisible): the mark must lose to the
+  // first visible focusable control.
+  await page.addStyleTag({ content: '[role="dialog"] [data-autofocus] { display: none }' })
+  await page.getByRole('tab', { name: 'Account' }).click()
+  await page.getByRole('button', { name: /^Backup/ }).click()
+  await page.getByRole('button', { name: 'Export .swarmid file' }).click()
+
+  const dialog = page.getByRole('dialog', { name: 'Export backup' })
+  await expect(dialog).toBeVisible()
+  await expect(dialog.getByRole('button', { name: 'Close' })).toBeFocused()
+})
+
+test.describe('touch-primary devices', () => {
+  // `hasTouch` makes `(pointer: coarse)` match in Chromium — the signal the
+  // dialog uses to keep the software keyboard down on open.
+  test.use({ hasTouch: true })
+
+  test('text inputs are not autofocused, so no software keyboard pops up', async ({ page }) => {
+    await createPasswordAccount(page)
+
+    await page.getByRole('tab', { name: 'Account' }).click()
+    await page.getByRole('button', { name: /^Backup/ }).click()
+    await page.getByRole('button', { name: 'Export .swarmid file' }).click()
+
+    // Focus still moves into the dialog, but onto the panel itself — focusing
+    // the marked password field would summon the keyboard mid-animation.
+    const dialog = page.getByRole('dialog', { name: 'Export backup' })
+    await expect(dialog).toBeFocused()
+    await expect(dialog.getByPlaceholder('Account password')).not.toBeFocused()
+  })
+
+  test('non-text controls still receive initial focus', async ({ page }) => {
+    await gotoSignin(page)
+    await openNetworkSettings(page)
+
+    const dialog = page.getByRole('dialog', { name: 'Network settings' })
+    await expect(dialog.getByRole('button', { name: 'Close' })).toBeFocused()
+  })
 })
 
 test('unlock dialog autofocuses the password input and returns focus to its opener', async ({

--- a/ui/tests/tabs-a11y.test.ts
+++ b/ui/tests/tabs-a11y.test.ts
@@ -1,0 +1,85 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { type Page, expect, test } from '@playwright/test'
+
+// Walks a fresh profile to the access step, whose tablist has three tabs
+// (Passkey / ETH wallet / Password) — enough to exercise wrap-around and
+// Home/End. The account is left un-finalized; this file is about the tablist.
+async function gotoAccessStep(page: Page) {
+  await page.goto('/')
+  // The first load on a cold dev server compiles the route on demand; give
+  // the shell extra time to appear before the default action timeout applies.
+  const getStarted = page.getByRole('link', { name: 'Get started' }).first()
+  await expect(getStarted).toBeVisible({ timeout: 15000 })
+  await getStarted.click()
+  await page.getByRole('link', { name: 'Create a new account' }).click()
+
+  await expect(page).toHaveURL(/\/account\/new$/)
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await expect(page).toHaveURL(/\/account\/new\/phrase$/)
+  await page.getByRole('button', { name: 'Reveal' }).click()
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await expect(page).toHaveURL(/\/account\/new\/access$/)
+}
+
+test('arrow keys move tab focus and selection, wrapping at both ends', async ({ page }) => {
+  await gotoAccessStep(page)
+
+  const passkey = page.getByRole('tab', { name: 'Passkey' })
+  const wallet = page.getByRole('tab', { name: 'ETH wallet' })
+  const password = page.getByRole('tab', { name: 'Password' })
+
+  await passkey.click()
+  await expect(passkey).toBeFocused()
+
+  // Automatic activation: arrows move focus and selection together.
+  await page.keyboard.press('ArrowRight')
+  await expect(wallet).toBeFocused()
+  await expect(wallet).toHaveAttribute('aria-selected', 'true')
+  await expect(passkey).toHaveAttribute('aria-selected', 'false')
+
+  await page.keyboard.press('ArrowRight')
+  await expect(password).toBeFocused()
+  await expect(password).toHaveAttribute('aria-selected', 'true')
+  // Selection is live — the password panel replaced the passkey copy.
+  await expect(page.locator('#new-password')).toBeVisible()
+
+  // ArrowRight from the last tab wraps to the first...
+  await page.keyboard.press('ArrowRight')
+  await expect(passkey).toBeFocused()
+  await expect(passkey).toHaveAttribute('aria-selected', 'true')
+
+  // ...and ArrowLeft from the first wraps back to the last.
+  await page.keyboard.press('ArrowLeft')
+  await expect(password).toBeFocused()
+  await expect(password).toHaveAttribute('aria-selected', 'true')
+
+  await page.keyboard.press('Home')
+  await expect(passkey).toBeFocused()
+  await expect(passkey).toHaveAttribute('aria-selected', 'true')
+
+  await page.keyboard.press('End')
+  await expect(password).toBeFocused()
+  await expect(password).toHaveAttribute('aria-selected', 'true')
+})
+
+test('the tablist is a single Tab stop (roving tabindex)', async ({ page }) => {
+  await gotoAccessStep(page)
+
+  const passkey = page.getByRole('tab', { name: 'Passkey' })
+  const wallet = page.getByRole('tab', { name: 'ETH wallet' })
+  const password = page.getByRole('tab', { name: 'Password' })
+
+  // Only the selected tab participates in the page Tab order.
+  await expect(passkey).toHaveAttribute('tabindex', '0')
+  await expect(wallet).toHaveAttribute('tabindex', '-1')
+  await expect(password).toHaveAttribute('tabindex', '-1')
+
+  // Tab from the selected tab leaves the tablist for the panel content
+  // instead of visiting the remaining tabs.
+  await passkey.click()
+  await page.keyboard.press('Tab')
+  await expect(page.getByRole('button', { name: 'Confirm with passkey' })).toBeFocused()
+})


### PR DESCRIPTION
Implements the accessibility contracts the hand-written primitives were announcing but not providing (per WAI-ARIA APG, no new dependencies).

**Dialog** (`ui/src/lib/components/ui/dialog/dialog.svelte`)
- On open, focus moves into the dialog: a consumer-marked `[data-autofocus]` element, else the first focusable control, else the panel itself
- Tab/Shift+Tab wrap within the dialog, and pull focus back inside if it ever lands outside
- On close, focus returns to the opener if it still exists — the restore chains correctly through pending-state dialog swaps (unlock → pending → back)
- The unlock dialogs mark their password input `data-autofocus`, so keyboard users can type the password immediately

**Tabs** (`ui/src/lib/components/ui/tabs/tabs.svelte`)
- Roving tabindex: only the selected tab is a page Tab stop
- ArrowLeft/ArrowRight (with wrap-around) and Home/End move focus and selection together (automatic activation)

**Tests** (Playwright, `ui/tests/`)
- `dialog-a11y.test.ts` — initial focus, Tab wrap in both directions, Escape, `data-autofocus`, focus restore to the opener
- `tabs-a11y.test.ts` — arrow/Home/End navigation with wrap, automatic activation, single-Tab-stop roving

All dialog and tabs consumers verified manually in the browser (network settings, unlock, set-method with tabs inside a dialog, delete account), plus the existing Playwright suite passes.

Out of scope: `aria-controls`/`role="tabpanel"` linkage — panels are rendered by consumers outside the primitive.

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)