### PR TITLE
refactor(ui): extract attempt guard for ceremony supersession

### DIFF
--- a/.claude/rules/attempt-guard.md
+++ b/.claude/rules/attempt-guard.md
@@ -1,0 +1,22 @@
+---
+paths:
+  - 'ui/**'
+---
+
+# Cancellable Async Flows: Attempt Guard
+
+Use the attempt guard (`ui/src/lib/attempt.ts`) for any ceremony or dialog flow the user can
+cancel, retry, or navigate away from — never hand-roll `myAttempt`/counter staleness checks
+(a forgotten post-await re-check caused #423).
+
+- `attempts.begin()` starts an attempt, superseding the one in flight; `attempts.supersede()`
+  invalidates without starting one (cancel/close/leave).
+- Route every await that precedes a side effect through `attempt.guard(work, onDiscard?)` — it
+  throws `SupersededError` once the attempt is stale, so a stale continuation cannot apply side
+  effects. `onDiscard` destroys material that must not leak past a cancel (e.g. zero a decrypted
+  seed).
+- Gate catch/finally blocks and callbacks on `attempt.current`. `SupersededError` is only ever
+  thrown once `current` is false, so `current`-gated catch blocks swallow it automatically — no
+  instanceof checks.
+- Awaits that must complete even after a cancel (e.g. an on-chain spend whose record must land)
+  deliberately stay outside the guard, with a comment saying so.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,15 +120,6 @@ Authentication uses storage events: popup writes to localStorage → storage eve
   armed and leaks its handle. `withTimeout(work, ms, message)` clears the timer and rejects with
   `TimeoutError`, so discriminate timeouts with `instanceof TimeoutError`, not by message.
   `rejectAfter` is deprecated and kept only for the public API.
-- **Cancellable async flows in `ui/`: use the attempt guard** (`ui/src/lib/attempt.ts`) — never
-  hand-roll `myAttempt`/counter staleness checks; a forgotten post-await re-check caused #423.
-  `attempts.begin()` starts an attempt (superseding the one in flight); route every await that
-  precedes a side effect through `attempt.guard(work, onDiscard?)`, which throws
-  `SupersededError` once cancelled/retried/superseded (`onDiscard` destroys secrets, e.g. zeroing
-  a decrypted seed); gate catch/finally blocks and callbacks on `attempt.current`; and call
-  `attempts.supersede()` on cancel/close/leave. Awaits that must complete even after a cancel
-  (e.g. an on-chain spend whose record must land) deliberately stay outside the guard, with a
-  comment saying so.
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,15 @@ Authentication uses storage events: popup writes to localStorage → storage eve
   armed and leaks its handle. `withTimeout(work, ms, message)` clears the timer and rejects with
   `TimeoutError`, so discriminate timeouts with `instanceof TimeoutError`, not by message.
   `rejectAfter` is deprecated and kept only for the public API.
+- **Cancellable async flows in `ui/`: use the attempt guard** (`ui/src/lib/attempt.ts`) — never
+  hand-roll `myAttempt`/counter staleness checks; a forgotten post-await re-check caused #423.
+  `attempts.begin()` starts an attempt (superseding the one in flight); route every await that
+  precedes a side effect through `attempt.guard(work, onDiscard?)`, which throws
+  `SupersededError` once cancelled/retried/superseded (`onDiscard` destroys secrets, e.g. zeroing
+  a decrypted seed); gate catch/finally blocks and callbacks on `attempt.current`; and call
+  `attempts.supersede()` on cancel/close/leave. Awaits that must complete even after a cancel
+  (e.g. an on-chain spend whose record must land) deliberately stay outside the guard, with a
+  comment saying so.
 
 ## Testing
 

--- a/ui/src/lib/attempt.test.ts
+++ b/ui/src/lib/attempt.test.ts
@@ -1,0 +1,110 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+import { describe, expect, it, vi } from 'vitest'
+
+import { SupersededError, createAttemptTracker } from './attempt'
+
+// A promise settled manually by the test — models a ceremony in flight while
+// the user clicks cancel or retry.
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (reason: Error) => void
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+  return { promise, resolve, reject }
+}
+
+describe('createAttemptTracker', () => {
+  it('resolves guarded work while the attempt is current', async () => {
+    const attempt = createAttemptTracker().begin()
+
+    await expect(attempt.guard(Promise.resolve('seed'))).resolves.toBe('seed')
+    expect(attempt.current).toBe(true)
+  })
+
+  it('supports several guarded stages within one attempt', async () => {
+    const attempt = createAttemptTracker().begin()
+
+    expect(await attempt.guard(Promise.resolve(1))).toBe(1)
+    expect(await attempt.guard(Promise.resolve(2))).toBe(2)
+  })
+
+  it('throws SupersededError when superseded while the work ran', async () => {
+    const attempts = createAttemptTracker()
+    const attempt = attempts.begin()
+    const work = deferred<string>()
+    const guarded = attempt.guard(work.promise)
+
+    attempts.supersede()
+    work.resolve('seed')
+
+    await expect(guarded).rejects.toBeInstanceOf(SupersededError)
+    expect(attempt.current).toBe(false)
+  })
+
+  it('beginning a new attempt supersedes the one in flight', async () => {
+    const attempts = createAttemptTracker()
+    const stale = attempts.begin()
+    const work = deferred<string>()
+    const guarded = stale.guard(work.promise)
+
+    const retry = attempts.begin()
+    work.resolve('seed')
+
+    await expect(guarded).rejects.toBeInstanceOf(SupersededError)
+    expect(stale.current).toBe(false)
+    expect(retry.current).toBe(true)
+    await expect(retry.guard(Promise.resolve('fresh'))).resolves.toBe('fresh')
+  })
+
+  it('runs onDiscard on the resolved value only when superseded', async () => {
+    const attempts = createAttemptTracker()
+    const attempt = attempts.begin()
+    const onDiscard = vi.fn()
+
+    await attempt.guard(Promise.resolve('kept'), onDiscard)
+    expect(onDiscard).not.toHaveBeenCalled()
+
+    const work = deferred<string>()
+    const guarded = attempt.guard(work.promise, onDiscard)
+    attempts.supersede()
+    work.resolve('discarded')
+
+    await expect(guarded).rejects.toBeInstanceOf(SupersededError)
+    expect(onDiscard).toHaveBeenCalledExactlyOnceWith('discarded')
+  })
+
+  it('propagates a rejection unchanged and never discards', async () => {
+    const attempts = createAttemptTracker()
+    const attempt = attempts.begin()
+    const onDiscard = vi.fn()
+    const failure = new Error('ceremony failed')
+    const work = deferred<string>()
+    const guarded = attempt.guard(work.promise, onDiscard)
+
+    attempts.supersede()
+    work.reject(failure)
+
+    await expect(guarded).rejects.toBe(failure)
+    expect(onDiscard).not.toHaveBeenCalled()
+  })
+
+  it('SupersededError is only thrown once current is false', async () => {
+    // Catch blocks gate on `attempt.current` instead of instanceof checks —
+    // that only swallows the error if the two can never disagree.
+    const attempts = createAttemptTracker()
+    const attempt = attempts.begin()
+    const work = deferred<string>()
+    const guarded = attempt.guard(work.promise)
+
+    attempts.supersede()
+    work.resolve('seed')
+
+    await guarded.catch((caught: unknown) => {
+      expect(caught).toBeInstanceOf(SupersededError)
+      expect(attempt.current).toBe(false)
+    })
+  })
+})

--- a/ui/src/lib/attempt.ts
+++ b/ui/src/lib/attempt.ts
@@ -1,0 +1,94 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Supersedable attempts: only the latest attempt may act on its results.
+ *
+ * Ceremony handlers (passkey/wallet/password prompts and the async work that
+ * follows) must not apply side effects once the user cancelled, retried, or
+ * left the page. The hand-rolled `myAttempt !== attempt` counter idiom relied
+ * on remembering a re-check after every await — forgetting one caused #423.
+ * This helper makes the check structural: route every await through
+ * `attempt.guard(...)` and stale continuations throw instead of proceeding.
+ *
+ * Usage:
+ *
+ *   const attempts = createAttemptTracker()
+ *
+ *   async function confirm() {
+ *     const attempt = attempts.begin()
+ *     try {
+ *       const key = await attempt.guard(ceremony())
+ *       applySideEffects(key)
+ *     } catch (caught) {
+ *       if (attempt.current) {
+ *         error = message(caught)
+ *       }
+ *     }
+ *   }
+ *
+ *   function cancel() {
+ *     attempts.supersede()
+ *   }
+ *
+ * `guard` does not cancel the underlying work — like the counter it replaces,
+ * it discards the result once the work settles (pass `onDiscard` to e.g. zero
+ * a decrypted seed). Deliberately awaiting OUTSIDE the guard is the escape
+ * hatch for work that must complete and be recorded even after a cancel, such
+ * as an on-chain spend.
+ */
+
+/**
+ * Thrown by `Attempt.guard` when the attempt was superseded while its work ran.
+ * It is only ever thrown once `current` is false, so catch blocks gated on
+ * `attempt.current` swallow it without needing an instanceof check.
+ */
+export class SupersededError extends Error {
+  constructor() {
+    super('Attempt superseded by cancel, retry, or leaving the page')
+    this.name = 'SupersededError'
+  }
+}
+
+export interface Attempt {
+  /** True while no newer attempt (begin) or cancel (supersede) replaced this one. */
+  readonly current: boolean
+  /**
+   * Resolve `work`, then throw `SupersededError` if this attempt is no longer
+   * current. `onDiscard` runs on the resolved value before the throw — use it
+   * to destroy material that must not leak past a cancel (e.g. zero a seed).
+   * A rejection of `work` propagates unchanged and never invokes `onDiscard`.
+   */
+  guard<T>(work: Promise<T>, onDiscard?: (value: T) => void): Promise<T>
+}
+
+export interface AttemptTracker {
+  /** Start a new attempt, superseding any attempt currently in flight. */
+  begin(): Attempt
+  /** Invalidate all in-flight attempts without starting a new one (cancel/close/leave). */
+  supersede(): void
+}
+
+export function createAttemptTracker(): AttemptTracker {
+  let latest = 0
+  return {
+    begin(): Attempt {
+      const mine = ++latest
+      return {
+        get current() {
+          return mine === latest
+        },
+        async guard<T>(work: Promise<T>, onDiscard?: (value: T) => void): Promise<T> {
+          const value = await work
+          if (mine !== latest) {
+            onDiscard?.(value)
+            throw new SupersededError()
+          }
+          return value
+        },
+      }
+    },
+    supersede() {
+      latest++
+    },
+  }
+}

--- a/ui/src/lib/components/drive-add-dialog.svelte
+++ b/ui/src/lib/components/drive-add-dialog.svelte
@@ -11,6 +11,7 @@
   import TriangleAlert from '@lucide/svelte/icons/triangle-alert'
   import { BatchIdSchema, PrivateKeySchema } from '@snaha/swarm-id'
 
+  import { createAttemptTracker } from '$lib/attempt'
   import DriveDialogStatus from '$lib/components/drive-dialog-status.svelte'
   import { Button } from '$lib/components/ui/button'
   import { Dialog } from '$lib/components/ui/dialog'
@@ -66,8 +67,8 @@
   let errorMessage = $state('')
 
   let currentPrice = $state<bigint | undefined>(undefined)
-  // Bumped on cancel/close so a late ceremony or widget callback can't complete.
-  let attempt = 0
+  // Superseded on cancel/close so a late ceremony or widget callback can't complete.
+  const attempts = createAttemptTracker()
   // In-flight widget purchase; cancelled on close so the popup can't settle a
   // payment we would silently drop.
   let purchase: StampPurchaseHandle | undefined
@@ -133,7 +134,7 @@
   })
 
   function close() {
-    attempt++
+    attempts.supersede()
     purchase?.cancel()
     purchase = undefined
     onClose()
@@ -156,7 +157,7 @@
   }
 
   async function purchaseNew() {
-    const myAttempt = ++attempt
+    const attempt = attempts.begin()
     phase = 'pending'
     // The popup-less /dev mock settles locally — telling the user to look for a
     // popup window there is wrong.
@@ -168,12 +169,11 @@
     // batch-ID-derived label.
     const driveName = name.trim() || undefined
     try {
-      const { signerKey, destination } = await derivePostageSigner(account.derivationKey)
       // The user may have cancelled during the derivation — bail before the
       // popup opens, or a payment window would appear after they backed out.
-      if (myAttempt !== attempt) {
-        return
-      }
+      const { signerKey, destination } = await attempt.guard(
+        derivePostageSigner(account.derivationKey),
+      )
       purchase = openStampPurchaseWidget({
         destination,
         // /dev mock (see dev-settings): simulate the purchase without a real
@@ -182,7 +182,7 @@
         mockPopup: devSettingsStore.data.mockStampPopup,
         mockError: devSettingsStore.data.mockStampResult === 'error',
         onSuccess: (batch) => {
-          if (myAttempt !== attempt) {
+          if (!attempt.current) {
             return
           }
           // The size/lifespan actually bought are chosen INSIDE the widget —
@@ -197,25 +197,25 @@
           succeed()
         },
         onError: (error) => {
-          if (myAttempt !== attempt) {
+          if (!attempt.current) {
             return
           }
           errorMessage = error.message
           phase = 'error'
         },
         onCancel: () => {
-          if (myAttempt === attempt) {
+          if (attempt.current) {
             phase = 'form'
           }
         },
         onUnconfirmedClose: () => {
-          if (myAttempt === attempt) {
+          if (attempt.current) {
             phase = 'unconfirmed'
           }
         },
       })
     } catch (caught) {
-      if (myAttempt !== attempt) {
+      if (!attempt.current) {
         return
       }
       errorMessage = caught instanceof Error ? caught.message : 'Could not start the purchase.'
@@ -224,7 +224,7 @@
   }
 
   async function attachExisting() {
-    const myAttempt = ++attempt
+    const attempt = attempts.begin()
     phase = 'pending'
     pendingLabel = 'Looking up the batch…'
     const driveName = name.trim() || undefined
@@ -233,14 +233,13 @@
       // this account's signer from its (plaintext) derivation key.
       const signerKey = pastedSignerKey
         ? new PrivateKey(strip0x(pastedSignerKey))
-        : (await derivePostageSigner(account.derivationKey)).signerKey
+        : (await attempt.guard(derivePostageSigner(account.derivationKey))).signerKey
       // Read the batch straight from the PostageStamp contract on-chain, not the
       // Bee node — a public gateway has no /stamps and won't know a batch bought
       // independently of it.
-      const stamp = await fetchExistingBatchFromChain(batchIdInput.trim(), signerKey, driveName)
-      if (myAttempt !== attempt) {
-        return
-      }
+      const stamp = await attempt.guard(
+        fetchExistingBatchFromChain(batchIdInput.trim(), signerKey, driveName),
+      )
       if (!stamp) {
         errorMessage =
           'Couldn’t find that batch on chain. Check the Batch ID, or the Gnosis RPC endpoint in Network settings.'
@@ -250,10 +249,9 @@
       // Existence isn't enough — upload one stamped test chunk to prove the
       // signer key can actually stamp uploads for this batch before attaching.
       pendingLabel = 'Verifying the batch…'
-      const stampable = await verifyBatchStampable(stamp.batchID, signerKey, stamp.depth)
-      if (myAttempt !== attempt) {
-        return
-      }
+      const stampable = await attempt.guard(
+        verifyBatchStampable(stamp.batchID, signerKey, stamp.depth),
+      )
       if (!stampable) {
         errorMessage =
           'That batch exists, but this signer key can’t stamp uploads for it. Check the signer key.'
@@ -263,7 +261,7 @@
       account.addStamp(stamp)
       succeed()
     } catch (caught) {
-      if (myAttempt !== attempt) {
+      if (!attempt.current) {
         return
       }
       errorMessage = caught instanceof Error ? caught.message : 'Could not add the drive.'

--- a/ui/src/lib/components/drive-extend-dialog.svelte
+++ b/ui/src/lib/components/drive-extend-dialog.svelte
@@ -9,6 +9,7 @@
   import Plus from '@lucide/svelte/icons/plus'
   import type { PostageStamp } from '@snaha/swarm-id'
 
+  import { createAttemptTracker } from '$lib/attempt'
   import DriveDialogStatus from '$lib/components/drive-dialog-status.svelte'
   import { Button } from '$lib/components/ui/button'
   import { Dialog } from '$lib/components/ui/dialog'
@@ -44,7 +45,7 @@
   let phase = $state<Phase>('form')
   let errorMessage = $state('')
   let currentPrice = $state<bigint | undefined>(undefined)
-  let attempt = 0
+  const attempts = createAttemptTracker()
 
   const addedSeconds = $derived(lifespanToSeconds(Number(count), unit))
 
@@ -76,7 +77,7 @@
   }
 
   function close() {
-    attempt++
+    attempts.supersede()
     onClose()
   }
 
@@ -84,29 +85,33 @@
     if (!changed) {
       return
     }
-    const myAttempt = ++attempt
+    const attempt = attempts.begin()
     phase = 'pending'
     errorMessage = ''
     try {
-      const price = (currentPrice ??= await currentChainPrice())
+      // Guarded: closing during the price fetch must not go on to spend.
+      const price = (currentPrice ??= await attempt.guard(currentChainPrice()))
       const topUpAmount = stampAmountForSeconds(price, addedSeconds)
       // The drive may have been removed meanwhile (another tab, a sync fold) —
       // check before spending on the node against a record we'd never show.
       if (!account.hasLiveStamp(drive.batchID)) {
         throw new Error('This drive was removed in the meantime.')
       }
+      // Deliberately unguarded from here: once the top-up is sent the money is
+      // spent, so the record update must land even if the dialog was closed —
+      // only the UI epilogue below is skipped for a superseded attempt.
       await topUpStamp(drive.batchID.toHex(), topUpAmount)
       account.updateStamp(
         drive.batchID,
         extendedStamp(drive, addedSeconds, topUpAmount, remainingLifespanSeconds(drive)),
       )
-      if (myAttempt !== attempt) {
+      if (!attempt.current) {
         return
       }
       onUpdated?.('Lifespan extended')
       close()
     } catch (caught) {
-      if (myAttempt !== attempt) {
+      if (!attempt.current) {
         return
       }
       errorMessage = caught instanceof Error ? caught.message : 'Could not extend the lifespan.'

--- a/ui/src/lib/components/drive-resize-dialog.svelte
+++ b/ui/src/lib/components/drive-resize-dialog.svelte
@@ -9,6 +9,7 @@
   import Info from '@lucide/svelte/icons/info'
   import type { PostageStamp } from '@snaha/swarm-id'
 
+  import { createAttemptTracker } from '$lib/attempt'
   import DriveDialogStatus from '$lib/components/drive-dialog-status.svelte'
   import { Button } from '$lib/components/ui/button'
   import { Dialog } from '$lib/components/ui/dialog'
@@ -36,7 +37,7 @@
   let keepLifespan = $state(true)
   let phase = $state<Phase>('form')
   let errorMessage = $state('')
-  let attempt = 0
+  const attempts = createAttemptTracker()
   // Set once the dilute has landed on-chain: dilute and top-up are two separate
   // node transactions, so a failed top-up must NOT re-run the dilute on retry
   // (the node rejects a dilution to the batch's now-current depth). While set,
@@ -92,7 +93,7 @@
   })
 
   function close() {
-    attempt++
+    attempts.supersede()
     onClose()
   }
 
@@ -103,9 +104,12 @@
     if (!active) {
       return
     }
-    const myAttempt = ++attempt
+    const attempt = attempts.begin()
     phase = 'pending'
     errorMessage = ''
+    // Deliberately no guards on the awaits below: dilute and top-up are
+    // on-chain spends whose record updates must land even if the dialog was
+    // closed mid-flight — only the UI epilogue is skipped when superseded.
     try {
       const batchId = drive.batchID.toHex()
       if (!committedPlan) {
@@ -125,13 +129,13 @@
         await topUpStamp(batchId, active.topUpAmount)
         account.updateStamp(drive.batchID, active.afterTopUp)
       }
-      if (myAttempt !== attempt) {
+      if (!attempt.current) {
         return
       }
       onUpdated?.('Drive size increased')
       close()
     } catch (caught) {
-      if (myAttempt !== attempt) {
+      if (!attempt.current) {
         return
       }
       errorMessage = caught instanceof Error ? caught.message : 'Could not increase the size.'

--- a/ui/src/lib/components/home-account.svelte
+++ b/ui/src/lib/components/home-account.svelte
@@ -22,6 +22,7 @@
   import Wallet from '@lucide/svelte/icons/wallet'
   import type { AccessMethod } from '@snaha/swarm-id'
 
+  import { createAttemptTracker } from '$lib/attempt'
   import DeleteAccountDialog from '$lib/components/delete-account-dialog.svelte'
   import DriveAddDialog from '$lib/components/drive-add-dialog.svelte'
   import NewPasswordFields, { isNewPasswordValid } from '$lib/components/new-password-fields.svelte'
@@ -83,8 +84,8 @@
   let setMethodDialog = $state<'form' | 'pending' | undefined>(undefined)
   let dialogError = $state<string | undefined>(undefined)
   let busy = $state(false)
-  /** Bumped on cancel/retry — a stale ceremony resolution must not complete. */
-  let attempt = 0
+  /** Cancel/retry supersedes the in-flight ceremony — it must not complete. */
+  const attempts = createAttemptTracker()
   let abortController: AbortController | undefined
 
   let newMethod = $state('passkey')
@@ -178,7 +179,7 @@
   function closeSetMethod() {
     // Invalidate any in-flight ceremony — wallet prompts can't be aborted, so
     // a later approval of a cancelled prompt must not complete.
-    attempt++
+    attempts.supersede()
     abortController?.abort()
     changeMethodSeed?.fill(0)
     changeMethodSeed = undefined
@@ -193,7 +194,7 @@
     if (busy || setMethodDialog === undefined || !changeMethodSeed) {
       return
     }
-    const myAttempt = ++attempt
+    const attempt = attempts.begin()
     dialogError = undefined
     busy = true
     if (newMethod !== 'password') {
@@ -201,24 +202,27 @@
     }
     try {
       abortController = newMethod === 'passkey' ? new AbortController() : undefined
-      const { access: newAccess, key } = await createAccess(newMethod, {
-        accountName: account.name,
-        password: newPassword,
-        signal: abortController?.signal,
-      })
-      if (myAttempt !== attempt) {
-        return
-      }
+      const { access: newAccess, key } = await attempt.guard(
+        createAccess(newMethod, {
+          accountName: account.name,
+          password: newPassword,
+          signal: abortController?.signal,
+        }),
+      )
+      // Guarded too: cancelling while the seed re-encrypts must not go on to
+      // `setAccess` — the superseded attempt leaves the held seed alone, since
+      // closeSetMethod owns destroying it and a retry's seed lives in the same
+      // variable.
+      const encryptedSeed = await attempt.guard(encryptSeed(changeMethodSeed, key))
       if (account.isSignedOut) {
         // Signed out mid-ceremony (e.g. cross-tab): `setAccess` would re-arm
         // the vault the sign-out just wiped. This is the live attempt, so the
-        // held seed is ours to destroy — a superseded attempt must NOT touch
-        // it, since a retry's seed lives in the same variable.
+        // held seed is ours to destroy.
         changeMethodSeed.fill(0)
         changeMethodSeed = undefined
         return
       }
-      account.setAccess(newAccess, await encryptSeed(changeMethodSeed, key))
+      account.setAccess(newAccess, encryptedSeed)
       changeMethodSeed.fill(0)
       changeMethodSeed = undefined
       setMethodDialog = undefined
@@ -226,12 +230,12 @@
       verifyNewPassword = ''
       toastStore.show('Unlock method updated')
     } catch (caught) {
-      if (myAttempt === attempt) {
+      if (attempt.current) {
         dialogError = caught instanceof Error ? caught.message : 'Could not set the new method.'
         setMethodDialog = 'form'
       }
     } finally {
-      if (myAttempt === attempt) {
+      if (attempt.current) {
         busy = false
         abortController = undefined
       }

--- a/ui/src/lib/components/unlock-dialog.svelte
+++ b/ui/src/lib/components/unlock-dialog.svelte
@@ -14,6 +14,7 @@
 
   import LoaderCircle from '@lucide/svelte/icons/loader-circle'
 
+  import { createAttemptTracker } from '$lib/attempt'
   import { Button } from '$lib/components/ui/button'
   import { Dialog } from '$lib/components/ui/dialog'
   import { Input } from '$lib/components/ui/input'
@@ -57,41 +58,43 @@
   let busy = $state(false)
   let pendingCeremony = $state(false)
   let error = $state<string | undefined>(undefined)
-  /** Bumped on cancel/retry — a stale ceremony resolution must not complete. */
-  let attempt = 0
+  /** Cancel/retry supersedes the in-flight ceremony — it must not complete. */
+  const attempts = createAttemptTracker()
 
   async function confirm() {
     if (busy) {
       return
     }
-    const myAttempt = ++attempt
+    const attempt = attempts.begin()
     error = undefined
     busy = true
     if (access.type !== 'password') {
       pendingCeremony = true
     }
     try {
-      const entropy = await unlockAccount(
-        account,
-        access.type === 'password' ? password : undefined,
+      // A passkey/wallet unlock can take seconds; a ceremony superseded while
+      // it ran (cancel/retry) must not complete, and its decrypted entropy is
+      // zeroed on the way out.
+      const entropy = await attempt.guard(
+        unlockAccount(account, access.type === 'password' ? password : undefined),
+        (seed) => seed.fill(0),
       )
-      // Bail if this ceremony was superseded (cancel/retry) or the account was
-      // signed out mid-flight (e.g. cross-tab): a passkey/wallet unlock can take
-      // seconds, and `unlockAccount` captured the vault before the wipe so it
-      // still resolves — but completing the connection with a now-signed-out
-      // account would re-arm app session material the sign-out just cleared.
-      if (myAttempt !== attempt || account.isSignedOut) {
+      // Signed out mid-flight (e.g. cross-tab): `unlockAccount` captured the
+      // vault before the wipe so it still resolves — but completing the
+      // connection with a now-signed-out account would re-arm app session
+      // material the sign-out just cleared.
+      if (account.isSignedOut) {
         entropy.fill(0)
         return
       }
       await onunlocked(entropy)
     } catch (caught) {
-      if (myAttempt === attempt) {
+      if (attempt.current) {
         error = caught instanceof Error ? caught.message : 'Unlock failed.'
         pendingCeremony = false
       }
     } finally {
-      if (myAttempt === attempt) {
+      if (attempt.current) {
         busy = false
       }
     }
@@ -100,7 +103,7 @@
   function close() {
     // Invalidate any in-flight ceremony — wallet prompts can't be aborted, so
     // a later approval of a cancelled prompt must not complete.
-    attempt++
+    attempts.supersede()
     onclose()
   }
 </script>

--- a/ui/src/routes/account/new/access/+page.svelte
+++ b/ui/src/routes/account/new/access/+page.svelte
@@ -19,6 +19,7 @@
   import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'
 
+  import { type Attempt, createAttemptTracker } from '$lib/attempt'
   import AppHeader from '$lib/components/app-header.svelte'
   import NewPasswordFields, { isNewPasswordValid } from '$lib/components/new-password-fields.svelte'
   import { Button } from '$lib/components/ui/button'
@@ -49,8 +50,8 @@
   let verifyPassword = $state('')
 
   let abortController: AbortController | undefined
-  /** Bumped on cancel/retry — a stale ceremony resolution must not finalize. */
-  let attempt = 0
+  /** Cancel/retry supersedes the in-flight ceremony — it must not finalize. */
+  const attempts = createAttemptTracker()
 
   const passwordValid = $derived(isNewPasswordValid(password, verifyPassword))
 
@@ -72,11 +73,11 @@
     // Leaving the page (back navigation) is an implicit cancel: an in-flight
     // ceremony or finalize must not later create the account and yank the
     // user to the done page.
-    attempt++
+    attempts.supersede()
     abortController?.abort()
   })
 
-  async function finalize(access: AccessMethod, key: CryptoKey, myAttempt: number) {
+  async function finalize(access: AccessMethod, key: CryptoKey, attempt: Attempt) {
     const draft = sessionStore.draft
     if (!draft?.phrase) {
       return
@@ -88,15 +89,11 @@
     // The derivation key is computed from the master key (the wallet private
     // key) while the entropy is in hand — the same chain the proxy/sync use.
     const masterKey = strip0x(wallet.privateKey)
-    const [derivationKey, encryptedSeed] = await Promise.all([
-      deriveAccountDerivationKey(masterKey),
-      encryptSeed(wallet.entropy, key),
-    ])
-    // The derivation gave Cancel a window — a superseded attempt must not
-    // create the account or navigate (#423).
-    if (myAttempt !== attempt) {
-      return
-    }
+    // The derivation gives Cancel a window — a superseded attempt must not
+    // create the account or navigate (#423); the guard throws it out.
+    const [derivationKey, encryptedSeed] = await attempt.guard(
+      Promise.all([deriveAccountDerivationKey(masterKey), encryptSeed(wallet.entropy, key)]),
+    )
     const account: AccountRecord = {
       id: new EthAddress(wallet.address),
       name: draft.name,
@@ -133,13 +130,10 @@
     // leaves the Confirm buttons functional for a retry.
     const request = connectStore.request
     if (request) {
-      await completeConnect(liveAccount, wallet.entropy, request)
       // Cancelled while the handshake was in flight: the account exists and
       // the dApp got its secret, but stay put — the intact draft lets the
       // user confirm again rather than being yanked to the done page.
-      if (myAttempt !== attempt) {
-        return
-      }
+      await attempt.guard(completeConnect(liveAccount, wallet.entropy, request))
       sessionStore.setCompletedFlow(flow)
       sessionStore.clearDraft()
       goto(resolve(routes.CONNECT_DONE))
@@ -156,7 +150,7 @@
     if (busy || !draft) {
       return
     }
-    const myAttempt = ++attempt
+    const attempt = attempts.begin()
     error = undefined
     busy = true
     if (method !== 'password') {
@@ -164,17 +158,16 @@
     }
     try {
       abortController = method === 'passkey' ? new AbortController() : undefined
-      const { access, key } = await createAccess(method, {
-        accountName: draft.name,
-        password,
-        signal: abortController?.signal,
-      })
-      if (myAttempt !== attempt) {
-        return
-      }
-      await finalize(access, key, myAttempt)
+      const { access, key } = await attempt.guard(
+        createAccess(method, {
+          accountName: draft.name,
+          password,
+          signal: abortController?.signal,
+        }),
+      )
+      await finalize(access, key, attempt)
     } catch (caught) {
-      if (myAttempt === attempt) {
+      if (attempt.current) {
         error =
           caught instanceof Error
             ? caught.message
@@ -185,7 +178,7 @@
                 : 'Encryption failed.'
       }
     } finally {
-      if (myAttempt === attempt) {
+      if (attempt.current) {
         pending = false
         busy = false
         abortController = undefined
@@ -196,7 +189,7 @@
   function cancelPending() {
     // Invalidate the in-flight ceremony — wallet prompts can't be aborted, so
     // a later approval of a cancelled prompt must not finalize.
-    attempt++
+    attempts.supersede()
     abortController?.abort()
     pending = false
     busy = false


### PR DESCRIPTION
## Why

The `myAttempt !== attempt` counter idiom (used by six components) relies on remembering a re-check after every await. Forgetting one caused #423 — fixed acutely in #485 by threading the counter through `finalize` — and the same hole existed in `home-account.svelte`'s change-method flow. This makes the check structural instead of disciplinary.

## What

**`$lib/attempt.ts`** — a small supersedable-attempt helper, unit-tested:

- `attempts.begin()` starts an attempt and supersedes the one in flight; `attempts.supersede()` invalidates without starting one (cancel/close/leave).
- `attempt.guard(work)` resolves the work, then **throws `SupersededError`** if the attempt is stale — a forgotten re-check is no longer possible on guarded awaits. `onDiscard` destroys material that must not leak past a cancel (zeroing decrypted seeds).
- `attempt.current` replaces `myAttempt === attempt` in catch/finally blocks and widget callbacks. `SupersededError` is only ever thrown once `current` is false, so existing `current`-gated catch blocks swallow it with no instanceof checks.
- Like the counter, `guard` discards results rather than cancelling work; awaits that must complete and be recorded even after a cancel — the drive dialogs' on-chain spends — deliberately stay outside the guard, now with comments saying so.

**Migrated:** the account-access page (converting the counter #485 threaded through `finalize` into the guard), `unlock-dialog` (which also covers `delete-account-dialog`, a thin wrapper around it since #487), `drive-add-dialog`, `drive-extend-dialog`, `drive-resize-dialog`, `home-account`.

## Behavior changes (all cancel-window fixes, called out per commit)

- `home-account` change-method: cancelling while the seed re-encrypts no longer calls `setAccess` (second commit — this was the tracked sibling of #423). The signed-out bail now sits after the last await, covering the encryption window too.
- `drive-extend-dialog`: closing during the price fetch no longer goes on to spend.
- `drive-add-dialog` attach flow: a close now bails right after the signer derivation instead of after the next chain read.

## Tests

- 7 new vitest unit tests for the helper (supersession, retry, discard hook, rejection passthrough, the `current`/throw invariant).
- Full suite green after the rebase onto `main`: ui unit tests 85/85, Playwright e2e 21/21 in CI (including the #423 regression test from #485, which exercises the guard inside `finalize` end-to-end), `pnpm check:all` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
