### PR TITLE
fix(lib): upload zero-byte data and reject multi-chunk explicit encryption key

### DIFF
--- a/lib/src/chunk/cac.test.ts
+++ b/lib/src/chunk/cac.test.ts
@@ -103,20 +103,6 @@ describe("makeContentAddressedChunk", () => {
   })
 
   describe("error handling", () => {
-    it("should throw error on empty payload", () => {
-      const emptyPayload = new Uint8Array(0)
-
-      expect(() => makeContentAddressedChunk(emptyPayload)).toThrow(
-        /payload size .* exceeds limits/,
-      )
-    })
-
-    it("should throw error on empty string", () => {
-      expect(() => makeContentAddressedChunk("")).toThrow(
-        /payload size .* exceeds limits/,
-      )
-    })
-
     it("should throw error on payload larger than 4096 bytes", () => {
       const largePayload = new Uint8Array(4097)
 
@@ -154,6 +140,20 @@ describe("makeContentAddressedChunk", () => {
   })
 
   describe("payload size variations", () => {
+    it("should handle a zero-length payload (Bee's empty-file chunk)", () => {
+      const chunk = makeContentAddressedChunk(new Uint8Array(0))
+
+      expect(chunk.span.toBigInt()).toBe(BigInt(0))
+      expect(chunk.data.length).toBe(8) // span only
+      // Canonical reference for empty content — bee builder_test.go TestEmpty
+      expect(chunk.address.toHex()).toBe(
+        "b34ca8c22b9e982354f9c7f50b470d66db428d880c8a904d5fe4ec9713171526",
+      )
+      expect(makeContentAddressedChunk("").address.toHex()).toBe(
+        chunk.address.toHex(),
+      )
+    })
+
     it("should handle minimum payload size (1 byte)", () => {
       const payload = new Uint8Array([42])
       const chunk = makeContentAddressedChunk(payload)

--- a/lib/src/chunk/constants.ts
+++ b/lib/src/chunk/constants.ts
@@ -1,8 +1,10 @@
 // Copyright 2026 The Swarm Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// Chunk size constants
-export const MIN_PAYLOAD_SIZE = 1
+// Chunk size constants. An empty payload is valid — Bee represents
+// zero-length content as a single chunk with span 0 (cac.validateDataLength
+// allows 0..4096).
+export const MIN_PAYLOAD_SIZE = 0
 export const MAX_PAYLOAD_SIZE = 4096
 
 // Span size (8 bytes for uint64 little-endian)

--- a/lib/src/chunk/encrypted-cac.test.ts
+++ b/lib/src/chunk/encrypted-cac.test.ts
@@ -122,20 +122,6 @@ describe("makeEncryptedContentAddressedChunk", () => {
   })
 
   describe("error handling", () => {
-    it("should throw error on empty payload", () => {
-      const emptyPayload = new Uint8Array(0)
-
-      expect(() => makeEncryptedContentAddressedChunk(emptyPayload)).toThrow(
-        /payload size .* exceeds limits/,
-      )
-    })
-
-    it("should throw error on empty string", () => {
-      expect(() => makeEncryptedContentAddressedChunk("")).toThrow(
-        /payload size .* exceeds limits/,
-      )
-    })
-
     it("should throw error on payload larger than 4096 bytes", () => {
       const largePayload = new Uint8Array(4097)
 
@@ -146,6 +132,17 @@ describe("makeEncryptedContentAddressedChunk", () => {
   })
 
   describe("payload size variations", () => {
+    it("should handle a zero-length payload (empty content)", () => {
+      const chunk = makeEncryptedContentAddressedChunk(new Uint8Array(0))
+
+      expect(chunk.span.toBigInt()).toBe(BigInt(0))
+      expect(chunk.data.length).toBe(4104) // span + fully random-padded data
+
+      // Span must decrypt back to 0 so downloads slice the payload to empty
+      const decrypted = decryptEncryptedChunk(chunk.data, chunk.encryptionKey)
+      expect(decrypted.slice(0, 8)).toEqual(new Uint8Array(8))
+    })
+
     it("should handle minimum payload size (1 byte)", () => {
       const payload = new Uint8Array([42])
       const chunk = makeEncryptedContentAddressedChunk(payload)

--- a/lib/src/proxy/chunking.ts
+++ b/lib/src/proxy/chunking.ts
@@ -13,6 +13,11 @@ export const REFS_PER_CHUNK = 64 // 4096 / 64 = 64 refs per intermediate chunk
  * Split data into 4096-byte chunks
  */
 export function splitDataIntoChunks(data: Uint8Array): Uint8Array[] {
+  // Zero-length content is a single empty chunk (span 0) — Bee's canonical
+  // representation of an empty file.
+  if (data.length === 0) {
+    return [new Uint8Array(0)]
+  }
   const chunks: Uint8Array[] = []
   for (let i = 0; i < data.length; i += CHUNK_SIZE) {
     chunks.push(data.slice(i, Math.min(i + CHUNK_SIZE, data.length)))

--- a/lib/src/proxy/upload.test.ts
+++ b/lib/src/proxy/upload.test.ts
@@ -1,0 +1,118 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Upload edge cases: zero-length content and explicit encryption keys.
+ *
+ * Zero-length content is valid on Swarm — Bee represents it as a single
+ * chunk with span 0 and an empty payload, whose address is the canonical
+ * empty-file reference (see bee `pkg/file/pipeline/builder` TestEmpty).
+ *
+ * An explicit encryption key can only apply to data that fits one chunk:
+ * every chunk of a multi-chunk upload needs its own key, so passing one
+ * key with larger data must fail loudly instead of being silently replaced
+ * by fresh random keys (which would break deterministic addressing/dedup).
+ */
+
+import { describe, it, expect } from "vitest"
+import type { Bee, Stamper } from "@ethersphere/bee-js"
+import { uploadData, type UploadTarget } from "./upload"
+import { downloadDataWithChunkAPI } from "./download-data"
+import { CHUNK_SIZE } from "./chunking"
+import {
+  MockBee,
+  MockChunkStore,
+  createMockStamper,
+} from "./feeds/epochs/test-utils"
+
+const ENCRYPTED_REF_HEX_LEN = 128 // 32-byte address + 32-byte key
+
+// BMT address of the span-0, empty-payload chunk — Bee's reference for
+// zero-length content (pkg/file/pipeline/builder/builder_test.go TestEmpty).
+const EMPTY_DATA_REFERENCE =
+  "b34ca8c22b9e982354f9c7f50b470d66db428d880c8a904d5fe4ec9713171526"
+
+/** Build `length` bytes with position-dependent variation so chunks differ. */
+function makeData(length: number): Uint8Array {
+  const data = new Uint8Array(length)
+  for (let i = 0; i < length; i++) {
+    data[i] = (i * 31 + 7) & 0xff
+  }
+  return data
+}
+
+function setup(): { bee: Bee; target: UploadTarget } {
+  const store = new MockChunkStore()
+  const bee = new MockBee(store) as unknown as Bee
+  const target: UploadTarget = {
+    mode: "stamper",
+    bee,
+    stamper: createMockStamper() as unknown as Stamper,
+  }
+  return { bee, target }
+}
+
+describe("uploadData with zero-length data", () => {
+  it("uploads plain empty data as the canonical empty chunk", async () => {
+    const { bee, target } = setup()
+
+    const { reference } = await uploadData(target, new Uint8Array(0))
+    expect(reference).toBe(EMPTY_DATA_REFERENCE)
+
+    const downloaded = await downloadDataWithChunkAPI(bee, reference)
+    expect(downloaded).toEqual(new Uint8Array(0))
+  })
+
+  it("round-trips encrypted empty data", async () => {
+    const { bee, target } = setup()
+
+    const { reference } = await uploadData(target, new Uint8Array(0), {
+      encryptionKey: true,
+    })
+    expect(reference.length).toBe(ENCRYPTED_REF_HEX_LEN)
+
+    const downloaded = await downloadDataWithChunkAPI(bee, reference)
+    expect(downloaded).toEqual(new Uint8Array(0))
+  })
+})
+
+describe("uploadData with an explicit encryption key", () => {
+  const key = new Uint8Array(32).fill(7)
+
+  it("rejects data spanning multiple chunks instead of silently ignoring the key", async () => {
+    const { target } = setup()
+
+    await expect(
+      uploadData(target, makeData(CHUNK_SIZE + 1), { encryptionKey: key }),
+    ).rejects.toThrow(/single-chunk/)
+  })
+
+  it("produces a deterministic reference for a full single chunk", async () => {
+    // Exactly CHUNK_SIZE bytes: no random padding, so the same key must give
+    // the same ciphertext and therefore the same address.
+    const data = makeData(CHUNK_SIZE)
+
+    const first = await uploadData(setup().target, data, {
+      encryptionKey: key,
+    })
+    const second = await uploadData(setup().target, data, {
+      encryptionKey: key,
+    })
+    expect(first.reference).toBe(second.reference)
+  })
+
+  it("embeds the provided key in the reference and round-trips a partial chunk", async () => {
+    // Sub-chunk payloads are random-padded (like Bee), so the address varies
+    // — but the key half of the reference must be the caller's key.
+    const { bee, target } = setup()
+    const data = makeData(100)
+
+    const { reference } = await uploadData(target, data, {
+      encryptionKey: key,
+    })
+    expect(reference.slice(64)).toBe("07".repeat(32))
+
+    const downloaded = await downloadDataWithChunkAPI(bee, reference)
+    expect(downloaded).toEqual(data)
+  })
+})

--- a/lib/src/proxy/upload.ts
+++ b/lib/src/proxy/upload.ts
@@ -32,7 +32,7 @@ import {
   type EncryptedChunk,
   DEFAULT_UPLOAD_CONCURRENCY,
 } from "../chunk"
-import { splitDataIntoChunks, REFS_PER_CHUNK } from "./chunking"
+import { splitDataIntoChunks, CHUNK_SIZE, REFS_PER_CHUNK } from "./chunking"
 import { ENCRYPTED_REFS_PER_CHUNK } from "./chunking-encrypted"
 import { ChunkUploadStream } from "./chunk-upload-stream"
 import { marshalEnvelope } from "./stamp-marshal"
@@ -103,7 +103,11 @@ export function isSubsidisedTarget(
  * Unified options for data upload
  */
 export interface UploadDataOptions {
-  /** Encryption key: undefined = plain, Uint8Array = use this key, true = auto-generate */
+  /**
+   * Encryption key: undefined = plain, Uint8Array = use this key, true =
+   * auto-generate. An explicit key only applies to single-chunk data
+   * (≤ 4096 bytes); larger data throws — pass true instead.
+   */
   encryptionKey?: Uint8Array | true
   /** Pin the uploaded data */
   pin?: boolean
@@ -258,11 +262,22 @@ interface EncryptedChunkRef {
 
 /**
  * Encrypt all payloads into EncryptedChunks and collect their references.
+ *
+ * An explicit key is only valid for a single payload: every chunk of a
+ * multi-chunk upload carries its own key, so honouring one shared key is
+ * impossible and substituting random keys would silently break the caller's
+ * expectation of a key-addressed reference.
  */
 function encryptChunkPayloads(
   payloads: Uint8Array[],
   encryptionKey?: Uint8Array,
 ): { chunks: EncryptedChunk[]; refs: EncryptedChunkRef[] } {
+  if (encryptionKey && payloads.length > 1) {
+    throw new Error(
+      `Explicit encryption key is only supported for single-chunk data (up to ${CHUNK_SIZE} bytes), got ${payloads.length} chunks — pass encryptionKey: true to auto-generate per-chunk keys`,
+    )
+  }
+
   const chunks: EncryptedChunk[] = []
   const refs: EncryptedChunkRef[] = []
 
@@ -697,10 +712,7 @@ async function uploadDataEncrypted(
   // Split and encrypt
   const payloads = splitDataIntoChunks(data)
   const { chunks: encryptedChunks, refs: encryptedChunkRefs } =
-    encryptChunkPayloads(
-      payloads,
-      payloads.length === 1 ? encryptionKey : undefined,
-    )
+    encryptChunkPayloads(payloads, encryptionKey)
 
   // Prepare chunk data for upload
   const chunksToUpload = encryptedChunks.map((chunk) => ({


### PR DESCRIPTION
## Summary

Two upload edge-case fixes in `lib/src/proxy` (TDD: failing tests written first).

**Zero-byte uploads crashed.** `splitDataIntoChunks(new Uint8Array(0))` returned `[]`, so both `uploadDataPlain` and `uploadDataEncrypted` skipped the single-chunk branch and crashed dereferencing the first ref in the Merkle-tree builders. Swarm represents zero-length content as a single chunk with span 0: Bee's `cac.validateDataLength` accepts 0..4096-byte payloads, its upload pipeline writes an empty root chunk for empty input (`pkg/file/pipeline/feeder` `Sum()`), and `builder_test.go` `TestEmpty` pins the canonical reference `b34ca8c22b9e982354f9c7f50b470d66db428d880c8a904d5fe4ec9713171526` — which our BMT reproduces exactly (asserted in the new tests). `splitDataIntoChunks` now returns one empty payload and `MIN_PAYLOAD_SIZE` drops to 0 to match Bee; the empty-payload CAC tests flip from "throws" to asserting the canonical empty chunk.

**Explicit encryption key was silently ignored for multi-chunk data.** `encryptChunkPayloads(payloads, payloads.length === 1 ? encryptionKey : undefined)` gave every chunk a fresh random key when data exceeded 4096 bytes, silently breaking the caller's expectation of a key-addressed reference. Honouring one shared key is impossible (every chunk of a multi-chunk upload carries its own key in its parent ref), so it now throws with an actionable message. Note: for sub-4096 payloads the *address* half of the reference still varies by design (random chunk padding, matching Bee — #468); the new tests assert full-chunk determinism and key embedding separately.

## Tests

- `upload.test.ts` (new): plain 0-byte upload returns the canonical empty reference and round-trips; encrypted 0-byte upload round-trips; multi-chunk + explicit key rejects; full-single-chunk explicit key gives a deterministic reference; partial-chunk explicit key is embedded in the reference and round-trips.
- `cac.test.ts` / `encrypted-cac.test.ts`: empty-payload cases now assert Bee-aligned behavior (span-0 chunk, canonical address / decryptable empty content).
- `pnpm check:all` passes (969/969 lib tests; ui/demo checks green).

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)