### PR TITLE
refactor(ui): extract shared DropdownMenu and UnlockDialog components

### DIFF
--- a/ui/src/lib/components/account-switcher.svelte
+++ b/ui/src/lib/components/account-switcher.svelte
@@ -14,6 +14,7 @@
   import SignOutDialog from '$lib/components/sign-out-dialog.svelte'
   import { Badge } from '$lib/components/ui/badge'
   import { Button } from '$lib/components/ui/button'
+  import { DropdownMenu, DropdownMenuItem } from '$lib/components/ui/dropdown-menu'
   import routes from '$lib/routes'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
@@ -29,7 +30,6 @@
   let { account, onmanage }: Props = $props()
 
   let open = $state(false)
-  let container = $state<HTMLDivElement>()
   /** Replaces the panel actions with the create/import choice. */
   let addingAccount = $state(false)
   let signingOut = $state(false)
@@ -38,142 +38,111 @@
     accountsStore.accounts.filter((candidate) => !candidate.id.equals(account.id)),
   )
 
-  function close() {
-    open = false
-    addingAccount = false
-  }
-
-  function onWindowPointerDown(event: PointerEvent) {
-    if (open && container && !container.contains(event.target as Node)) {
-      close()
+  // However the menu closes (item click, outside pointerdown, Escape), the
+  // next open starts back on the main actions.
+  $effect(() => {
+    if (!open) {
+      addingAccount = false
     }
-  }
-
-  function onWindowKeydown(event: KeyboardEvent) {
-    if (event.key === 'Escape') {
-      close()
-    }
-  }
+  })
 
   function select(candidate: Account) {
     if (candidate.isSignedOut) {
       // No keys on this device — signing back in means importing the phrase.
-      close()
       void goto(resolve(routes.ACCOUNT_IMPORT))
       return
     }
     sessionStore.setCurrentAccount(candidate.id)
-    close()
   }
 
   function startSignOut() {
-    close()
+    open = false
     signingOut = true
   }
 
   function manage() {
-    close()
+    open = false
     onmanage?.()
   }
 </script>
 
-<svelte:window onpointerdown={onWindowPointerDown} onkeydown={onWindowKeydown} />
-
-<div bind:this={container} class="relative">
-  <Button
-    variant="ghost"
-    class="h-10 gap-2 px-2"
-    aria-label="Switch account"
-    aria-haspopup="menu"
-    aria-expanded={open}
-    onclick={() => (open ? close() : (open = true))}
-  >
-    <span class="flex flex-col items-end">
-      <span class="text-sm font-medium">{account.name}</span>
-      <span class="text-muted-foreground text-xs font-normal">
-        {truncateAddress(account.id.toChecksum())}
+<DropdownMenu bind:open class="top-0 right-0 flex w-80 flex-col gap-4 p-2.5">
+  {#snippet trigger(props)}
+    <Button variant="ghost" class="h-10 gap-2 px-2" aria-label="Switch account" {...props}>
+      <span class="flex flex-col items-end">
+        <span class="text-sm font-medium">{account.name}</span>
+        <span class="text-muted-foreground text-xs font-normal">
+          {truncateAddress(account.id.toChecksum())}
+        </span>
       </span>
-    </span>
-    <Polycon value={account.id.toHex()} size={32} class="shrink-0 overflow-hidden rounded-lg" />
-  </Button>
+      <Polycon value={account.id.toHex()} size={32} class="shrink-0 overflow-hidden rounded-lg" />
+    </Button>
+  {/snippet}
 
-  {#if open}
-    <div
-      role="menu"
-      tabindex="-1"
-      class="bg-popover text-popover-foreground absolute top-0 right-0 z-50 flex w-80 flex-col gap-4 rounded-lg border p-2.5 shadow-md"
-    >
-      <div class="flex flex-col gap-2">
-        <div class="flex flex-col items-center gap-2 pt-0.5">
-          <Polycon value={account.id.toHex()} size={48} class="overflow-hidden rounded-lg" />
-          <div class="flex flex-col items-center">
-            <p class="text-sm font-medium">{account.name}</p>
-            <p class="text-muted-foreground text-xs">{truncateAddress(account.id.toChecksum())}</p>
-          </div>
-        </div>
-
-        <Button variant="outline" class="w-full" onclick={manage}>Manage account</Button>
-        <!-- A local account has nothing on Swarm to come back to — signing it out
-             would destroy it, so it only gets Delete (on the Account tab), no Sign out. -->
-        {#if !account.isLocal}
-          <Button variant="outline" class="w-full" onclick={startSignOut}>Sign out</Button>
-        {/if}
+  <div class="flex flex-col gap-2">
+    <div class="flex flex-col items-center gap-2 pt-0.5">
+      <Polycon value={account.id.toHex()} size={48} class="overflow-hidden rounded-lg" />
+      <div class="flex flex-col items-center">
+        <p class="text-sm font-medium">{account.name}</p>
+        <p class="text-muted-foreground text-xs">{truncateAddress(account.id.toChecksum())}</p>
       </div>
+    </div>
 
-      {#if addingAccount}
-        <div class="flex flex-col gap-2">
-          <Button variant="ghost" size="sm" class="w-full" href={resolve(routes.ACCOUNT_NEW)}>
-            Create a new account
-          </Button>
-          <Button variant="ghost" size="sm" class="w-full" href={resolve(routes.ACCOUNT_IMPORT)}>
-            I already have an account
-          </Button>
-        </div>
-      {:else}
-        {#if others.length > 0}
-          <div class="flex flex-col">
-            {#each others as candidate (candidate.id.toHex())}
-              <button
-                type="button"
-                role="menuitem"
-                class="hover:bg-muted focus-visible:bg-muted flex w-full cursor-pointer items-center gap-2 rounded-md p-1 text-left outline-none"
-                onclick={() => select(candidate)}
-              >
-                <Polycon
-                  value={candidate.id.toHex()}
-                  size={36}
-                  class="shrink-0 overflow-hidden rounded-md"
-                />
-                <span class="flex min-w-0 flex-1 flex-col">
-                  <span class="truncate text-sm font-medium">{candidate.name}</span>
-                  <span class="text-muted-foreground text-xs">
-                    {truncateAddress(candidate.id.toChecksum())}
-                  </span>
-                </span>
-                {#if candidate.isSignedOut}
-                  <Badge>Signed out</Badge>
-                {/if}
-              </button>
-            {/each}
-          </div>
-        {/if}
+    <Button variant="outline" class="w-full" onclick={manage}>Manage account</Button>
+    <!-- A local account has nothing on Swarm to come back to — signing it out
+         would destroy it, so it only gets Delete (on the Account tab), no Sign out. -->
+    {#if !account.isLocal}
+      <Button variant="outline" class="w-full" onclick={startSignOut}>Sign out</Button>
+    {/if}
+  </div>
 
-        <div class="flex flex-col gap-2">
-          {#if others.length > 0}
-            <Button variant="ghost" size="sm" class="w-full" onclick={notImplemented}>
-              <UserRoundMinus />
-              Remove an account
-            </Button>
-          {/if}
-          <Button variant="ghost" size="sm" class="w-full" onclick={() => (addingAccount = true)}>
-            <UserRoundPlus />
-            Sign in to another account
-          </Button>
-        </div>
+  {#if addingAccount}
+    <div class="flex flex-col gap-2">
+      <Button variant="ghost" size="sm" class="w-full" href={resolve(routes.ACCOUNT_NEW)}>
+        Create a new account
+      </Button>
+      <Button variant="ghost" size="sm" class="w-full" href={resolve(routes.ACCOUNT_IMPORT)}>
+        I already have an account
+      </Button>
+    </div>
+  {:else}
+    {#if others.length > 0}
+      <div class="flex flex-col">
+        {#each others as candidate (candidate.id.toHex())}
+          <DropdownMenuItem class="h-auto gap-2 p-1" onclick={() => select(candidate)}>
+            <Polycon
+              value={candidate.id.toHex()}
+              size={36}
+              class="shrink-0 overflow-hidden rounded-md"
+            />
+            <span class="flex min-w-0 flex-1 flex-col">
+              <span class="truncate text-sm font-medium">{candidate.name}</span>
+              <span class="text-muted-foreground text-xs">
+                {truncateAddress(candidate.id.toChecksum())}
+              </span>
+            </span>
+            {#if candidate.isSignedOut}
+              <Badge>Signed out</Badge>
+            {/if}
+          </DropdownMenuItem>
+        {/each}
+      </div>
+    {/if}
+
+    <div class="flex flex-col gap-2">
+      {#if others.length > 0}
+        <Button variant="ghost" size="sm" class="w-full" onclick={notImplemented}>
+          <UserRoundMinus />
+          Remove an account
+        </Button>
       {/if}
+      <Button variant="ghost" size="sm" class="w-full" onclick={() => (addingAccount = true)}>
+        <UserRoundPlus />
+        Sign in to another account
+      </Button>
     </div>
   {/if}
-</div>
+</DropdownMenu>
 
 {#if signingOut}
   <SignOutDialog {account} onClose={() => (signingOut = false)} />

--- a/ui/src/lib/components/delete-account-dialog.svelte
+++ b/ui/src/lib/components/delete-account-dialog.svelte
@@ -8,17 +8,12 @@
   row and can be reversed with the recovery phrase), delete hard-removes the
   record via `accountsStore.remove`. Because it is destructive and irreversible
   for a local account, it is gated on the account's own access method: the user
-  must re-confirm with their passkey, wallet, or password (`unlockAccount`)
-  before the record is dropped. The decrypted seed is proof-of-control only and
-  is zeroed immediately.
+  must re-confirm with their passkey, wallet, or password before the record is
+  dropped. The decrypted seed is proof-of-control only and is zeroed
+  immediately.
 -->
 <script lang="ts">
-  import LoaderCircle from '@lucide/svelte/icons/loader-circle'
-
-  import { Button } from '$lib/components/ui/button'
-  import { Dialog } from '$lib/components/ui/dialog'
-  import { Input } from '$lib/components/ui/input'
-  import { unlockAccount } from '$lib/crypto/unlock'
+  import UnlockDialog from '$lib/components/unlock-dialog.svelte'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
   import { toastStore } from '$lib/stores/toast.svelte'
@@ -35,15 +30,6 @@
   // access method is always present (`accessMethod` asserts it).
   const access = $derived(account.accessMethod)
 
-  let password = $state('')
-  let busy = $state(false)
-  // Passkey/wallet prompt in flight — swaps to the centered pending body.
-  let pending = $state(false)
-  let error = $state<string | undefined>(undefined)
-  // Bumped on cancel/close so a passkey/wallet prompt that resolves after the
-  // user dismissed the dialog does not go on to delete the account.
-  let attempt = 0
-
   const confirmLabel = $derived(
     access.type === 'passkey'
       ? 'Confirm delete with passkey'
@@ -52,95 +38,29 @@
         : 'Confirm delete with password',
   )
 
-  function cancel() {
-    attempt++
+  function deleteAccount(seed: Uint8Array) {
+    // Deletion needs proof-of-control, not the seed itself.
+    seed.fill(0)
+    const target = account
+    accountsStore.remove(target.id)
+    if (sessionStore.currentAccountId === target.id.toHex()) {
+      sessionStore.clearCurrentAccount()
+    }
+    toastStore.show('Account deleted')
     onClose()
-  }
-
-  async function confirm() {
-    if (busy) {
-      return
-    }
-    const myAttempt = ++attempt
-    error = undefined
-    busy = true
-    if (access.type !== 'password') {
-      pending = true
-    }
-    try {
-      const seed = await unlockAccount(account, access.type === 'password' ? password : undefined)
-      // Deletion needs proof-of-control, not the seed itself. Zero it, and bail
-      // if the dialog was dismissed while the prompt was open (an approval of a
-      // cancelled prompt must not delete the account).
-      seed.fill(0)
-      if (myAttempt !== attempt) {
-        return
-      }
-      const target = account
-      accountsStore.remove(target.id)
-      if (sessionStore.currentAccountId === target.id.toHex()) {
-        sessionStore.clearCurrentAccount()
-      }
-      toastStore.show('Account deleted')
-      onClose()
-    } catch (caught) {
-      if (myAttempt === attempt) {
-        error = caught instanceof Error ? caught.message : 'Could not delete the account.'
-        busy = false
-        pending = false
-      }
-    }
   }
 </script>
 
-{#if pending}
-  <Dialog onclose={cancel} dismissable={false}>
-    <div class="flex flex-col items-center gap-2 py-2">
-      <LoaderCircle class="size-5 animate-spin" />
-      <div class="flex flex-col items-center text-center">
-        <p class="text-sm font-bold">
-          {access.type === 'eth-wallet' ? 'Confirm with wallet' : 'Confirm with passkey'}
-        </p>
-        <p class="text-sm">
-          {access.type === 'eth-wallet'
-            ? 'Approve the request in your Ethereum wallet.'
-            : 'Follow the prompts on your device.'}
-        </p>
-      </div>
-    </div>
-    <Button variant="outline" class="w-full" onclick={cancel}>Cancel</Button>
-  </Dialog>
-{:else}
-  <Dialog onclose={cancel} title="Delete account">
-    <p class="text-sm">
-      This permanently deletes <span class="font-medium">{account.name}</span> from this device. Your
-      account and its data may not be recoverable.
-    </p>
-
-    {#if access.type === 'password'}
-      <Input
-        type="password"
-        bind:value={password}
-        placeholder="Account password"
-        autocomplete="current-password"
-        onkeydown={(event: KeyboardEvent) => event.key === 'Enter' && confirm()}
-      />
-    {/if}
-
-    {#if error}
-      <p class="text-destructive text-xs">{error}</p>
-    {/if}
-
-    <Button
-      variant="destructive"
-      class="w-full"
-      disabled={busy || (access.type === 'password' && password.length === 0)}
-      onclick={confirm}
-    >
-      {#if busy}
-        <LoaderCircle class="animate-spin" />
-      {/if}
-      {confirmLabel}
-    </Button>
-  </Dialog>
-{/if}
+<UnlockDialog
+  {account}
+  title="Delete account"
+  {confirmLabel}
+  destructive
+  onunlocked={deleteAccount}
+  onclose={onClose}
+>
+  <p class="text-sm">
+    This permanently deletes <span class="font-medium">{account.name}</span> from this device. Your account
+    and its data may not be recoverable.
+  </p>
+</UnlockDialog>

--- a/ui/src/lib/components/home-account.svelte
+++ b/ui/src/lib/components/home-account.svelte
@@ -20,10 +20,11 @@
   import LoaderCircle from '@lucide/svelte/icons/loader-circle'
   import RefreshCw from '@lucide/svelte/icons/refresh-cw'
   import Wallet from '@lucide/svelte/icons/wallet'
-  import { type AccessMethod, uint8ArrayToHex } from '@snaha/swarm-id'
+  import type { AccessMethod } from '@snaha/swarm-id'
 
   import DeleteAccountDialog from '$lib/components/delete-account-dialog.svelte'
   import DriveAddDialog from '$lib/components/drive-add-dialog.svelte'
+  import NewPasswordFields, { isNewPasswordValid } from '$lib/components/new-password-fields.svelte'
   import PhraseGrid from '$lib/components/phrase-grid.svelte'
   import Polycon from '$lib/components/polycon.svelte'
   import SignOutDialog from '$lib/components/sign-out-dialog.svelte'
@@ -31,23 +32,16 @@
   import { Dialog } from '$lib/components/ui/dialog'
   import { Input } from '$lib/components/ui/input'
   import { Tabs } from '$lib/components/ui/tabs'
+  import UnlockDialog from '$lib/components/unlock-dialog.svelte'
+  import { createAccess } from '$lib/crypto/access-setup'
   import { backupFilename, createBackup } from '$lib/crypto/backup'
-  import {
-    PASSWORD_KDF_ITERATIONS,
-    deriveKeyFromPassword,
-    encryptSeed,
-    randomSalt,
-  } from '$lib/crypto/encryption'
-  import { deriveWalletKey, requestWalletKeySource } from '$lib/crypto/eth-wallet'
+  import { encryptSeed } from '$lib/crypto/encryption'
   import { prefix0x } from '$lib/crypto/hex'
   import { phraseFromEntropy, privateKeyFromEntropy } from '$lib/crypto/mnemonic'
-  import { createPasskeyKey } from '$lib/crypto/passkey'
-  import { unlockAccount } from '$lib/crypto/unlock'
   import { toastStore } from '$lib/stores/toast.svelte'
   import type { Account } from '$lib/types'
   import { copyToClipboard, truncateAddress } from '$lib/utils'
 
-  const MIN_PASSWORD_LENGTH = 8
   const MASKED_KEY = '•'.repeat(66)
   const METHOD_TABS = [
     { value: 'passkey', label: 'Passkey' },
@@ -64,9 +58,6 @@
   type SectionId = 'identity' | 'access' | 'keys' | 'phrase' | 'backup'
   /** What the unlock confirmation is for; completes once the seed decrypts. */
   type UnlockTarget = 'private-key' | 'phrase' | 'export' | 'change-method'
-  type DialogState =
-    | { kind: 'unlock'; target: UnlockTarget; pending: boolean }
-    | { kind: 'set-method'; pending: boolean }
 
   let name = $derived(account.name)
   let expanded = $state<Record<SectionId, boolean>>({
@@ -88,14 +79,14 @@
   // Seed held only across the change-method two-step ceremony; zeroed after.
   let changeMethodSeed: Uint8Array | undefined
 
-  let dialog = $state<DialogState | undefined>(undefined)
+  let unlockTarget = $state<UnlockTarget | undefined>(undefined)
+  let setMethodDialog = $state<'form' | 'pending' | undefined>(undefined)
   let dialogError = $state<string | undefined>(undefined)
   let busy = $state(false)
   /** Bumped on cancel/retry — a stale ceremony resolution must not complete. */
   let attempt = 0
   let abortController: AbortController | undefined
 
-  let password = $state('')
   let newMethod = $state('passkey')
   let newPassword = $state('')
   let verifyNewPassword = $state('')
@@ -109,14 +100,23 @@
     access.type === 'passkey' ? Fingerprint : access.type === 'eth-wallet' ? Wallet : KeyRound,
   )
   const publicKeyDisplay = $derived(prefix0x(account.publicKey))
-  const newPasswordTooShort = $derived(
-    newPassword.length > 0 && newPassword.length < MIN_PASSWORD_LENGTH,
+  const newPasswordValid = $derived(isNewPasswordValid(newPassword, verifyNewPassword))
+
+  const unlockTitle = $derived(
+    unlockTarget === 'private-key'
+      ? 'Reveal private key'
+      : unlockTarget === 'phrase'
+        ? 'Reveal secret recovery phrase'
+        : unlockTarget === 'export'
+          ? 'Export backup'
+          : 'Change unlock method',
   )
-  const newPasswordMismatch = $derived(
-    verifyNewPassword.length > 0 && newPassword !== verifyNewPassword,
-  )
-  const newPasswordValid = $derived(
-    newPassword.length >= MIN_PASSWORD_LENGTH && newPassword === verifyNewPassword,
+  const unlockDescription = $derived(
+    unlockTarget === 'change-method'
+      ? `This changes how you unlock your account on this device only. To continue, confirm with your current ${accessLabel.toLowerCase()}.`
+      : unlockTarget === 'export'
+        ? 'Unlock your account to export an encrypted backup file.'
+        : 'Make sure no one is watching your screen.',
   )
 
   function methodLabel(type: AccessMethod['type']): string {
@@ -142,65 +142,16 @@
     }
   }
 
-  function openUnlock(target: UnlockTarget) {
-    dialogError = undefined
-    password = ''
-    dialog = { kind: 'unlock', target, pending: false }
-  }
-
-  function closeDialog() {
-    // Invalidate any in-flight ceremony — wallet prompts can't be aborted, so
-    // a later approval of a cancelled prompt must not complete.
-    attempt++
-    abortController?.abort()
-    changeMethodSeed?.fill(0)
-    changeMethodSeed = undefined
-    dialog = undefined
-    dialogError = undefined
-    busy = false
-    password = ''
-    newPassword = ''
-    verifyNewPassword = ''
-  }
-
-  async function confirmUnlock() {
-    if (busy || dialog?.kind !== 'unlock') {
+  // Called by the unlock dialog with the decrypted seed; a throw from
+  // `complete` surfaces as a dialog error, so only success closes it.
+  function onUnlocked(seed: Uint8Array) {
+    const target = unlockTarget
+    if (!target) {
+      seed.fill(0)
       return
     }
-    const target = dialog.target
-    const myAttempt = ++attempt
-    dialogError = undefined
-    busy = true
-    if (access.type !== 'password') {
-      dialog = { kind: 'unlock', target, pending: true }
-    }
-    try {
-      const unlocked = await unlockAccount(
-        account,
-        access.type === 'password' ? password : undefined,
-      )
-      // Bail if this ceremony was superseded (cancel/retry) or the account was
-      // signed out mid-flight (e.g. cross-tab): the sign-out unmounts this
-      // component but not this continuation, and completing would still
-      // download a backup (export) or stage the seed for a change-method
-      // `setAccess` — acting on a vault the sign-out just wiped.
-      if (myAttempt !== attempt || account.isSignedOut) {
-        unlocked.fill(0)
-        return
-      }
-      password = ''
-      dialog = undefined
-      complete(target, unlocked)
-    } catch (caught) {
-      if (myAttempt === attempt) {
-        dialogError = caught instanceof Error ? caught.message : 'Unlock failed.'
-        dialog = { kind: 'unlock', target, pending: false }
-      }
-    } finally {
-      if (myAttempt === attempt) {
-        busy = false
-      }
-    }
+    complete(target, seed)
+    unlockTarget = undefined
   }
 
   // Consumes `seed`: zeroed here for transient targets, handed to the export /
@@ -219,45 +170,42 @@
       newMethod = 'passkey'
       newPassword = ''
       verifyNewPassword = ''
-      dialog = { kind: 'set-method', pending: false }
+      dialogError = undefined
+      setMethodDialog = 'form'
     }
   }
 
+  function closeSetMethod() {
+    // Invalidate any in-flight ceremony — wallet prompts can't be aborted, so
+    // a later approval of a cancelled prompt must not complete.
+    attempt++
+    abortController?.abort()
+    changeMethodSeed?.fill(0)
+    changeMethodSeed = undefined
+    setMethodDialog = undefined
+    dialogError = undefined
+    busy = false
+    newPassword = ''
+    verifyNewPassword = ''
+  }
+
   async function confirmNewMethod() {
-    if (busy || dialog?.kind !== 'set-method' || !changeMethodSeed) {
+    if (busy || setMethodDialog === undefined || !changeMethodSeed) {
       return
     }
     const myAttempt = ++attempt
     dialogError = undefined
     busy = true
     if (newMethod !== 'password') {
-      dialog = { kind: 'set-method', pending: true }
+      setMethodDialog = 'pending'
     }
     try {
-      let access: AccessMethod
-      let key: CryptoKey
-      if (newMethod === 'passkey') {
-        abortController = new AbortController()
-        const passkey = await createPasskeyKey(account.name, abortController.signal)
-        access = { type: 'passkey', credentialId: passkey.credentialId }
-        key = passkey.key
-      } else if (newMethod === 'eth-wallet') {
-        const source = await requestWalletKeySource()
-        const salt = randomSalt()
-        key = await deriveWalletKey(source, salt)
-        access = {
-          type: 'eth-wallet',
-          encryptionSalt: uint8ArrayToHex(salt),
-        }
-      } else {
-        const salt = randomSalt()
-        key = await deriveKeyFromPassword(newPassword, salt)
-        access = {
-          type: 'password',
-          kdfSalt: uint8ArrayToHex(salt),
-          kdfIterations: PASSWORD_KDF_ITERATIONS,
-        }
-      }
+      abortController = newMethod === 'passkey' ? new AbortController() : undefined
+      const { access: newAccess, key } = await createAccess(newMethod, {
+        accountName: account.name,
+        password: newPassword,
+        signal: abortController?.signal,
+      })
       if (myAttempt !== attempt) {
         return
       }
@@ -270,17 +218,17 @@
         changeMethodSeed = undefined
         return
       }
-      account.setAccess(access, await encryptSeed(changeMethodSeed, key))
+      account.setAccess(newAccess, await encryptSeed(changeMethodSeed, key))
       changeMethodSeed.fill(0)
       changeMethodSeed = undefined
-      dialog = undefined
+      setMethodDialog = undefined
       newPassword = ''
       verifyNewPassword = ''
       toastStore.show('Unlock method updated')
     } catch (caught) {
       if (myAttempt === attempt) {
         dialogError = caught instanceof Error ? caught.message : 'Could not set the new method.'
-        dialog = { kind: 'set-method', pending: false }
+        setMethodDialog = 'form'
       }
     } finally {
       if (myAttempt === attempt) {
@@ -342,17 +290,6 @@
   </div>
 {/snippet}
 
-{#snippet pendingBody(label: string, caption: string)}
-  <div class="flex flex-col items-center gap-2 py-2">
-    <LoaderCircle class="size-5 animate-spin" />
-    <div class="flex flex-col items-center text-center">
-      <p class="text-sm font-bold">{label}</p>
-      <p class="text-sm">{caption}</p>
-    </div>
-  </div>
-  <Button variant="outline" class="w-full" onclick={closeDialog}>Cancel</Button>
-{/snippet}
-
 <div class="flex w-full flex-col gap-6">
   {#if isLocal}
     <!-- Local account banner: no stamps yet, so the account is view-only. -->
@@ -401,7 +338,7 @@
             variant="ghost"
             size="sm"
             class="-mr-2"
-            onclick={() => openUnlock('change-method')}
+            onclick={() => (unlockTarget = 'change-method')}
           >
             <RefreshCw />
             Change
@@ -504,7 +441,7 @@
                       size="icon"
                       class="size-7 shrink-0"
                       aria-label="Reveal private key"
-                      onclick={() => openUnlock('private-key')}
+                      onclick={() => (unlockTarget = 'private-key')}
                     >
                       <Eye />
                     </Button>
@@ -560,7 +497,7 @@
           <div
             class="border-border flex h-38 w-full flex-col items-center justify-center gap-2 rounded-lg border"
           >
-            <Button variant="ghost" onclick={() => openUnlock('phrase')}>
+            <Button variant="ghost" onclick={() => (unlockTarget = 'phrase')}>
               <Eye />
               Reveal
             </Button>
@@ -576,7 +513,7 @@
     {@render sectionHeader('backup', 'Backup', 'Exports an encrypted backup of your account.')}
     {#if expanded.backup}
       <div class="pl-5">
-        <Button variant="outline" onclick={() => openUnlock('export')}>
+        <Button variant="outline" onclick={() => (unlockTarget = 'export')}>
           <FileDown />
           Export .swarmid file
         </Button>
@@ -597,146 +534,64 @@
   </div>
 </div>
 
-{#if dialog?.kind === 'unlock'}
-  {#if dialog.pending}
-    <Dialog onclose={closeDialog} dismissable={false}>
-      {@render pendingBody(
-        access.type === 'eth-wallet' ? 'Confirm with wallet' : 'Confirm with passkey',
-        access.type === 'eth-wallet'
-          ? 'Approve the request in your Ethereum wallet.'
-          : 'Follow the prompts on your device.',
-      )}
-    </Dialog>
-  {:else}
-    <Dialog
-      onclose={closeDialog}
-      title={dialog.target === 'private-key'
-        ? 'Reveal private key'
-        : dialog.target === 'phrase'
-          ? 'Reveal secret recovery phrase'
-          : dialog.target === 'export'
-            ? 'Export backup'
-            : 'Change unlock method'}
-    >
-      <p class="text-sm">
-        {#if dialog.target === 'change-method'}
-          This changes how you unlock your account on this device only. To continue, confirm with
-          your current {accessLabel.toLowerCase()}.
-        {:else if dialog.target === 'export'}
-          Unlock your account to export an encrypted backup file.
-        {:else}
-          Make sure no one is watching your screen.
-        {/if}
-      </p>
-
-      {#if access.type === 'password'}
-        <Input
-          type="password"
-          bind:value={password}
-          placeholder="Account password"
-          autocomplete="current-password"
-          data-autofocus
-          onkeydown={(event: KeyboardEvent) => event.key === 'Enter' && confirmUnlock()}
-        />
-      {/if}
-
-      {#if dialogError}
-        <p class="text-destructive text-xs">{dialogError}</p>
-      {/if}
-
-      <Button
-        class="w-full"
-        disabled={busy || (access.type === 'password' && password.length === 0)}
-        onclick={confirmUnlock}
-      >
-        {#if busy}
-          <LoaderCircle class="animate-spin" />
-        {/if}
-        {access.type === 'passkey'
-          ? 'Confirm with passkey'
-          : access.type === 'eth-wallet'
-            ? 'Confirm with wallet'
-            : 'Confirm'}
-      </Button>
-    </Dialog>
-  {/if}
-{:else if dialog?.kind === 'set-method'}
-  {#if dialog.pending}
-    <Dialog onclose={closeDialog} dismissable={false}>
-      {@render pendingBody(
-        newMethod === 'eth-wallet' ? 'Confirm with new wallet' : 'Confirm with new passkey',
-        newMethod === 'eth-wallet'
-          ? 'Approve the request in your Ethereum wallet.'
-          : 'Follow the prompts on your device.',
-      )}
-    </Dialog>
-  {:else}
-    <Dialog onclose={closeDialog} title="Set new unlock method">
-      <Tabs tabs={METHOD_TABS} bind:value={newMethod} />
-
-      {#if newMethod === 'passkey'}
-        <p class="text-sm">
-          Unlock with your device&rsquo;s built-in authentication &mdash; fingerprint, face, or PIN.
+{#if unlockTarget}
+  <UnlockDialog
+    {account}
+    title={unlockTitle}
+    description={unlockDescription}
+    onunlocked={onUnlocked}
+    onclose={() => (unlockTarget = undefined)}
+  />
+{:else if setMethodDialog === 'pending'}
+  <Dialog onclose={closeSetMethod} dismissable={false}>
+    <div class="flex flex-col items-center gap-2 py-2">
+      <LoaderCircle class="size-5 animate-spin" />
+      <div class="flex flex-col items-center text-center">
+        <p class="text-sm font-bold">
+          {newMethod === 'eth-wallet' ? 'Confirm with new wallet' : 'Confirm with new passkey'}
         </p>
-      {:else if newMethod === 'eth-wallet'}
-        <p class="text-sm">Unlock by signing a message with your Ethereum wallet.</p>
-      {:else}
-        <div class="flex w-full flex-col gap-4">
-          <div class="flex w-full flex-col gap-2">
-            <label for="change-new-password" class="text-sm font-medium">
-              Create new password
-            </label>
-            <Input
-              id="change-new-password"
-              type="password"
-              bind:value={newPassword}
-              autocomplete="new-password"
-              aria-invalid={newPasswordTooShort}
-            />
-            <p
-              class={newPasswordTooShort
-                ? 'text-destructive text-xs'
-                : 'text-muted-foreground text-xs'}
-            >
-              Must be at least {MIN_PASSWORD_LENGTH} characters
-            </p>
-          </div>
-          <div class="flex w-full flex-col gap-2">
-            <label for="change-verify-password" class="text-sm font-medium">Verify password</label>
-            <Input
-              id="change-verify-password"
-              type="password"
-              bind:value={verifyNewPassword}
-              autocomplete="new-password"
-              aria-invalid={newPasswordMismatch}
-            />
-            {#if newPasswordMismatch}
-              <p class="text-destructive text-xs">Passwords do not match</p>
-            {/if}
-          </div>
-        </div>
-      {/if}
+        <p class="text-sm">
+          {newMethod === 'eth-wallet'
+            ? 'Approve the request in your Ethereum wallet.'
+            : 'Follow the prompts on your device.'}
+        </p>
+      </div>
+    </div>
+    <Button variant="outline" class="w-full" onclick={closeSetMethod}>Cancel</Button>
+  </Dialog>
+{:else if setMethodDialog === 'form'}
+  <Dialog onclose={closeSetMethod} title="Set new unlock method">
+    <Tabs tabs={METHOD_TABS} bind:value={newMethod} />
 
-      {#if dialogError}
-        <p class="text-destructive text-xs">{dialogError}</p>
-      {/if}
+    {#if newMethod === 'passkey'}
+      <p class="text-sm">
+        Unlock with your device&rsquo;s built-in authentication &mdash; fingerprint, face, or PIN.
+      </p>
+    {:else if newMethod === 'eth-wallet'}
+      <p class="text-sm">Unlock by signing a message with your Ethereum wallet.</p>
+    {:else}
+      <NewPasswordFields bind:password={newPassword} bind:verify={verifyNewPassword} />
+    {/if}
 
-      <Button
-        class="w-full"
-        disabled={busy || (newMethod === 'password' && !newPasswordValid)}
-        onclick={confirmNewMethod}
-      >
-        {#if busy}
-          <LoaderCircle class="animate-spin" />
-        {/if}
-        {newMethod === 'passkey'
-          ? 'Confirm with new passkey'
-          : newMethod === 'eth-wallet'
-            ? 'Confirm with new wallet'
-            : 'Confirm'}
-      </Button>
-    </Dialog>
-  {/if}
+    {#if dialogError}
+      <p class="text-destructive text-xs">{dialogError}</p>
+    {/if}
+
+    <Button
+      class="w-full"
+      disabled={busy || (newMethod === 'password' && !newPasswordValid)}
+      onclick={confirmNewMethod}
+    >
+      {#if busy}
+        <LoaderCircle class="animate-spin" />
+      {/if}
+      {newMethod === 'passkey'
+        ? 'Confirm with new passkey'
+        : newMethod === 'eth-wallet'
+          ? 'Confirm with new wallet'
+          : 'Confirm'}
+    </Button>
+  </Dialog>
 {/if}
 
 {#if addDriveOpen}

--- a/ui/src/lib/components/home-apps.svelte
+++ b/ui/src/lib/components/home-apps.svelte
@@ -10,6 +10,7 @@
 
   import AppIcon from '$lib/components/app-icon.svelte'
   import { Button } from '$lib/components/ui/button'
+  import { DropdownMenu, DropdownMenuItem } from '$lib/components/ui/dropdown-menu'
   import { Select } from '$lib/components/ui/select'
   import { msToDays } from '$lib/duration'
   import type { Account } from '$lib/types'
@@ -21,8 +22,6 @@
     { value: '30', label: '30 days' },
     { value: '90', label: '90 days' },
   ]
-  const MENU_ITEM_CLASS =
-    'flex h-7 w-full cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-1 text-left text-sm outline-none hover:bg-muted focus-visible:bg-muted'
 
   interface Props {
     account: Account
@@ -39,31 +38,20 @@
   )
   // Revoked tombstones stay in the record for sync; only show live entries.
   const activeApps = $derived(account.activeApps)
-  let openMenuFor = $state<string | undefined>(undefined)
 
   function isConnected(connectedUntil: number | undefined): boolean {
     return connectedUntil !== undefined && connectedUntil > Date.now()
   }
 
-  function onWindowPointerDown(event: PointerEvent) {
-    if (openMenuFor && !(event.target as HTMLElement).closest('[data-app-menu]')) {
-      openMenuFor = undefined
-    }
-  }
-
   function disconnect(appUrl: string) {
     // Drops the app secret the dApp's proxy iframe authenticates from.
     account.disconnectApp(appUrl)
-    openMenuFor = undefined
   }
 
   function remove(appUrl: string) {
     account.removeApp(appUrl)
-    openMenuFor = undefined
   }
 </script>
-
-<svelte:window onpointerdown={onWindowPointerDown} />
 
 <div class="flex w-full flex-col gap-4">
   <div class="flex w-full items-center justify-between gap-4">
@@ -94,46 +82,24 @@
               Connected
             </span>
           {/if}
-          <div class="relative" data-app-menu>
-            <Button
-              variant="ghost"
-              size="icon"
-              aria-label="App actions"
-              aria-haspopup="menu"
-              aria-expanded={openMenuFor === app.appUrl}
-              onclick={() => (openMenuFor = openMenuFor === app.appUrl ? undefined : app.appUrl)}
-            >
-              <EllipsisVertical />
-            </Button>
-            {#if openMenuFor === app.appUrl}
-              <div
-                role="menu"
-                tabindex="-1"
-                class="bg-popover text-popover-foreground absolute top-full right-0 z-50 mt-1 min-w-36 rounded-lg border p-1 shadow-md"
-              >
-                {#if isConnected(app.connectedUntil)}
-                  <button
-                    type="button"
-                    role="menuitem"
-                    class={MENU_ITEM_CLASS}
-                    onclick={() => disconnect(app.appUrl)}
-                  >
-                    <Unlink class="size-4 shrink-0" />
-                    <span class="flex-1 whitespace-nowrap">Disconnect</span>
-                  </button>
-                {/if}
-                <button
-                  type="button"
-                  role="menuitem"
-                  class={MENU_ITEM_CLASS}
-                  onclick={() => remove(app.appUrl)}
-                >
-                  <Trash2 class="size-4 shrink-0" />
-                  <span class="flex-1 whitespace-nowrap">Remove</span>
-                </button>
-              </div>
+          <DropdownMenu class="top-full right-0 mt-1 min-w-36 p-1">
+            {#snippet trigger(props)}
+              <Button variant="ghost" size="icon" aria-label="App actions" {...props}>
+                <EllipsisVertical />
+              </Button>
+            {/snippet}
+
+            {#if isConnected(app.connectedUntil)}
+              <DropdownMenuItem onclick={() => disconnect(app.appUrl)}>
+                <Unlink class="size-4 shrink-0" />
+                <span class="flex-1 whitespace-nowrap">Disconnect</span>
+              </DropdownMenuItem>
             {/if}
-          </div>
+            <DropdownMenuItem onclick={() => remove(app.appUrl)}>
+              <Trash2 class="size-4 shrink-0" />
+              <span class="flex-1 whitespace-nowrap">Remove</span>
+            </DropdownMenuItem>
+          </DropdownMenu>
         </div>
       {/each}
     </div>

--- a/ui/src/lib/components/home-drives.svelte
+++ b/ui/src/lib/components/home-drives.svelte
@@ -19,15 +19,13 @@
   import DriveResizeDialog from '$lib/components/drive-resize-dialog.svelte'
   import { Badge } from '$lib/components/ui/badge'
   import { Button } from '$lib/components/ui/button'
+  import { DropdownMenu, DropdownMenuItem } from '$lib/components/ui/dropdown-menu'
   import { Input } from '$lib/components/ui/input'
   import UtilizationBar from '$lib/components/utilization-bar.svelte'
   import { describeDrive } from '$lib/drives'
   import { toastStore } from '$lib/stores/toast.svelte'
   import type { Account } from '$lib/types'
   import { cn } from '$lib/utils'
-
-  const MENU_ITEM_CLASS =
-    'flex h-7 w-full cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-1 text-left text-sm outline-none hover:bg-muted focus-visible:bg-muted'
 
   interface Props {
     account: Account
@@ -36,7 +34,6 @@
   let { account }: Props = $props()
 
   let expandedId = $state<string | undefined>(undefined)
-  let openMenuId = $state<string | undefined>(undefined)
   let nameDraft = $state('')
   let addOpen = $state(false)
   let resizeDrive = $state<PostageStamp | undefined>(undefined)
@@ -50,7 +47,6 @@
     }
     expandedId = batchId
     nameDraft = currentName
-    openMenuId = undefined
   }
 
   function commitRename(drive: PostageStamp) {
@@ -63,13 +59,11 @@
 
   function setDefault(drive: PostageStamp) {
     account.setDefaultStamp(drive.batchID)
-    openMenuId = undefined
     toastStore.show('Default drive updated')
   }
 
   function remove(drive: PostageStamp) {
     removeDrive = drive
-    openMenuId = undefined
   }
 
   function onDriveRemoved(message: string) {
@@ -77,20 +71,6 @@
       expandedId = undefined
     }
     toastStore.show(message)
-  }
-
-  function onWindowPointerDown(event: PointerEvent) {
-    // `target` can be a Text node (Firefox), which has no `.closest`.
-    const target = event.target instanceof Element ? event.target : undefined
-    if (openMenuId && !target?.closest('[data-drive-menu]')) {
-      openMenuId = undefined
-    }
-  }
-
-  function onWindowKeydown(event: KeyboardEvent) {
-    if (event.key === 'Escape') {
-      openMenuId = undefined
-    }
   }
 
   function addDrive() {
@@ -104,8 +84,6 @@
     extendDrive = drive
   }
 </script>
-
-<svelte:window onpointerdown={onWindowPointerDown} onkeydown={onWindowKeydown} />
 
 <div class="flex w-full flex-col gap-4">
   <div class="flex flex-col gap-1">
@@ -271,47 +249,30 @@
             <!-- Footer: purchase date + overflow menu -->
             <div class="border-border flex items-center justify-between gap-2 border-t px-4 py-2">
               <p class="text-muted-foreground text-xs">Purchased on {d.purchasedOn}</p>
-              <div class="relative" data-drive-menu>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  class="size-7"
-                  aria-label="Drive actions"
-                  aria-haspopup="menu"
-                  aria-expanded={openMenuId === batchKey}
-                  onclick={() => (openMenuId = openMenuId === batchKey ? undefined : batchKey)}
-                >
-                  <EllipsisVertical />
-                </Button>
-                {#if openMenuId === batchKey}
-                  <div
-                    role="menu"
-                    tabindex="-1"
-                    class="bg-popover text-popover-foreground absolute right-0 bottom-full z-50 mb-1 min-w-40 rounded-lg border p-1 shadow-md"
+              <DropdownMenu class="right-0 bottom-full mb-1 min-w-40 p-1">
+                {#snippet trigger(props)}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    class="size-7"
+                    aria-label="Drive actions"
+                    {...props}
                   >
-                    {#if !isDefault}
-                      <button
-                        type="button"
-                        role="menuitem"
-                        class={MENU_ITEM_CLASS}
-                        onclick={() => setDefault(drive)}
-                      >
-                        <Star class="size-4 shrink-0" />
-                        <span class="flex-1 whitespace-nowrap">Set as default</span>
-                      </button>
-                    {/if}
-                    <button
-                      type="button"
-                      role="menuitem"
-                      class={MENU_ITEM_CLASS}
-                      onclick={() => remove(drive)}
-                    >
-                      <Trash2 class="size-4 shrink-0" />
-                      <span class="flex-1 whitespace-nowrap">Remove</span>
-                    </button>
-                  </div>
+                    <EllipsisVertical />
+                  </Button>
+                {/snippet}
+
+                {#if !isDefault}
+                  <DropdownMenuItem onclick={() => setDefault(drive)}>
+                    <Star class="size-4 shrink-0" />
+                    <span class="flex-1 whitespace-nowrap">Set as default</span>
+                  </DropdownMenuItem>
                 {/if}
-              </div>
+                <DropdownMenuItem onclick={() => remove(drive)}>
+                  <Trash2 class="size-4 shrink-0" />
+                  <span class="flex-1 whitespace-nowrap">Remove</span>
+                </DropdownMenuItem>
+              </DropdownMenu>
             </div>
           {/if}
         </div>

--- a/ui/src/lib/components/new-password-fields.svelte
+++ b/ui/src/lib/components/new-password-fields.svelte
@@ -1,0 +1,91 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<!--
+  The create-password + verify field pair shared by the account-creation access
+  step and the change-method ceremony: length rule, mismatch hint, and show/hide
+  toggles in one place. Callers gate their confirm on `isNewPasswordValid`.
+-->
+<script lang="ts" module>
+  const MIN_PASSWORD_LENGTH = 8
+
+  /** The single source of the create-password rule. */
+  export function isNewPasswordValid(password: string, verify: string): boolean {
+    return password.length >= MIN_PASSWORD_LENGTH && password === verify
+  }
+</script>
+
+<script lang="ts">
+  import Eye from '@lucide/svelte/icons/eye'
+  import EyeOff from '@lucide/svelte/icons/eye-off'
+
+  import { Button } from '$lib/components/ui/button'
+  import { Input } from '$lib/components/ui/input'
+
+  interface Props {
+    password: string
+    verify: string
+  }
+
+  let { password = $bindable(), verify = $bindable() }: Props = $props()
+
+  let showPassword = $state(false)
+  let showVerify = $state(false)
+
+  const tooShort = $derived(password.length > 0 && password.length < MIN_PASSWORD_LENGTH)
+  const mismatch = $derived(verify.length > 0 && password !== verify)
+</script>
+
+{#snippet revealToggle(shown: boolean, flip: () => void)}
+  <Button
+    variant="ghost"
+    size="icon"
+    class="size-6 shrink-0 rounded-md [&_svg]:size-3.5"
+    aria-label={shown ? 'Hide password' : 'Show password'}
+    onclick={flip}
+  >
+    {#if shown}
+      <EyeOff />
+    {:else}
+      <Eye />
+    {/if}
+  </Button>
+{/snippet}
+
+<div class="flex w-full flex-col gap-4">
+  <div class="flex w-full flex-col gap-2">
+    <label for="new-password" class="text-sm font-medium">Create new password</label>
+    <div class="flex w-full items-center gap-2">
+      <Input
+        id="new-password"
+        type={showPassword ? 'text' : 'password'}
+        bind:value={password}
+        autocomplete="new-password"
+        aria-invalid={tooShort}
+      />
+      {@render revealToggle(showPassword, () => (showPassword = !showPassword))}
+    </div>
+    <p class={tooShort ? 'text-destructive text-xs' : 'text-muted-foreground text-xs'}>
+      Must be at least {MIN_PASSWORD_LENGTH} characters
+    </p>
+  </div>
+
+  <div class="flex w-full flex-col gap-2">
+    <label for="verify-password" class="text-sm font-medium">Verify password</label>
+    <div class="flex w-full items-center gap-2">
+      <Input
+        id="verify-password"
+        type={showVerify ? 'text' : 'password'}
+        bind:value={verify}
+        autocomplete="new-password"
+        aria-invalid={mismatch}
+      />
+      {@render revealToggle(showVerify, () => (showVerify = !showVerify))}
+    </div>
+    {#if mismatch}
+      <p class="text-destructive text-xs">Passwords do not match</p>
+    {/if}
+  </div>
+</div>

--- a/ui/src/lib/components/settings-menu.svelte
+++ b/ui/src/lib/components/settings-menu.svelte
@@ -19,8 +19,14 @@
 
   import NetworkSettingsDialog from '$lib/components/network-settings-dialog.svelte'
   import { Button } from '$lib/components/ui/button'
+  import {
+    DropdownMenu,
+    DropdownMenuItem,
+    DropdownMenuLabel,
+    DropdownMenuSeparator,
+  } from '$lib/components/ui/dropdown-menu'
   import routes from '$lib/routes'
-  import { type ThemePreference, themeStore } from '$lib/stores/theme.svelte'
+  import { themeStore } from '$lib/stores/theme.svelte'
 
   const APPEARANCE_OPTIONS = [
     { value: 'auto', label: 'Automatic', icon: Contrast },
@@ -31,123 +37,63 @@
   const PRODUCT_PAGE_URL = 'https://swarm-id.snaha.net'
   const DOCUMENTATION_URL = 'https://swarm.snaha.net/docs'
 
-  const ITEM_CLASS =
-    'flex h-7 w-full cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-1 text-left text-sm outline-none hover:bg-muted focus-visible:bg-muted'
-
-  let open = $state(false)
   let dialogOpen = $state(false)
-  let container = $state<HTMLDivElement>()
-
-  function close() {
-    open = false
-  }
-
-  function onWindowPointerDown(event: PointerEvent) {
-    if (open && container && !container.contains(event.target as Node)) {
-      close()
-    }
-  }
-
-  function onWindowKeydown(event: KeyboardEvent) {
-    if (event.key === 'Escape') {
-      close()
-    }
-  }
 
   function restoreFromBackup() {
-    close()
     goto(resolve(routes.ACCOUNT_RESTORE))
   }
 
   function networkSettings() {
-    close()
     dialogOpen = true
-  }
-
-  function selectAppearance(value: ThemePreference) {
-    themeStore.set(value)
-    close()
   }
 </script>
 
-<svelte:window onpointerdown={onWindowPointerDown} onkeydown={onWindowKeydown} />
+<DropdownMenu class="top-full right-0 mt-2 min-w-36 p-1">
+  {#snippet trigger(props)}
+    <Button variant="outline" size="icon" aria-label="Settings" {...props}>
+      <Settings />
+    </Button>
+  {/snippet}
 
-<div bind:this={container} class="relative">
-  <Button
-    variant="outline"
-    size="icon"
-    aria-label="Settings"
-    aria-haspopup="menu"
-    aria-expanded={open}
-    onclick={() => (open = !open)}
-  >
-    <Settings />
-  </Button>
+  <DropdownMenuItem onclick={networkSettings}>
+    <Settings class="size-4 shrink-0" />
+    <span class="flex-1 whitespace-nowrap">Network settings</span>
+  </DropdownMenuItem>
+  <DropdownMenuItem onclick={restoreFromBackup}>
+    <History class="size-4 shrink-0" />
+    <span class="flex-1 whitespace-nowrap">Restore account from backup</span>
+  </DropdownMenuItem>
 
-  {#if open}
-    <div
-      role="menu"
-      tabindex="-1"
-      class="bg-popover text-popover-foreground absolute top-full right-0 z-50 mt-2 min-w-36 rounded-lg border p-1 shadow-md"
+  <DropdownMenuSeparator />
+
+  <DropdownMenuItem href={PRODUCT_PAGE_URL} target="_blank" rel="noopener noreferrer">
+    <Globe class="size-4 shrink-0" />
+    <span class="flex-1 whitespace-nowrap">Product page</span>
+    <ExternalLink class="text-muted-foreground size-3.5 shrink-0" />
+  </DropdownMenuItem>
+  <DropdownMenuItem href={DOCUMENTATION_URL} target="_blank" rel="noopener noreferrer">
+    <BookOpen class="size-4 shrink-0" />
+    <span class="flex-1 whitespace-nowrap">Documentation</span>
+    <ExternalLink class="text-muted-foreground size-3.5 shrink-0" />
+  </DropdownMenuItem>
+
+  <DropdownMenuSeparator />
+
+  <DropdownMenuLabel>Appearance</DropdownMenuLabel>
+  {#each APPEARANCE_OPTIONS as option (option.value)}
+    {@const Icon = option.icon}
+    <DropdownMenuItem
+      checked={themeStore.preference === option.value}
+      onclick={() => themeStore.set(option.value)}
     >
-      <button type="button" role="menuitem" class={ITEM_CLASS} onclick={networkSettings}>
-        <Settings class="size-4 shrink-0" />
-        <span class="flex-1 whitespace-nowrap">Network settings</span>
-      </button>
-      <button type="button" role="menuitem" class={ITEM_CLASS} onclick={restoreFromBackup}>
-        <History class="size-4 shrink-0" />
-        <span class="flex-1 whitespace-nowrap">Restore account from backup</span>
-      </button>
-
-      <div class="bg-border -mx-1 my-1 h-px"></div>
-
-      <a
-        href={PRODUCT_PAGE_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-        role="menuitem"
-        class={ITEM_CLASS}
-        onclick={close}
-      >
-        <Globe class="size-4 shrink-0" />
-        <span class="flex-1 whitespace-nowrap">Product page</span>
-        <ExternalLink class="text-muted-foreground size-3.5 shrink-0" />
-      </a>
-      <a
-        href={DOCUMENTATION_URL}
-        target="_blank"
-        rel="noopener noreferrer"
-        role="menuitem"
-        class={ITEM_CLASS}
-        onclick={close}
-      >
-        <BookOpen class="size-4 shrink-0" />
-        <span class="flex-1 whitespace-nowrap">Documentation</span>
-        <ExternalLink class="text-muted-foreground size-3.5 shrink-0" />
-      </a>
-
-      <div class="bg-border -mx-1 my-1 h-px"></div>
-
-      <div class="text-muted-foreground px-1.5 py-1 text-xs">Appearance</div>
-      {#each APPEARANCE_OPTIONS as option (option.value)}
-        {@const Icon = option.icon}
-        <button
-          type="button"
-          role="menuitemradio"
-          aria-checked={themeStore.preference === option.value}
-          class={ITEM_CLASS}
-          onclick={() => selectAppearance(option.value)}
-        >
-          <Icon class="size-4 shrink-0" />
-          <span class="flex-1 whitespace-nowrap">{option.label}</span>
-          {#if themeStore.preference === option.value}
-            <Check class="size-4 shrink-0" />
-          {/if}
-        </button>
-      {/each}
-    </div>
-  {/if}
-</div>
+      <Icon class="size-4 shrink-0" />
+      <span class="flex-1 whitespace-nowrap">{option.label}</span>
+      {#if themeStore.preference === option.value}
+        <Check class="size-4 shrink-0" />
+      {/if}
+    </DropdownMenuItem>
+  {/each}
+</DropdownMenu>
 
 {#if dialogOpen}
   <NetworkSettingsDialog onclose={() => (dialogOpen = false)} />

--- a/ui/src/lib/components/ui/dropdown-menu/dropdown-menu-item.svelte
+++ b/ui/src/lib/components/ui/dropdown-menu/dropdown-menu-item.svelte
@@ -1,0 +1,60 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<script lang="ts">
+  import { type Snippet, getContext } from 'svelte'
+
+  import { cn } from '$lib/utils'
+
+  import { DROPDOWN_MENU_CONTEXT, type DropdownMenuContext } from './dropdown-menu.svelte'
+
+  interface Props {
+    /** Renders an anchor instead of a button (e.g. external links). */
+    href?: string
+    target?: string
+    rel?: string
+    /** Set for a radio item — `role="menuitemradio"` with this checked state. */
+    checked?: boolean
+    class?: string
+    onclick?: () => void
+    children: Snippet
+  }
+
+  let { href, target, rel, checked, class: className, onclick, children }: Props = $props()
+
+  const { close } = getContext<DropdownMenuContext>(DROPDOWN_MENU_CONTEXT)
+
+  const itemClass = $derived(
+    cn(
+      'hover:bg-muted focus-visible:bg-muted flex h-7 w-full cursor-pointer items-center gap-1.5 rounded-md px-1.5 py-1 text-left text-sm outline-none',
+      className,
+    ),
+  )
+
+  function activate() {
+    onclick?.()
+    close()
+  }
+</script>
+
+{#if href}
+  <a {href} {target} {rel} role="menuitem" class={itemClass} onclick={activate}>
+    {@render children()}
+  </a>
+{:else if checked === undefined}
+  <button type="button" role="menuitem" class={itemClass} onclick={activate}>
+    {@render children()}
+  </button>
+{:else}
+  <button
+    type="button"
+    role="menuitemradio"
+    aria-checked={checked}
+    class={itemClass}
+    onclick={activate}
+  >
+    {@render children()}
+  </button>
+{/if}

--- a/ui/src/lib/components/ui/dropdown-menu/dropdown-menu-label.svelte
+++ b/ui/src/lib/components/ui/dropdown-menu/dropdown-menu-label.svelte
@@ -1,0 +1,18 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+
+  interface Props {
+    children: Snippet
+  }
+
+  let { children }: Props = $props()
+</script>
+
+<div class="text-muted-foreground px-1.5 py-1 text-xs">
+  {@render children()}
+</div>

--- a/ui/src/lib/components/ui/dropdown-menu/dropdown-menu-separator.svelte
+++ b/ui/src/lib/components/ui/dropdown-menu/dropdown-menu-separator.svelte
@@ -1,0 +1,6 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<div role="separator" class="bg-border -mx-1 my-1 h-px"></div>

--- a/ui/src/lib/components/ui/dropdown-menu/dropdown-menu.svelte
+++ b/ui/src/lib/components/ui/dropdown-menu/dropdown-menu.svelte
@@ -1,0 +1,132 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<!--
+  Menu with the shared dismissal contract: the trigger toggles, a pointerdown
+  outside closes, Escape closes (returning focus to the trigger), and
+  ArrowUp/ArrowDown/Home/End move focus across the menu items. Items rendered
+  through `DropdownMenuItem` close the menu when activated; other panel content
+  closes it by flipping the bindable `open`.
+-->
+
+<script lang="ts" module>
+  export interface DropdownMenuContext {
+    close: () => void
+  }
+
+  export const DROPDOWN_MENU_CONTEXT = Symbol('dropdown-menu')
+
+  interface TriggerProps {
+    'aria-haspopup': 'menu'
+    'aria-expanded': boolean
+    onclick: () => void
+  }
+</script>
+
+<script lang="ts">
+  import { type Snippet, setContext } from 'svelte'
+
+  import { cn } from '$lib/utils'
+
+  interface Props {
+    open?: boolean
+    /** Panel placement and sizing classes, e.g. `top-full right-0 mt-1 min-w-36 p-1`. */
+    class?: string
+    /** The toggle button; spread the given props onto it. */
+    trigger: Snippet<[TriggerProps]>
+    children: Snippet
+  }
+
+  let { open = $bindable(false), class: className, trigger, children }: Props = $props()
+
+  let container = $state<HTMLDivElement>()
+  let panel = $state<HTMLDivElement>()
+
+  setContext<DropdownMenuContext>(DROPDOWN_MENU_CONTEXT, { close })
+
+  function close() {
+    open = false
+  }
+
+  function onWindowPointerDown(event: PointerEvent) {
+    // `target` can be a Text node (Firefox), so guard to Node — `contains`
+    // accepts any Node, no Element cast needed.
+    if (open && container && !(event.target instanceof Node && container.contains(event.target))) {
+      close()
+    }
+  }
+
+  function onWindowKeydown(event: KeyboardEvent) {
+    if (!open) {
+      return
+    }
+    if (event.key === 'Escape') {
+      // Restore focus only when it was inside the menu (it would drop to
+      // <body> with the panel unmounted) — never steal it from elsewhere.
+      if (focusWithin()) {
+        container?.querySelector<HTMLElement>('[aria-haspopup="menu"]')?.focus()
+      }
+      close()
+      return
+    }
+    moveFocus(event)
+  }
+
+  function focusWithin(): boolean {
+    return (
+      container !== undefined &&
+      document.activeElement instanceof Node &&
+      container.contains(document.activeElement)
+    )
+  }
+
+  /** Roving focus across the panel's menu items, wrapping at the ends. */
+  function moveFocus(event: KeyboardEvent) {
+    if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key) || !focusWithin()) {
+      return
+    }
+    const items = panel ? [...panel.querySelectorAll<HTMLElement>('[role^="menuitem"]')] : []
+    if (items.length === 0) {
+      return
+    }
+    event.preventDefault()
+    const active = document.activeElement
+    const current = active instanceof HTMLElement ? items.indexOf(active) : -1
+    const last = items.length - 1
+    if (event.key === 'Home') {
+      items[0].focus()
+    } else if (event.key === 'End') {
+      items[last].focus()
+    } else if (event.key === 'ArrowDown') {
+      items[current < 0 || current === last ? 0 : current + 1].focus()
+    } else {
+      items[current <= 0 ? last : current - 1].focus()
+    }
+  }
+</script>
+
+<svelte:window onpointerdown={onWindowPointerDown} onkeydown={onWindowKeydown} />
+
+<div bind:this={container} class="relative">
+  {@render trigger({
+    'aria-haspopup': 'menu',
+    'aria-expanded': open,
+    onclick: () => (open = !open),
+  })}
+
+  {#if open}
+    <div
+      bind:this={panel}
+      role="menu"
+      tabindex="-1"
+      class={cn(
+        'bg-popover text-popover-foreground absolute z-50 rounded-lg border shadow-md',
+        className,
+      )}
+    >
+      {@render children()}
+    </div>
+  {/if}
+</div>

--- a/ui/src/lib/components/ui/dropdown-menu/index.ts
+++ b/ui/src/lib/components/ui/dropdown-menu/index.ts
@@ -1,0 +1,8 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import DropdownMenuItem from './dropdown-menu-item.svelte'
+import DropdownMenuLabel from './dropdown-menu-label.svelte'
+import DropdownMenuSeparator from './dropdown-menu-separator.svelte'
+import DropdownMenu from './dropdown-menu.svelte'
+
+export { DropdownMenu, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator }

--- a/ui/src/lib/components/unlock-dialog.svelte
+++ b/ui/src/lib/components/unlock-dialog.svelte
@@ -10,7 +10,7 @@
   error thrown from `onunlocked` is shown in the dialog for a retry.
 -->
 <script lang="ts">
-  import { untrack } from 'svelte'
+  import { type Snippet, untrack } from 'svelte'
 
   import LoaderCircle from '@lucide/svelte/icons/loader-circle'
 
@@ -23,12 +23,27 @@
   interface Props {
     account: Account
     title: string
-    description: string
+    description?: string
+    /** Richer body than a plain string — rendered in place of `description`. */
+    children?: Snippet
+    /** Overrides the access-method-derived confirm label. */
+    confirmLabel?: string
+    /** Destructive confirm styling for delete-style ceremonies. */
+    destructive?: boolean
     onunlocked: (entropy: Uint8Array) => void | Promise<void>
     onclose: () => void
   }
 
-  let { account, title, description, onunlocked, onclose }: Props = $props()
+  let {
+    account,
+    title,
+    description,
+    children,
+    confirmLabel,
+    destructive = false,
+    onunlocked,
+    onclose,
+  }: Props = $props()
 
   // The unlock ceremony only runs for a signed-in account, so the method is
   // present at mount. Read ONCE via `untrack` (not `$derived`): the method is
@@ -107,7 +122,11 @@
   </Dialog>
 {:else}
   <Dialog onclose={close} {title}>
-    <p class="text-sm">{description}</p>
+    {#if children}
+      {@render children()}
+    {:else if description}
+      <p class="text-sm">{description}</p>
+    {/if}
 
     {#if access.type === 'password'}
       <Input
@@ -125,6 +144,7 @@
     {/if}
 
     <Button
+      variant={destructive ? 'destructive' : 'default'}
       class="w-full"
       disabled={busy || (access.type === 'password' && password.length === 0)}
       onclick={confirm}
@@ -132,11 +152,12 @@
       {#if busy}
         <LoaderCircle class="animate-spin" />
       {/if}
-      {access.type === 'passkey'
-        ? 'Confirm with passkey'
-        : access.type === 'eth-wallet'
-          ? 'Confirm with wallet'
-          : 'Confirm'}
+      {confirmLabel ??
+        (access.type === 'passkey'
+          ? 'Confirm with passkey'
+          : access.type === 'eth-wallet'
+            ? 'Confirm with wallet'
+            : 'Confirm')}
     </Button>
   </Dialog>
 {/if}

--- a/ui/src/lib/crypto/access-setup.ts
+++ b/ui/src/lib/crypto/access-setup.ts
@@ -1,0 +1,49 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Create a fresh access method and its seed-encryption key — the
+ * passkey / wallet / password branching shared by the account-creation access
+ * step and the change-method ceremony.
+ */
+import { type AccessMethod, uint8ArrayToHex } from '@snaha/swarm-id'
+
+import { PASSWORD_KDF_ITERATIONS, deriveKeyFromPassword, randomSalt } from '$lib/crypto/encryption'
+import { deriveWalletKey, requestWalletKeySource } from '$lib/crypto/eth-wallet'
+import { createPasskeyKey } from '$lib/crypto/passkey'
+
+export interface AccessSetup {
+  access: AccessMethod
+  key: CryptoKey
+}
+
+/**
+ * Runs the ceremony for the chosen method: registers a passkey, prompts the
+ * wallet, or derives from the password. `method` mirrors the access tabs'
+ * value set; anything that is not `passkey`/`eth-wallet` is the password tab.
+ */
+export async function createAccess(
+  method: string,
+  options: { accountName: string; password: string; signal?: AbortSignal },
+): Promise<AccessSetup> {
+  if (method === 'passkey') {
+    const passkey = await createPasskeyKey(options.accountName, options.signal)
+    return { access: { type: 'passkey', credentialId: passkey.credentialId }, key: passkey.key }
+  }
+  if (method === 'eth-wallet') {
+    const source = await requestWalletKeySource()
+    const salt = randomSalt()
+    return {
+      access: { type: 'eth-wallet', encryptionSalt: uint8ArrayToHex(salt) },
+      key: await deriveWalletKey(source, salt),
+    }
+  }
+  const salt = randomSalt()
+  return {
+    access: {
+      type: 'password',
+      kdfSalt: uint8ArrayToHex(salt),
+      kdfIterations: PASSWORD_KDF_ITERATIONS,
+    },
+    key: await deriveKeyFromPassword(options.password, salt),
+  }
+}

--- a/ui/src/routes/account/new/access/+page.svelte
+++ b/ui/src/routes/account/new/access/+page.svelte
@@ -8,42 +8,32 @@
 
   import { EthAddress } from '@ethersphere/bee-js'
   import ChevronLeft from '@lucide/svelte/icons/chevron-left'
-  import Eye from '@lucide/svelte/icons/eye'
-  import EyeOff from '@lucide/svelte/icons/eye-off'
   import LoaderCircle from '@lucide/svelte/icons/loader-circle'
   import {
     type AccessMethod,
     type Account as AccountRecord,
     PARTITION_COUNT,
     deriveAccountDerivationKey,
-    uint8ArrayToHex,
   } from '@snaha/swarm-id'
 
   import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'
 
   import AppHeader from '$lib/components/app-header.svelte'
+  import NewPasswordFields, { isNewPasswordValid } from '$lib/components/new-password-fields.svelte'
   import { Button } from '$lib/components/ui/button'
-  import { Input } from '$lib/components/ui/input'
   import { Tabs } from '$lib/components/ui/tabs'
   import { completeConnect } from '$lib/connect-handshake'
-  import {
-    PASSWORD_KDF_ITERATIONS,
-    deriveKeyFromPassword,
-    encryptSeed,
-    randomSalt,
-  } from '$lib/crypto/encryption'
-  import { deriveWalletKey, requestWalletKeySource } from '$lib/crypto/eth-wallet'
+  import { createAccess } from '$lib/crypto/access-setup'
+  import { encryptSeed } from '$lib/crypto/encryption'
   import { strip0x } from '$lib/crypto/hex'
   import { walletFromPhrase } from '$lib/crypto/mnemonic'
-  import { createPasskeyKey } from '$lib/crypto/passkey'
   import { triggerSync } from '$lib/dev/sync-hooks'
   import routes from '$lib/routes'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { connectStore } from '$lib/stores/connect.svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
 
-  const MIN_PASSWORD_LENGTH = 8
   const TABS = [
     { value: 'passkey', label: 'Passkey' },
     { value: 'eth-wallet', label: 'ETH wallet' },
@@ -51,24 +41,18 @@
   ]
 
   let method = $state('passkey')
-  let pending = $state<'passkey' | 'eth-wallet' | undefined>(undefined)
+  let pending = $state(false)
   let busy = $state(false)
   let error = $state<string | undefined>(undefined)
 
   let password = $state('')
   let verifyPassword = $state('')
-  let showPassword = $state(false)
-  let showVerifyPassword = $state(false)
 
   let abortController: AbortController | undefined
   /** Bumped on cancel/retry — a stale ceremony resolution must not finalize. */
   let attempt = 0
 
-  const passwordTooShort = $derived(password.length > 0 && password.length < MIN_PASSWORD_LENGTH)
-  const passwordMismatch = $derived(verifyPassword.length > 0 && password !== verifyPassword)
-  const passwordValid = $derived(
-    password.length >= MIN_PASSWORD_LENGTH && password === verifyPassword,
-  )
+  const passwordValid = $derived(isNewPasswordValid(password, verifyPassword))
 
   const backHref = $derived(
     sessionStore.draft?.flow === 'sign-in'
@@ -148,82 +132,45 @@
     goto(resolve(flow === 'create' ? routes.ACCOUNT_NEW_DONE : routes.ACCOUNT_READY))
   }
 
-  async function confirmWithPasskey() {
+  async function confirm() {
     const draft = sessionStore.draft
-    if (!draft) {
+    if (busy || !draft) {
       return
     }
     const myAttempt = ++attempt
-    error = undefined
-    pending = 'passkey'
-    abortController = new AbortController()
-    try {
-      const passkey = await createPasskeyKey(draft.name, abortController.signal)
-      if (myAttempt !== attempt) {
-        return
-      }
-      await finalize({ type: 'passkey', credentialId: passkey.credentialId }, passkey.key)
-    } catch (caught) {
-      if (myAttempt === attempt) {
-        error = caught instanceof Error ? caught.message : 'Passkey creation failed.'
-      }
-    } finally {
-      if (myAttempt === attempt) {
-        pending = undefined
-      }
-    }
-  }
-
-  async function confirmWithWallet() {
-    const myAttempt = ++attempt
-    error = undefined
-    pending = 'eth-wallet'
-    try {
-      const source = await requestWalletKeySource()
-      if (myAttempt !== attempt) {
-        return
-      }
-      const salt = randomSalt()
-      const key = await deriveWalletKey(source, salt)
-      await finalize(
-        {
-          type: 'eth-wallet',
-          encryptionSalt: uint8ArrayToHex(salt),
-        },
-        key,
-      )
-    } catch (caught) {
-      if (myAttempt === attempt) {
-        error = caught instanceof Error ? caught.message : 'Wallet signing failed.'
-      }
-    } finally {
-      if (myAttempt === attempt) {
-        pending = undefined
-      }
-    }
-  }
-
-  async function confirmWithPassword() {
-    if (busy) {
-      return
-    }
     error = undefined
     busy = true
+    if (method !== 'password') {
+      pending = true
+    }
     try {
-      const salt = randomSalt()
-      const key = await deriveKeyFromPassword(password, salt)
-      await finalize(
-        {
-          type: 'password',
-          kdfSalt: uint8ArrayToHex(salt),
-          kdfIterations: PASSWORD_KDF_ITERATIONS,
-        },
-        key,
-      )
+      abortController = method === 'passkey' ? new AbortController() : undefined
+      const { access, key } = await createAccess(method, {
+        accountName: draft.name,
+        password,
+        signal: abortController?.signal,
+      })
+      if (myAttempt !== attempt) {
+        return
+      }
+      await finalize(access, key)
     } catch (caught) {
-      error = caught instanceof Error ? caught.message : 'Encryption failed.'
+      if (myAttempt === attempt) {
+        error =
+          caught instanceof Error
+            ? caught.message
+            : method === 'passkey'
+              ? 'Passkey creation failed.'
+              : method === 'eth-wallet'
+                ? 'Wallet signing failed.'
+                : 'Encryption failed.'
+      }
     } finally {
-      busy = false
+      if (myAttempt === attempt) {
+        pending = false
+        busy = false
+        abortController = undefined
+      }
     }
   }
 
@@ -232,7 +179,8 @@
     // a later approval of a cancelled prompt must not finalize.
     attempt++
     abortController?.abort()
-    pending = undefined
+    pending = false
+    busy = false
   }
 </script>
 
@@ -246,10 +194,10 @@
           <LoaderCircle class="size-5 animate-spin" />
           <div class="flex flex-col items-center text-center">
             <p class="text-sm font-bold">
-              {pending === 'passkey' ? 'Confirm with passkey' : 'Confirm with wallet'}
+              {method === 'passkey' ? 'Confirm with passkey' : 'Confirm with wallet'}
             </p>
             <p class="text-sm">
-              {pending === 'passkey'
+              {method === 'passkey'
                 ? 'Follow the prompts on your device.'
                 : 'Approve the request in your Ethereum wallet.'}
             </p>
@@ -291,69 +239,7 @@
           </div>
 
           {#if method === 'password'}
-            <div class="flex w-full flex-col gap-4">
-              <div class="flex w-full flex-col gap-2">
-                <label for="new-password" class="text-sm font-medium">Create new password</label>
-                <div class="flex w-full items-center gap-2">
-                  <Input
-                    id="new-password"
-                    type={showPassword ? 'text' : 'password'}
-                    bind:value={password}
-                    autocomplete="new-password"
-                    aria-invalid={passwordTooShort}
-                  />
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    class="size-6 shrink-0 rounded-md [&_svg]:size-3.5"
-                    aria-label={showPassword ? 'Hide password' : 'Show password'}
-                    onclick={() => (showPassword = !showPassword)}
-                  >
-                    {#if showPassword}
-                      <EyeOff />
-                    {:else}
-                      <Eye />
-                    {/if}
-                  </Button>
-                </div>
-                <p
-                  class={passwordTooShort
-                    ? 'text-destructive text-xs'
-                    : 'text-muted-foreground text-xs'}
-                >
-                  Must be at least {MIN_PASSWORD_LENGTH} characters
-                </p>
-              </div>
-
-              <div class="flex w-full flex-col gap-2">
-                <label for="verify-password" class="text-sm font-medium">Verify password</label>
-                <div class="flex w-full items-center gap-2">
-                  <Input
-                    id="verify-password"
-                    type={showVerifyPassword ? 'text' : 'password'}
-                    bind:value={verifyPassword}
-                    autocomplete="new-password"
-                    aria-invalid={passwordMismatch}
-                  />
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    class="size-6 shrink-0 rounded-md [&_svg]:size-3.5"
-                    aria-label={showVerifyPassword ? 'Hide password' : 'Show password'}
-                    onclick={() => (showVerifyPassword = !showVerifyPassword)}
-                  >
-                    {#if showVerifyPassword}
-                      <EyeOff />
-                    {:else}
-                      <Eye />
-                    {/if}
-                  </Button>
-                </div>
-                {#if passwordMismatch}
-                  <p class="text-destructive text-xs">Passwords do not match</p>
-                {/if}
-              </div>
-            </div>
+            <NewPasswordFields bind:password bind:verify={verifyPassword} />
           {/if}
 
           {#if error}
@@ -361,19 +247,15 @@
           {/if}
 
           {#if method === 'passkey'}
-            <Button class="w-full" onclick={confirmWithPasskey}>Confirm with passkey</Button>
+            <Button class="w-full" onclick={confirm}>Confirm with passkey</Button>
           {:else if method === 'eth-wallet'}
-            <Button class="w-full" onclick={confirmWithWallet}>Confirm with wallet</Button>
+            <Button class="w-full" onclick={confirm}>Confirm with wallet</Button>
           {:else}
             <div class="flex w-full flex-col gap-8">
               <p class="text-muted-foreground text-xs">
                 Save your password &mdash; it can&rsquo;t be reset or recovered.
               </p>
-              <Button
-                class="w-full"
-                disabled={!passwordValid || busy}
-                onclick={confirmWithPassword}
-              >
+              <Button class="w-full" disabled={!passwordValid || busy} onclick={confirm}>
                 {#if busy}
                   <LoaderCircle class="animate-spin" />
                 {/if}

--- a/ui/tests/dropdown-menu.test.ts
+++ b/ui/tests/dropdown-menu.test.ts
@@ -1,0 +1,69 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { expect, test } from '@playwright/test'
+
+// The account chooser (`/?signin`) renders the settings menu without needing
+// an account — the cheapest real mount of the shared DropdownMenu. These tests
+// pin the dismissal contract every menu call site inherits: the trigger
+// toggles, outside pointerdown closes, Escape closes, items close on activate,
+// and arrow keys rove focus.
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('/?signin')
+})
+
+test('trigger toggles the menu open and closed', async ({ page }) => {
+  const trigger = page.getByRole('button', { name: 'Settings' })
+  const menu = page.getByRole('menu')
+
+  await expect(menu).toBeHidden()
+  await trigger.click()
+  await expect(menu).toBeVisible()
+  await expect(page.getByRole('menuitem', { name: 'Network settings' })).toBeVisible()
+
+  await trigger.click()
+  await expect(menu).toBeHidden()
+})
+
+test('pointerdown outside closes the menu', async ({ page }) => {
+  await page.getByRole('button', { name: 'Settings' }).click()
+  await expect(page.getByRole('menu')).toBeVisible()
+
+  await page.mouse.click(10, 10)
+  await expect(page.getByRole('menu')).toBeHidden()
+})
+
+test('Escape closes the menu and returns focus to the trigger', async ({ page }) => {
+  const trigger = page.getByRole('button', { name: 'Settings' })
+  await trigger.click()
+  await expect(page.getByRole('menu')).toBeVisible()
+
+  await page.keyboard.press('Escape')
+  await expect(page.getByRole('menu')).toBeHidden()
+  await expect(trigger).toBeFocused()
+})
+
+test('arrow keys rove focus across menu items, wrapping at the ends', async ({ page }) => {
+  await page.getByRole('button', { name: 'Settings' }).click()
+
+  await page.keyboard.press('ArrowDown')
+  await expect(page.getByRole('menuitem', { name: 'Network settings' })).toBeFocused()
+
+  await page.keyboard.press('ArrowDown')
+  await expect(page.getByRole('menuitem', { name: 'Restore account from backup' })).toBeFocused()
+
+  await page.keyboard.press('ArrowUp')
+  await expect(page.getByRole('menuitem', { name: 'Network settings' })).toBeFocused()
+
+  // Wraps from the first item to the last (the Dark appearance radio).
+  await page.keyboard.press('ArrowUp')
+  await expect(page.getByRole('menuitemradio', { name: 'Dark' })).toBeFocused()
+})
+
+test('activating an item closes the menu', async ({ page }) => {
+  await page.getByRole('button', { name: 'Settings' }).click()
+  await page.getByRole('menuitem', { name: 'Network settings' }).click()
+
+  await expect(page.getByRole('menu')).toBeHidden()
+  await expect(page.getByRole('dialog', { name: 'Network settings' })).toBeVisible()
+})


### PR DESCRIPTION
## Summary

Two repeatedly hand-rolled UI patterns become shared components (behavior parity, dismissal edge cases fixed once):

**DropdownMenu primitive** (`ui/src/lib/components/ui/dropdown-menu/`, hand-written, no bits-ui)
- Owns the dismissal contract: trigger toggles, outside **pointerdown** closes (with the `Node` guard — `home-apps` previously called `.closest()` on a possibly-Text `event.target`, which throws in Firefox), **Escape** closes and restores focus to the trigger, and **ArrowUp/ArrowDown/Home/End** rove focus across menu items.
- `DropdownMenuItem` (button, anchor, or `menuitemradio` via `checked`) closes the menu on activation through context; `DropdownMenuSeparator`/`DropdownMenuLabel` cover the settings menu's structure.
- Migrated all four call sites: `account-switcher` (custom panel via `bind:open`), `settings-menu`, `home-drives` (upward placement), `home-apps` — `home-apps` also gains the Escape dismissal it was missing.

**Unlock ceremony**
- `UnlockDialog` gains `confirmLabel` / `destructive` / `children` props; `delete-account-dialog` is now a thin wrapper around it, and `home-account`'s four hand-rolled unlock targets (reveal key/phrase, export, change method) render through it too.
- The duplicated `MIN_PASSWORD_LENGTH` + create-password/verify pair is one `NewPasswordFields` component (the change-method dialog gains the show/hide toggles that had only been propagated to the access step).
- The passkey/wallet/password key-creation branching is a single `createAccess` helper (`ui/src/lib/crypto/access-setup.ts`) shared by the account-creation access step and the change-method ceremony.

Note: the issue also lists `drive-add-dialog` as an unlock call site, but its ceremony was already removed on main (the batch owner derives from the plaintext derivation key — no unlock needed), so there was nothing to migrate there.

Net: −46 lines while adding the primitive and its tests.

## Tests
- New `ui/tests/dropdown-menu.test.ts` pins the shared dismissal contract once (toggle, outside pointerdown, Escape + focus restore, arrow-key roving, item activation) through the settings menu on the account chooser.
- `pnpm check:all` passes; full e2e suite run (the two `done-page` failures under parallel-session load pass in isolation, as do the lib feed-roundtrip flakes).
- Manually verified every migrated menu and ceremony on `pnpm dev` (:5500): all four menus, wrong/correct password unlock, change-method → new password, delete with the changed password, mock-drive add.

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)