### PR TITLE
fix(lib)!: accept non-ACT download options; remove dead protocol paths

### DIFF
--- a/docs-site/src/content/docs/api/index.mdx
+++ b/docs-site/src/content/docs/api/index.mdx
@@ -529,7 +529,6 @@ The data is uploaded using the authenticated user's postage stamp. Progress can 
 | `options.encrypt`               | `boolean`                | No       | Whether to encrypt the data (defaults to `false`)     |
 | `options.tag`                   | `number`                 | No       | Tag ID for tracking upload progress                   |
 | `options.deferred`              | `boolean`                | No       | Whether to use deferred upload (defaults to `false`)  |
-| `options.redundancyLevel`       | `0-4`                    | No       | Redundancy level for data availability                |
 | `options.onProgress`            | `(progress) => void`     | No       | Callback for tracking upload progress                 |
 | `requestOptions`                | `RequestOptions`         | No       | Request configuration                                 |
 | `requestOptions.timeout`        | `number`                 | No       | Request timeout in milliseconds                       |
@@ -1091,7 +1090,6 @@ Creates a sequential feed writer for updating and reading a topic. If `signer` i
 | `encrypt`         | `boolean`                    | No       | Whether to encrypt the data                                  |
 | `tag`             | `number`                     | No       | Tag ID for tracking upload progress                          |
 | `deferred`        | `boolean`                    | No       | Whether to use deferred upload                               |
-| `redundancyLevel` | `0-4`                        | No       | Redundancy level for data availability                       |
 
 **Example:**
 
@@ -1258,7 +1256,6 @@ The data is encrypted using ACT (Access Control Tries) and can only be downloade
 | `options.pin`                   | `boolean`                | No       | Whether to pin the data locally (defaults to `false`) |
 | `options.tag`                   | `number`                 | No       | Tag ID for tracking upload progress                   |
 | `options.deferred`              | `boolean`                | No       | Whether to use deferred upload (defaults to `false`)  |
-| `options.redundancyLevel`       | `0-4`                    | No       | Redundancy level for data availability                |
 | `options.onProgress`            | `(progress) => void`     | No       | Callback for tracking upload progress                 |
 | `requestOptions`                | `RequestOptions`         | No       | Request configuration                                 |
 | `requestOptions.timeout`        | `number`                 | No       | Request timeout in milliseconds                       |

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -255,7 +255,6 @@ export type {
 export type {
   ClientOptions,
   AuthStatus,
-  ButtonStyles,
   UploadResult,
   FileData,
   PostageBatch,
@@ -432,7 +431,6 @@ export {
   FileDataSchema,
   PostageBatchSchema,
   AuthStatusSchema,
-  ButtonStylesSchema,
   ParentToIframeMessageSchema,
   IframeToParentMessageSchema,
   PopupToIframeMessageSchema,

--- a/lib/src/swarm-id-client.test.ts
+++ b/lib/src/swarm-id-client.test.ts
@@ -246,6 +246,83 @@ describe("SwarmIdClient connectionInfo", () => {
   })
 })
 
+describe("SwarmIdClient request seam", () => {
+  let client: SwarmIdClient
+  let postMessage: ReturnType<typeof vi.fn>
+
+  // Deliver an iframe→parent message as if it passed the origin/source checks
+  const deliver = (message: unknown) =>
+    (client as never)["handleIframeMessage"](message)
+
+  const lastPostedMessage = () =>
+    postMessage.mock.calls[postMessage.mock.calls.length - 1][0]
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    vi.stubGlobal("window", {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      parent: { postMessage: vi.fn() },
+      location: { origin: "https://localhost" },
+      open: vi.fn(),
+    })
+    vi.stubGlobal("document", {
+      createElement: vi.fn().mockReturnValue({
+        style: {},
+        onload: null,
+        onerror: null,
+        src: "",
+        contentWindow: { postMessage: vi.fn() },
+      }),
+      body: { appendChild: vi.fn(), removeChild: vi.fn() },
+    })
+
+    client = new SwarmIdClient({
+      iframeOrigin: "https://swarm-id.example.com",
+      metadata: { name: "Test App", description: "A test application" },
+    })
+    postMessage = vi.fn()
+    ;(client as never)["ready"] = true
+    ;(client as never)["iframe"] = {
+      style: {},
+      contentWindow: { postMessage },
+    }
+  })
+
+  it("downloadData sends plain non-ACT options (#420)", async () => {
+    const reference = "a".repeat(64)
+    const data = new Uint8Array([1, 2, 3])
+
+    const promise = client.downloadData(reference, { timeoutMs: 5000 })
+
+    // The outgoing message passed the client's schema validation and was posted
+    expect(postMessage).toHaveBeenCalledTimes(1)
+    const sent = lastPostedMessage()
+    expect(sent).toMatchObject({
+      type: "downloadData",
+      reference,
+      options: { timeoutMs: 5000 },
+    })
+
+    deliver({ type: "downloadDataResponse", requestId: sent.requestId, data })
+    await expect(promise).resolves.toEqual(data)
+  })
+
+  it("getPostageBatch rejects on a proxy error message", async () => {
+    const promise = client.getPostageBatch()
+
+    const sent = lastPostedMessage()
+    expect(sent).toMatchObject({ type: "getPostageBatch" })
+
+    deliver({
+      type: "error",
+      requestId: sent.requestId,
+      error: "Bee node unreachable",
+    })
+    await expect(promise).rejects.toThrow("Bee node unreachable")
+  })
+})
+
 describe("SwarmIdClient init-timeout timers (#421)", () => {
   // A distinctive value so the init timers are identifiable by delay.
   const INIT_TIMEOUT = 12345

--- a/lib/src/swarm-id-client.ts
+++ b/lib/src/swarm-id-client.ts
@@ -780,15 +780,10 @@ export class SwarmIdClient {
       type: "getPostageBatchResponse"
       requestId: string
       postageBatch?: PostageBatch
-      error?: string
     }>({
       type: "getPostageBatch",
       requestId,
     })
-
-    if (response.error) {
-      throw new Error(response.error)
-    }
 
     return response.postageBatch
   }
@@ -1041,7 +1036,6 @@ export class SwarmIdClient {
    * @param options.encrypt - Whether to encrypt the data (defaults to false)
    * @param options.tag - Tag ID for tracking upload progress
    * @param options.deferred - Whether to use deferred upload (defaults to false)
-   * @param options.redundancyLevel - Redundancy level from 0-4 for data availability
    * @param options.onProgress - Optional callback for tracking upload progress
    * @param requestOptions - Optional request configuration (timeout, headers, endlesslyRetry)
    * @returns A promise resolving to the upload result
@@ -1200,7 +1194,6 @@ export class SwarmIdClient {
    * @param options.encrypt - Whether to encrypt the file (defaults to false)
    * @param options.tag - Tag ID for tracking upload progress
    * @param options.deferred - Whether to use deferred upload (defaults to false)
-   * @param options.redundancyLevel - Redundancy level from 0-4 for data availability
    * @param requestOptions - Optional request configuration (timeout, headers, endlesslyRetry)
    * @returns A promise resolving to the upload result
    * @returns return.reference - The Swarm reference (hash) of the uploaded file
@@ -1389,7 +1382,6 @@ export class SwarmIdClient {
    * @param options.encrypt - Whether to encrypt the chunk (defaults to false)
    * @param options.tag - Tag ID for tracking upload progress
    * @param options.deferred - Whether to use deferred upload (defaults to false)
-   * @param options.redundancyLevel - Redundancy level from 0-4 for data availability
    * @param requestOptions - Optional request configuration (timeout, headers, endlesslyRetry)
    * @returns A promise resolving to the upload result
    * @returns return.reference - The Swarm reference (hash) of the uploaded chunk
@@ -2825,7 +2817,6 @@ export class SwarmIdClient {
    * @param options.pin - Whether to pin the data locally (defaults to false)
    * @param options.tag - Tag ID for tracking upload progress
    * @param options.deferred - Whether to use deferred upload (defaults to false)
-   * @param options.redundancyLevel - Redundancy level from 0-4 for data availability
    * @param options.onProgress - Optional callback for tracking upload progress
    * @param requestOptions - Optional request configuration (timeout, headers, endlesslyRetry)
    * @returns A promise resolving to the ACT upload result

--- a/lib/src/swarm-id-proxy.test.ts
+++ b/lib/src/swarm-id-proxy.test.ts
@@ -113,3 +113,58 @@ describe("SwarmIdProxy parentIdentify security (#410)", () => {
     })
   })
 })
+
+describe("SwarmIdProxy initialization failure (#420)", () => {
+  let parentWindow: { postMessage: ReturnType<typeof vi.fn> }
+  let messageListener: MessageListener
+  let proxy: SwarmIdProxy
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+
+    parentWindow = { postMessage: vi.fn() }
+
+    const listeners: Record<string, unknown> = {}
+    const mockWindow = {
+      addEventListener: vi.fn((type: string, listener: unknown) => {
+        listeners[type] = listener
+      }),
+      removeEventListener: vi.fn(),
+      parent: parentWindow,
+      location: { origin: "https://id.example.com" },
+    }
+    vi.stubGlobal("window", mockWindow)
+
+    proxy = new SwarmIdProxy()
+    messageListener = listeners["message"] as MessageListener
+  })
+
+  const messagesOfType = (type: string) =>
+    parentWindow.postMessage.mock.calls.filter(
+      ([message]) => message?.type === type,
+    )
+
+  it("sends initError to the parent when parentIdentify handling throws", async () => {
+    vi.spyOn(proxy as never, "loadAuthData").mockRejectedValue(
+      new Error("storage exploded"),
+    )
+
+    await messageListener({
+      data: {
+        type: "parentIdentify",
+        requestId: "r1",
+        metadata: { name: "Test App" },
+      },
+      origin: PARENT_ORIGIN,
+      source: parentWindow,
+    } as MessageEvent)
+
+    expect(messagesOfType("proxyReady")).toHaveLength(0)
+    const initErrors = messagesOfType("initError")
+    expect(initErrors).toHaveLength(1)
+    expect(initErrors[0][0]).toMatchObject({
+      type: "initError",
+      error: "storage exploded",
+    })
+  })
+})

--- a/lib/src/swarm-id-proxy.ts
+++ b/lib/src/swarm-id-proxy.ts
@@ -5,7 +5,6 @@ import type {
   ParentToIframeMessage,
   ParentIdentifyMessage,
   IframeToParentMessage,
-  ButtonStyles,
   ButtonConfig,
   UploadDataMessage,
   DownloadDataMessage,
@@ -231,7 +230,6 @@ export class SwarmIdProxy {
   private gnosisRpcUrl: string
   private postageStampContractAddress: string
   private authButtonContainer: HTMLElement | undefined
-  private currentStyles: ButtonStyles | undefined
   private buttonConfig: ButtonConfig | undefined
   private popupMode: "popup" | "window" = "window"
   private appMetadata: AppMetadata | undefined
@@ -878,7 +876,18 @@ export class SwarmIdProxy {
           console.warn("[Proxy] Invalid parentIdentify message:", result.error)
           return
         }
-        await this.handleParentIdentify(result.data, event)
+        try {
+          await this.handleParentIdentify(result.data, event)
+        } catch (error) {
+          // Without this the parent never hears back and its initialize()
+          // hangs until the initialization timeout.
+          console.error("[Proxy] Initialization failed:", error)
+          this.postMessage(event, {
+            type: "initError",
+            error:
+              error instanceof Error ? error.message : "Initialization failed",
+          })
+        }
         return
       }
 
@@ -903,16 +912,6 @@ export class SwarmIdProxy {
           "[Proxy] Rejected message from unauthorized origin:",
           event.origin,
         )
-        return
-      }
-
-      // Handle setButtonStyles message (UI-only, not in schema)
-      if (type === "setButtonStyles") {
-        this.currentStyles = event.data.styles
-        // Re-render button if not authenticated
-        if (!this.authenticated && this.authButtonContainer) {
-          this.showAuthButton()
-        }
         return
       }
 
@@ -1922,9 +1921,6 @@ export class SwarmIdProxy {
       button.textContent = connectText
     }
 
-    // Apply styles from currentStyles (for backward compat) and buttonConfig
-    const styles = this.currentStyles || {}
-
     // Make button fill container
     button.style.width = "100%"
     button.style.height = "100%"
@@ -1936,22 +1932,19 @@ export class SwarmIdProxy {
       button.style.backgroundColor = "#999"
       button.style.cursor = "default"
     } else if (isAuthenticated) {
-      // Different color for disconnect button (use default gray unless overridden)
+      // Different color for disconnect button
       button.style.backgroundColor = "#666"
-      button.style.cursor = styles.cursor || "pointer"
+      button.style.cursor = "pointer"
     } else {
-      // Use buttonConfig colors, then fall back to currentStyles, then defaults
-      button.style.backgroundColor =
-        config.backgroundColor || styles.backgroundColor || "#dd7200"
-      button.style.cursor = styles.cursor || "pointer"
+      button.style.backgroundColor = config.backgroundColor || "#dd7200"
+      button.style.cursor = "pointer"
     }
-    button.style.color = config.color || styles.color || "white"
-    button.style.border = styles.border || "none"
-    button.style.borderRadius =
-      config.borderRadius || styles.borderRadius || "0"
-    button.style.padding = styles.padding || "0"
-    button.style.fontSize = styles.fontSize || "14px"
-    button.style.fontWeight = styles.fontWeight || "600"
+    button.style.color = config.color || "white"
+    button.style.border = "none"
+    button.style.borderRadius = config.borderRadius || "0"
+    button.style.padding = "0"
+    button.style.fontSize = "14px"
+    button.style.fontWeight = "600"
 
     // Click handler
     button.addEventListener("click", () => {

--- a/lib/src/types.test.ts
+++ b/lib/src/types.test.ts
@@ -1,0 +1,61 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, it, expect } from "vitest"
+
+import { DownloadOptionsSchema, ParentToIframeMessageSchema } from "./types"
+
+const REFERENCE = "a".repeat(64)
+
+describe("DownloadOptionsSchema (#420)", () => {
+  it("accepts plain non-ACT options", () => {
+    const options = { timeoutMs: 5000 }
+
+    const parsed = DownloadOptionsSchema.parse(options)
+
+    expect(parsed).toEqual(options)
+  })
+
+  it("accepts an empty options object", () => {
+    expect(DownloadOptionsSchema.parse({})).toEqual({})
+  })
+
+  it("accepts omitted options", () => {
+    expect(DownloadOptionsSchema.parse(undefined)).toBeUndefined()
+  })
+
+  it("round-trips the full ACT option set", () => {
+    const options = {
+      redundancyStrategy: 1 as const,
+      fallback: true,
+      timeoutMs: 5000,
+      actPublisher: "02".padEnd(66, "ab"),
+      actHistoryAddress: REFERENCE,
+      actTimestamp: 1,
+    }
+
+    const parsed = DownloadOptionsSchema.parse(options)
+
+    expect(parsed).toEqual(options)
+  })
+})
+
+describe("download messages with plain options (#420)", () => {
+  const messages = [
+    { type: "downloadData", requestId: "r1", reference: REFERENCE },
+    { type: "downloadFile", requestId: "r2", reference: REFERENCE },
+    { type: "downloadChunk", requestId: "r3", reference: REFERENCE },
+  ]
+
+  it.each(messages)("$type validates with non-ACT options", (message) => {
+    const parsed = ParentToIframeMessageSchema.parse({
+      ...message,
+      options: { timeoutMs: 5000 },
+    })
+
+    expect(parsed).toMatchObject({
+      type: message.type,
+      options: { timeoutMs: 5000 },
+    })
+  })
+})

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -72,7 +72,6 @@ const UploadOptionsObjectSchema = z.object({
   encryptManifest: z.boolean().optional(),
   tag: z.number().optional(),
   deferred: z.boolean().optional(),
-  redundancyLevel: z.number().min(0).max(4).optional(),
 })
 
 export const UploadOptionsSchema = UploadOptionsObjectSchema.optional()
@@ -96,9 +95,11 @@ export const DownloadOptionsSchema = z
       .optional(),
     fallback: z.boolean().optional(),
     timeoutMs: z.number().optional(),
-    actPublisher: z.union([z.instanceof(Uint8Array), z.string()]),
-    actHistoryAddress: z.union([z.instanceof(Uint8Array), z.string()]),
-    actTimestamp: z.union([z.number(), z.string()]),
+    actPublisher: z.union([z.instanceof(Uint8Array), z.string()]).optional(),
+    actHistoryAddress: z
+      .union([z.instanceof(Uint8Array), z.string()])
+      .optional(),
+    actTimestamp: z.union([z.number(), z.string()]).optional(),
   })
   .optional()
 
@@ -113,7 +114,6 @@ export interface UploadOptions {
   encryptManifest?: boolean
   tag?: number
   deferred?: boolean
-  redundancyLevel?: number
   onProgress?: (progress: UploadProgress) => void
   /** Use WebSocket for chunk upload instead of HTTP. Per-chunk stamping is used. */
   useWebSocket?: boolean
@@ -600,28 +600,6 @@ export const ConnectionInfoSchema = z.object({
 })
 
 export type ConnectionInfo = z.infer<typeof ConnectionInfoSchema>
-
-// ============================================================================
-// Button Styles
-// ============================================================================
-
-export const ButtonStylesSchema = z
-  .object({
-    backgroundColor: z.string().optional(),
-    color: z.string().optional(),
-    border: z.string().optional(),
-    borderRadius: z.string().optional(),
-    padding: z.string().optional(),
-    fontSize: z.string().optional(),
-    fontFamily: z.string().optional(),
-    fontWeight: z.string().optional(),
-    cursor: z.string().optional(),
-    width: z.string().optional(),
-    height: z.string().optional(),
-  })
-  .optional()
-
-export type ButtonStyles = z.infer<typeof ButtonStylesSchema>
 
 // ============================================================================
 // App Metadata
@@ -1459,7 +1437,6 @@ export const GetPostageBatchResponseMessageSchema = z.object({
   type: z.literal("getPostageBatchResponse"),
   requestId: z.string(),
   postageBatch: PostageBatchSchema.optional(),
-  error: z.string().optional(),
 })
 
 export const IframeToParentMessageSchema = z.discriminatedUnion("type", [


### PR DESCRIPTION
## Problem

`DownloadOptionsSchema` made `actPublisher`/`actHistoryAddress`/`actTimestamp` required, so the documented non-ACT calls — e.g. `downloadData(ref, { timeoutMs: 5000 })` — failed the client's outgoing Zod validation with "Invalid message format". The same schema gates `downloadFile` and `downloadChunk`, so plain options were unusable on all three paths.

## Changes

- **`DownloadOptionsSchema`**: the three ACT fields are now `.optional()`, mirroring bee-js `DownloadOptions` (which `handleDownloadChunk` forwards into `bee.downloadChunk`). TDD: schema round-trip tests plus a client-seam test that `downloadData(ref, { timeoutMs })` passes validation and resolves.
- **`initError` wired up**: previously schema'd and handled by the client but never sent. A throw during `parentIdentify` handling (e.g. corrupted storage in `loadAuthData`) now posts `initError` to the parent, so `initialize()` rejects with the real error instead of hanging until the initialization timeout. Covered by a proxy test.
- **`redundancyLevel` removed** from `UploadOptions` schema/interface, JSDoc, and docs-site tables: no proxy handler ever forwarded it. Uploads go through client-side chunking and per-chunk/SOC endpoints, so bee-side erasure coding never applies — deleting is the honest option.
- **`setButtonStyles` handler removed** (with the `ButtonStyles` schema/type and always-empty `currentStyles` fallback): nothing ever sent that message; button styling comes from `buttonConfig`.
- **`GetPostageBatchResponse.error` removed** along with the client's dead check: the proxy never set it — failures already arrive via the generic `error` message (regression-guarded by a new client test).

## Breaking changes

- `UploadOptions` no longer accepts `redundancyLevel` (TS consumers passing it will need to drop it — it was always a no-op).
- `ButtonStyles` / `ButtonStylesSchema` are no longer exported from `@snaha/swarm-id` (nothing could ever send `setButtonStyles`; use `buttonConfig`).

Intentional removals rather than deprecation: both surfaces were validated-but-ignored no-ops, so keeping them would keep the lie alive.

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)
