### PR TITLE
fix(lib): use 128-ref fanout for plain Merkle trees

### DIFF
--- a/lib/src/proxy/chunking.ts
+++ b/lib/src/proxy/chunking.ts
@@ -7,7 +7,7 @@ import type { ChunkReference } from "./types"
 
 // Constants
 export const CHUNK_SIZE = 4096
-export const REFS_PER_CHUNK = 64 // 4096 / 64 = 64 refs per intermediate chunk
+export const PLAIN_REFS_PER_CHUNK = 128 // 4096 / 32 = 128 plain (unencrypted) refs per intermediate chunk
 
 /**
  * Split data into 4096-byte chunks
@@ -41,11 +41,20 @@ export async function buildMerkleTree(
   // Build intermediate level
   const intermediateRefs: ChunkReference[] = []
 
-  for (let i = 0; i < chunkRefs.length; i += REFS_PER_CHUNK) {
+  for (let i = 0; i < chunkRefs.length; i += PLAIN_REFS_PER_CHUNK) {
     const refs = chunkRefs.slice(
       i,
-      Math.min(i + REFS_PER_CHUNK, chunkRefs.length),
+      Math.min(i + PLAIN_REFS_PER_CHUNK, chunkRefs.length),
     )
+
+    // Pass through single-ref batches without wrapping in an intermediate
+    // (Bee's "carrier chunk" rule). A ghost intermediate with span ≤ 4096
+    // would be misidentified as a leaf by the download path's span-based
+    // leaf check.
+    if (refs.length === 1) {
+      intermediateRefs.push(refs[0])
+      continue
+    }
 
     // Build payload with 32-byte references
     const payload = new Uint8Array(refs.length * 32)

--- a/lib/src/proxy/download-data.ts
+++ b/lib/src/proxy/download-data.ts
@@ -24,6 +24,8 @@ import {
   UNENCRYPTED_REF_SIZE,
 } from "../chunk"
 import { Binary } from "cafe-utility"
+import { PLAIN_REFS_PER_CHUNK } from "./chunking"
+import { ENCRYPTED_REFS_PER_CHUNK } from "./chunking-encrypted"
 import type { UploadProgress } from "./types"
 import type { SingleOwnerChunk } from "../types"
 import { hexToUint8Array } from "../utils/hex"
@@ -293,9 +295,11 @@ async function joinChunks(
 
 /**
  * Estimate total chunks for progress tracking
- * This is an approximation based on span
+ * This is an approximation based on span. The branching factor depends on
+ * the reference width: 128 refs per intermediate for plain trees (32-byte
+ * refs), 64 for encrypted trees (64-byte refs).
  */
-function estimateTotalChunks(span: number): number {
+function estimateTotalChunks(span: number, refsPerChunk: number): number {
   if (span <= MAX_PAYLOAD_SIZE) {
     return 1
   }
@@ -303,13 +307,12 @@ function estimateTotalChunks(span: number): number {
   // Number of leaf chunks
   const leafChunks = Math.ceil(span / MAX_PAYLOAD_SIZE)
 
-  // For a full binary tree with 64-way branching, intermediate chunks
+  // Intermediate chunks for a tree with refsPerChunk-way branching
   // This is a rough estimate - actual count depends on tree structure
   let intermediateChunks = 0
   let level = leafChunks
   while (level > 1) {
-    const branchingFactor = 64 // REFS_PER_CHUNK
-    level = Math.ceil(level / branchingFactor)
+    level = Math.ceil(level / refsPerChunk)
     intermediateChunks += level
   }
 
@@ -356,7 +359,10 @@ export async function downloadDataWithChunkAPI(
   }
 
   // Estimate total chunks for progress tracking
-  const estimatedTotal = estimateTotalChunks(span)
+  const estimatedTotal = estimateTotalChunks(
+    span,
+    isEncrypted ? ENCRYPTED_REFS_PER_CHUNK : PLAIN_REFS_PER_CHUNK,
+  )
   let processedChunks = 1 // Already downloaded root
 
   const onChunkDownloaded = () => {

--- a/lib/src/proxy/upload.interop.test.ts
+++ b/lib/src/proxy/upload.interop.test.ts
@@ -1,0 +1,228 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Interop tests pinning the plain (unencrypted) upload path to Bee's
+ * canonical Merkle layout, with bee-js's `MerkleTree` as the oracle.
+ *
+ * Canonical facts these tests encode (independent of the code under test):
+ * - An intermediate chunk is 4096 bytes of refs. Plain refs are 32 bytes,
+ *   so a full plain intermediate holds 128 refs; encrypted refs are 64
+ *   bytes, so a full encrypted intermediate holds 64.
+ * - A trailing chunk that would sit alone in its batch is promoted to the
+ *   next level as-is (Bee's "carrier chunk"), never wrapped in a
+ *   single-ref intermediate.
+ *
+ * The upload direction asserts our root reference equals the bee-js-computed
+ * reference for the same payload; the download direction seeds the store with
+ * a bee-js-built tree and reads it back through `downloadDataWithChunkAPI`.
+ */
+
+import { describe, it, expect } from "vitest"
+import { MerkleTree } from "@ethersphere/bee-js"
+import type { Bee, Stamper } from "@ethersphere/bee-js"
+import { uploadData, type UploadTarget } from "./upload"
+import { downloadDataWithChunkAPI } from "./download-data"
+import { SPAN_SIZE, UNENCRYPTED_REF_SIZE } from "../chunk"
+import { uint8ArrayToHex } from "../utils/hex"
+import type { UploadProgress } from "./types"
+import {
+  MockBee,
+  MockChunkStore,
+  createMockStamper,
+} from "./feeds/epochs/test-utils"
+
+const CHUNK_SIZE = 4096
+// Canonical Swarm fanout for plain trees: 4096-byte payload / 32-byte refs.
+const CANONICAL_PLAIN_FANOUT = 128
+
+/** Build `length` bytes with position-dependent variation so chunks differ. */
+function makeData(length: number): Uint8Array {
+  const data = new Uint8Array(length)
+  for (let i = 0; i < length; i++) {
+    data[i] = (i * 31 + 7) & 0xff
+  }
+  return data
+}
+
+function setup(): { bee: Bee; store: MockChunkStore; target: UploadTarget } {
+  const store = new MockChunkStore()
+  const bee = new MockBee(store) as unknown as Bee
+  const target: UploadTarget = {
+    mode: "stamper",
+    bee,
+    stamper: createMockStamper() as unknown as Stamper,
+  }
+  return { bee, store, target }
+}
+
+/** Compute the canonical root reference for a payload via bee-js. */
+async function canonicalRootHex(data: Uint8Array): Promise<string> {
+  const root = await MerkleTree.root(data)
+  return uint8ArrayToHex(root.hash())
+}
+
+/**
+ * Build the canonical chunk tree for a payload via bee-js and seed the store
+ * with every chunk (span + written payload, trimmed of BMT zero padding).
+ * Returns the root reference hex and the number of chunks in the tree.
+ */
+async function seedCanonicalTree(
+  store: MockChunkStore,
+  data: Uint8Array,
+): Promise<{ rootHex: string; chunkCount: number }> {
+  let chunkCount = 0
+  const tree = new MerkleTree(async (chunk) => {
+    chunkCount++
+    const chunkData = chunk.build().slice(0, SPAN_SIZE + chunk.writer.cursor)
+    await store.put(uint8ArrayToHex(chunk.hash()), chunkData)
+  })
+  await tree.append(data)
+  const root = await tree.finalize()
+  return { rootHex: uint8ArrayToHex(root.hash()), chunkCount }
+}
+
+function readSpan(chunkData: Uint8Array): number {
+  const view = new DataView(
+    chunkData.buffer,
+    chunkData.byteOffset,
+    chunkData.byteLength,
+  )
+  return Number(view.getBigUint64(0, true))
+}
+
+describe("plain uploads match Bee's canonical Merkle layout", () => {
+  // Named payload sizes around the 128-ref intermediate boundary. Everything
+  // above 128 leaf chunks (512 KiB) needs the canonical fanout to agree with
+  // Bee; 129 leaves additionally exercises the carrier-chunk promotion.
+  const CASES: Array<{ name: string; size: number }> = [
+    { name: "3 full chunks (single intermediate)", size: 3 * CHUNK_SIZE },
+    {
+      // The filed threshold: the first size where the old 64-ref fanout
+      // split the tree while the canonical layout still fits one level.
+      name: "65 full chunks (>256KB, minimal reproducer)",
+      size: 65 * CHUNK_SIZE,
+    },
+    {
+      name: "128 full chunks (exactly one full intermediate)",
+      size: CANONICAL_PLAIN_FANOUT * CHUNK_SIZE,
+    },
+    {
+      name: "129 full chunks (carrier chunk boundary)",
+      size: (CANONICAL_PLAIN_FANOUT + 1) * CHUNK_SIZE,
+    },
+    {
+      name: "128 full chunks + 1 byte (short carrier leaf)",
+      size: CANONICAL_PLAIN_FANOUT * CHUNK_SIZE + 1,
+    },
+    {
+      name: "130 full chunks (>256KB, two-ref root)",
+      size: (CANONICAL_PLAIN_FANOUT + 2) * CHUNK_SIZE,
+    },
+  ]
+
+  for (const { name, size } of CASES) {
+    it(`root reference matches bee-js for ${name}`, async () => {
+      const { bee, target } = setup()
+      const data = makeData(size)
+
+      const { reference } = await uploadData(target, data)
+
+      expect(reference).toBe(await canonicalRootHex(data))
+
+      // The tree we produced must also read back through our own downloader.
+      const downloaded = await downloadDataWithChunkAPI(bee, reference)
+      expect(downloaded).toEqual(data)
+    })
+  }
+
+  it("builds intermediate chunks holding 128 refs with child spans", async () => {
+    const { store, target } = setup()
+    const leafCount = CANONICAL_PLAIN_FANOUT + 2
+    const data = makeData(leafCount * CHUNK_SIZE)
+
+    const { reference } = await uploadData(target, data)
+
+    // Root: two refs — a full 128-ref intermediate and a 2-ref intermediate.
+    const rootData = await store.get(reference)
+    expect(readSpan(rootData)).toBe(leafCount * CHUNK_SIZE)
+    const rootPayload = rootData.slice(SPAN_SIZE)
+    expect(rootPayload.length).toBe(2 * UNENCRYPTED_REF_SIZE)
+
+    const firstChild = await store.get(
+      uint8ArrayToHex(rootPayload.slice(0, UNENCRYPTED_REF_SIZE)),
+    )
+    expect(readSpan(firstChild)).toBe(CANONICAL_PLAIN_FANOUT * CHUNK_SIZE)
+    expect(firstChild.slice(SPAN_SIZE).length).toBe(
+      CANONICAL_PLAIN_FANOUT * UNENCRYPTED_REF_SIZE,
+    )
+
+    const secondChild = await store.get(
+      uint8ArrayToHex(rootPayload.slice(UNENCRYPTED_REF_SIZE)),
+    )
+    expect(readSpan(secondChild)).toBe(2 * CHUNK_SIZE)
+    expect(secondChild.slice(SPAN_SIZE).length).toBe(2 * UNENCRYPTED_REF_SIZE)
+  })
+
+  it("downloads a bee-js-built tree with exact progress totals", async () => {
+    const { bee, store } = setup()
+    const leafCount = CANONICAL_PLAIN_FANOUT + 2
+    const data = makeData(leafCount * CHUNK_SIZE)
+
+    const { rootHex, chunkCount } = await seedCanonicalTree(store, data)
+    // 130 leaves + two level-1 intermediates + root.
+    expect(chunkCount).toBe(leafCount + 3)
+
+    const progress: UploadProgress[] = []
+    const downloaded = await downloadDataWithChunkAPI(
+      bee,
+      rootHex,
+      undefined,
+      (p) => progress.push(p),
+    )
+
+    expect(downloaded).toEqual(data)
+    expect(progress[progress.length - 1].processed).toBe(chunkCount)
+    // The final event normalizes total to the processed count, so the
+    // estimate is only observable before it. It must assume the canonical
+    // 128-ref plain fanout; a 64-ref estimate overcounts the intermediates.
+    expect(progress[progress.length - 2]).toEqual({
+      total: chunkCount,
+      processed: chunkCount,
+    })
+  })
+})
+
+describe("encrypted uploads keep the 64-ref fanout", () => {
+  const ENCRYPTED_FANOUT = 64
+
+  it("uploads 130 encrypted leaves as 64-ref intermediates", async () => {
+    const { bee, target } = setup()
+    const leafCount = ENCRYPTED_FANOUT * 2 + 2
+    const data = makeData(leafCount * CHUNK_SIZE)
+
+    const { reference, chunkAddresses } = await uploadData(target, data, {
+      encryptionKey: true,
+    })
+
+    // 130 leaves ⇒ level-1 batches [64], [64], [2] ⇒ 3 intermediates + root.
+    expect(chunkAddresses).toHaveLength(leafCount + 4)
+
+    // And the tree must read back with an exact 64-ref-fanout estimate.
+    const progress: UploadProgress[] = []
+    const downloaded = await downloadDataWithChunkAPI(
+      bee,
+      reference,
+      undefined,
+      (p) => progress.push(p),
+    )
+    expect(downloaded).toEqual(data)
+    expect(progress[progress.length - 1].processed).toBe(leafCount + 4)
+    // Pre-normalization event: the estimate must use the 64-ref encrypted
+    // fanout — a 128-ref estimate would undercount the intermediates.
+    expect(progress[progress.length - 2]).toEqual({
+      total: leafCount + 4,
+      processed: leafCount + 4,
+    })
+  })
+})

--- a/lib/src/proxy/upload.roundtrip.test.ts
+++ b/lib/src/proxy/upload.roundtrip.test.ts
@@ -3,7 +3,8 @@
 
 /**
  * Upload → download round-trips for payloads large enough to build a Merkle
- * tree with ≥2 levels (more than `REFS_PER_CHUNK` leaf chunks).
+ * tree with ≥2 levels (more leaf chunks than one intermediate holds:
+ * `PLAIN_REFS_PER_CHUNK` plain, `ENCRYPTED_REFS_PER_CHUNK` encrypted).
  *
  * These guard the span-based leaf detection on the download path against the
  * intermediate-chunk layout the upload path produces — in particular the
@@ -20,7 +21,8 @@ import { describe, it, expect } from "vitest"
 import type { Bee, Stamper } from "@ethersphere/bee-js"
 import { uploadData, type UploadTarget } from "./upload"
 import { downloadDataWithChunkAPI } from "./download-data"
-import { CHUNK_SIZE, REFS_PER_CHUNK } from "./chunking"
+import { CHUNK_SIZE, PLAIN_REFS_PER_CHUNK } from "./chunking"
+import { ENCRYPTED_REFS_PER_CHUNK } from "./chunking-encrypted"
 import {
   MockBee,
   MockChunkStore,
@@ -32,7 +34,8 @@ const ENCRYPTED_REF_HEX_LEN = 128 // 32-byte address + 32-byte key
 
 // More than one full intermediate's worth of leaves ⇒ the tree needs a 2nd
 // level. The +9 keeps the final batch comfortably multi-ref (no edge case).
-const TWO_LEVEL_LEAF_COUNT = REFS_PER_CHUNK + 9
+const PLAIN_TWO_LEVEL_LEAF_COUNT = PLAIN_REFS_PER_CHUNK + 9
+const ENCRYPTED_TWO_LEVEL_LEAF_COUNT = ENCRYPTED_REFS_PER_CHUNK + 9
 
 /** Build `length` bytes with position-dependent variation so chunks differ. */
 function makeData(length: number): Uint8Array {
@@ -57,7 +60,7 @@ function setup(): { bee: Bee; target: UploadTarget } {
 describe("uploadData ↔ downloadDataWithChunkAPI (multi-level Merkle tree)", () => {
   it("round-trips plain data spanning ≥2 tree levels", async () => {
     const { bee, target } = setup()
-    const data = makeData(TWO_LEVEL_LEAF_COUNT * CHUNK_SIZE)
+    const data = makeData(PLAIN_TWO_LEVEL_LEAF_COUNT * CHUNK_SIZE)
 
     const { reference } = await uploadData(target, data)
     expect(reference.length).toBe(PLAIN_REF_HEX_LEN)
@@ -68,7 +71,7 @@ describe("uploadData ↔ downloadDataWithChunkAPI (multi-level Merkle tree)", ()
 
   it("round-trips encrypted data spanning ≥2 tree levels", async () => {
     const { bee, target } = setup()
-    const data = makeData(TWO_LEVEL_LEAF_COUNT * CHUNK_SIZE)
+    const data = makeData(ENCRYPTED_TWO_LEVEL_LEAF_COUNT * CHUNK_SIZE)
 
     const { reference } = await uploadData(target, data, {
       encryptionKey: true,
@@ -80,12 +83,13 @@ describe("uploadData ↔ downloadDataWithChunkAPI (multi-level Merkle tree)", ()
   })
 
   it("round-trips encrypted data whose final intermediate batch holds a single ref", async () => {
-    // REFS_PER_CHUNK + 1 leaves ⇒ intermediate batches [REFS_PER_CHUNK], [1].
-    // The trailing single-ref batch is exactly the case the span fix passes
-    // through; without it the lone ref would be wrapped in a ghost
-    // intermediate whose ≤CHUNK_SIZE span the downloader misreads as a leaf.
+    // ENCRYPTED_REFS_PER_CHUNK + 1 leaves ⇒ intermediate batches
+    // [ENCRYPTED_REFS_PER_CHUNK], [1]. The trailing single-ref batch is
+    // exactly the case the span fix passes through; without it the lone ref
+    // would be wrapped in a ghost intermediate whose ≤CHUNK_SIZE span the
+    // downloader misreads as a leaf.
     const { bee, target } = setup()
-    const data = makeData(REFS_PER_CHUNK * CHUNK_SIZE + 1)
+    const data = makeData(ENCRYPTED_REFS_PER_CHUNK * CHUNK_SIZE + 1)
 
     const { reference } = await uploadData(target, data, {
       encryptionKey: true,

--- a/lib/src/proxy/upload.ts
+++ b/lib/src/proxy/upload.ts
@@ -32,7 +32,11 @@ import {
   type EncryptedChunk,
   DEFAULT_UPLOAD_CONCURRENCY,
 } from "../chunk"
-import { splitDataIntoChunks, CHUNK_SIZE, REFS_PER_CHUNK } from "./chunking"
+import {
+  splitDataIntoChunks,
+  CHUNK_SIZE,
+  PLAIN_REFS_PER_CHUNK,
+} from "./chunking"
 import { ENCRYPTED_REFS_PER_CHUNK } from "./chunking-encrypted"
 import { ChunkUploadStream } from "./chunk-upload-stream"
 import { marshalEnvelope } from "./stamp-marshal"
@@ -451,11 +455,20 @@ async function buildPlainMerkleTree(
 
   const intermediateRefs: ChunkReference[] = []
 
-  for (let i = 0; i < chunkRefs.length; i += REFS_PER_CHUNK) {
+  for (let i = 0; i < chunkRefs.length; i += PLAIN_REFS_PER_CHUNK) {
     const refs = chunkRefs.slice(
       i,
-      Math.min(i + REFS_PER_CHUNK, chunkRefs.length),
+      Math.min(i + PLAIN_REFS_PER_CHUNK, chunkRefs.length),
     )
+
+    // Pass through single-ref batches without wrapping in an intermediate
+    // (Bee's "carrier chunk" rule). A ghost intermediate with span ≤ 4096
+    // would be misidentified as a leaf by the download path's span-based
+    // leaf check.
+    if (refs.length === 1) {
+      intermediateRefs.push(refs[0])
+      continue
+    }
 
     // Build payload with 32-byte references
     const payload = new Uint8Array(refs.length * 32)

--- a/lib/test/integration/large-plain-upload.test.ts
+++ b/lib/test/integration/large-plain-upload.test.ts
@@ -19,9 +19,16 @@ const clusterReachable = await isClusterReachable()
 const MAX_CHUNK = 4096
 const PLAIN_FANOUT = 128
 
-function sequentialPayload(size: number): Uint8Array {
+/**
+ * Payload whose 4096-byte chunks are all DISTINCT (the `i >> 12` term shifts
+ * each chunk's byte pattern). A plain `i % 256` pattern repeats every 256
+ * bytes, making every full chunk identical — 129 copies of one address all
+ * stamp into the same postage bucket and overflow its 2^(depth-16) slots at
+ * the test stamp's depth 20.
+ */
+function distinctChunkPayload(size: number): Uint8Array {
   const data = new Uint8Array(size)
-  for (let i = 0; i < size; i++) data[i] = i % 256
+  for (let i = 0; i < size; i++) data[i] = (i * 3 + (i >> 12)) & 0xff
   return data
 }
 
@@ -49,7 +56,7 @@ describe.skipIf(!clusterReachable)(
         `Bee serves a ${size}-byte plain upload via /bytes`,
         { timeout: LARGE_UPLOAD_TIMEOUT_MS },
         async () => {
-          const data = sequentialPayload(size)
+          const data = distinctChunkPayload(size)
           const { reference } = await uploadData(target, data)
           const downloaded = (await bee.downloadData(reference)).toUint8Array()
           expect(downloaded.length).toBe(size)

--- a/lib/test/integration/large-plain-upload.test.ts
+++ b/lib/test/integration/large-plain-upload.test.ts
@@ -1,0 +1,61 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Integration test for plain uploads large enough to need 128-ref
+ * intermediate chunks (>512 KiB), read back through Bee's native /bytes
+ * API. This is the interop proof that our plain Merkle layout matches what
+ * a stock node builds and can traverse (#417): with the old 64-ref fanout
+ * Bee could not join these trees.
+ */
+
+import { describe, it, expect, beforeAll, inject } from "vitest"
+import type { Bee } from "@ethersphere/bee-js"
+import { uploadData, type UploadTarget } from "../../src/proxy/upload"
+import { isClusterReachable, createClusterContext } from "./cluster"
+
+const clusterReachable = await isClusterReachable()
+
+const MAX_CHUNK = 4096
+const PLAIN_FANOUT = 128
+
+function sequentialPayload(size: number): Uint8Array {
+  const data = new Uint8Array(size)
+  for (let i = 0; i < size; i++) data[i] = i % 256
+  return data
+}
+
+// 129 full chunks exercises the carrier-chunk promotion (a lone trailing
+// leaf is promoted, not wrapped); 130 adds a two-ref root over a full
+// 128-ref intermediate.
+const SIZES = [(PLAIN_FANOUT + 1) * MAX_CHUNK, (PLAIN_FANOUT + 2) * MAX_CHUNK]
+
+describe.skipIf(!clusterReachable)(
+  "Large plain upload read back via Bee /bytes",
+  () => {
+    let bee: Bee
+    let target: UploadTarget
+
+    beforeAll(() => {
+      ;({ bee, target } = createClusterContext(inject("clusterBatchId")))
+    })
+
+    // ~131 sequential single-chunk uploads per case; give slow CI headroom
+    // over the suite's default 60s.
+    const LARGE_UPLOAD_TIMEOUT_MS = 120_000
+
+    for (const size of SIZES) {
+      it(
+        `Bee serves a ${size}-byte plain upload via /bytes`,
+        { timeout: LARGE_UPLOAD_TIMEOUT_MS },
+        async () => {
+          const data = sequentialPayload(size)
+          const { reference } = await uploadData(target, data)
+          const downloaded = (await bee.downloadData(reference)).toUint8Array()
+          expect(downloaded.length).toBe(size)
+          expect(downloaded).toEqual(data)
+        },
+      )
+    }
+  },
+)


### PR DESCRIPTION
## Problem

`REFS_PER_CHUNK = 64` sized **plain** intermediate chunks by the **encrypted** ref width. Unencrypted refs are 32 bytes, so a 4096-byte intermediate holds **128** refs. Plain uploads beyond 64 leaf chunks (>256 KB) built trees that diverge from Bee's canonical layout: the same data gets a different address than a bee-js upload (dedup loss) and stock-node `/bytes` reads of our references break.

It was worse than address divergence: at leaf counts ≡ 1 (mod fanout) the lone trailing ref was wrapped in a single-ref intermediate whose ≤4096 span the downloader misreads as a leaf — those payload sizes didn't even round-trip through our own downloader.

## Fix

- Split the constant: `PLAIN_REFS_PER_CHUNK = 128` in the plain builders (`chunking.ts` `buildMerkleTree`, `upload.ts` `buildPlainMerkleTree`); `ENCRYPTED_REFS_PER_CHUNK = 64` unchanged for the encrypted path (64-byte refs).
- Both plain builders now promote a lone trailing ref to the next level (Bee's carrier-chunk rule), matching the encrypted path's existing pass-through.
- `estimateTotalChunks` (download progress) takes the per-path branching factor instead of hardcoding 64.

## Tests (TDD — red first, then the fix)

`upload.interop.test.ts` pins the layout to bee-js's canonical `MerkleTree` as an independent oracle:

- plain root reference equals the bee-js-computed reference for 3 / **65** / 128 / 129 / 130 full-chunk payloads and 128 chunks + 1 byte (65 is the filed >256 KB threshold; 129 and 128+1 exercise carrier promotion — every case >64 chunks failed before the fix)
- structural check: intermediates carry 128 refs with correct child spans
- a bee-js-**built** tree downloads through `downloadDataWithChunkAPI` with exact progress totals (pins the 128-ref estimate)
- encrypted guard: a 130-leaf encrypted tree still builds 64-ref intermediates and downloads with an exact 64-ref estimate

`test/integration/large-plain-upload.test.ts` (opt-in cluster suite, runs in the Integration Tests workflow): >512 KiB plain uploads read back through Bee's native `/bytes` API — the definitive stock-node interop check.

`pnpm check:all` passes; full lib suite 974/974.

Closes #417

🤖 Generated with [Claude Code](https://claude.com/claude-code)