### PR TITLE
fix(lib): don't re-encrypt the content reference on ACT revocation

### DIFF
--- a/lib/src/proxy/act/index.test.ts
+++ b/lib/src/proxy/act/index.test.ts
@@ -494,7 +494,7 @@ describe("revokeGranteesFromAct", () => {
     vi.clearAllMocks()
   })
 
-  it("should revoke grantees and rotate keys", async () => {
+  it("should revoke grantees and drop their entries", async () => {
     const publisher = createTestKeyPair(80)
     const grantee1 = createTestKeyPair(81)
     const grantee2 = createTestKeyPair(82) // Will be revoked
@@ -535,8 +535,8 @@ describe("revokeGranteesFromAct", () => {
       [grantee2.publicKey],
     )
 
-    // Should have new encrypted reference (key rotation)
-    expect(result.encryptedReference).not.toBe(createResult.encryptedReference)
+    // Reference is unchanged — revocation must not re-encrypt it (#496)
+    expect(result.encryptedReference).toBe(createResult.encryptedReference)
     expect(result.actReference).toBeDefined()
 
     // New ACT should have 2 entries (publisher + grantee1)
@@ -569,6 +569,64 @@ describe("revokeGranteesFromAct", () => {
     )
     const grantee1Entry = findActEntryByKey(newActData, grantee1Keys.lookupKey)
     expect(grantee1Entry).toBeDefined()
+  })
+
+  it("does not re-encrypt the content reference under a rotated key (#496)", async () => {
+    // A nonce-free CTR cipher must never produce a second ciphertext of the same
+    // content reference under a different key. A revoked grantee keeps the access
+    // key it learned while granted and can read both ciphertexts from immutable
+    // history, so a re-encrypted reference leaks the new keystream (KS = C_new XOR
+    // R) and defeats revocation. Revocation must return the reference unchanged.
+    const publisher = createTestKeyPair(90)
+    const revoked = createTestKeyPair(91)
+
+    const contentRef = randomBytes(32)
+    const { storage, uploadMock, downloadMock } =
+      createContentAddressedUploadMock()
+    vi.mocked(uploadData).mockImplementation(uploadMock)
+
+    const target = createMockTarget()
+    const createResult = await createActForContent(
+      target,
+      contentRef,
+      publisher.privateKey,
+      [revoked.publicKey],
+    )
+    vi.mocked(downloadDataWithChunkAPI).mockImplementation(downloadMock)
+
+    // The revoked grantee legitimately learned the access key while granted.
+    const actData = loadActDataFromStorage(storage, createResult.actReference)
+    const revokedKeys = deriveKeys(
+      revoked.privateKey,
+      publisher.publicKey.x,
+      publisher.publicKey.y,
+    )
+    const cachedAccessKey = counterModeDecrypt(
+      findActEntryByKey(actData, revokedKeys.lookupKey)!,
+      revokedKeys.accessKeyDecryptionKey,
+    )
+
+    const result = await revokeGranteesFromAct(
+      target,
+      mockBee,
+      createResult.historyReference,
+      createResult.encryptedReference,
+      publisher.privateKey,
+      [revoked.publicKey],
+    )
+
+    // No second ciphertext of the reference exists to XOR against.
+    expect(result.encryptedReference).toBe(createResult.encryptedReference)
+
+    // The unchanged reference is still the real content pointer — the revoked
+    // grantee could already read it before revocation (immutability), which
+    // revocation cannot undo; the fix only avoids leaking anything *new*.
+    expect(
+      counterModeDecrypt(
+        fromHex(result.encryptedReference),
+        cachedAccessKey,
+      ).slice(0, contentRef.length),
+    ).toEqual(contentRef)
   })
 })
 

--- a/lib/src/proxy/act/index.ts
+++ b/lib/src/proxy/act/index.ts
@@ -77,10 +77,11 @@ export interface ActGranteeModifyResult {
 }
 
 /**
- * Result of ACT revocation (includes new encrypted reference due to key rotation)
+ * Result of ACT revocation. `encryptedReference` is returned unchanged (#496):
+ * revocation drops the revoked entries but must not re-encrypt the reference.
  */
 export interface ActRevocationResult extends ActGranteeModifyResult {
-  encryptedReference: string // New encrypted reference after key rotation
+  encryptedReference: string // Unchanged content reference (see #496)
 }
 
 /**
@@ -524,7 +525,8 @@ export async function addGranteesToAct(
 }
 
 /**
- * Revoke grantees from an ACT (performs key rotation)
+ * Revoke grantees from an ACT by dropping their entries. The content reference is
+ * returned unchanged — revocation must not re-encrypt it (#496).
  */
 export async function revokeGranteesFromAct(
   target: UploadTarget,
@@ -592,20 +594,16 @@ export async function revokeGranteesFromAct(
     throw new Error("Cannot find publisher entry in ACT")
   }
 
-  const oldAccessKey = counterModeDecrypt(
+  // Keep the existing access key. Rotating it and re-encrypting the SAME content
+  // reference under the new key was a revocation bypass (#496): counterModeEncrypt
+  // is nonce-free CTR, so two ciphertexts of the same reference expose the new
+  // keystream to any former grantee, who read both from immutable history. Re-keying
+  // is also pointless — immutability keeps the old ciphertext readable forever, so
+  // it can never un-share. Revocation only drops the revoked entries from the ACT.
+  const accessKey = counterModeDecrypt(
     publisherEntry.encryptedAccessKey,
     publisherKeys.accessKeyDecryptionKey,
   )
-
-  // Decrypt the content reference
-  const encryptedRef = hexToUint8Array(encryptedReference)
-  const decryptedRef = counterModeDecrypt(encryptedRef, oldAccessKey)
-
-  // Generate NEW access key for key rotation
-  const newAccessKey = generateRandomKey()
-
-  // Encrypt content reference with new access key
-  const newEncryptedRef = counterModeEncrypt(decryptedRef, newAccessKey)
 
   // Get current grantee list and filter out revoked
   let currentGrantees: UncompressedPublicKey[] = []
@@ -629,14 +627,14 @@ export async function revokeGranteesFromAct(
     )
   })
 
-  // Rebuild ALL entries with new access key
+  // Rebuild the ACT with the surviving entries under the same access key.
   const newEntries: ActEntry[] = []
 
   // Entry for publisher
   newEntries.push({
     lookupKey: publisherKeys.lookupKey,
     encryptedAccessKey: counterModeEncrypt(
-      newAccessKey,
+      accessKey,
       publisherKeys.accessKeyDecryptionKey,
     ),
   })
@@ -651,7 +649,7 @@ export async function revokeGranteesFromAct(
     newEntries.push({
       lookupKey: granteeKeys.lookupKey,
       encryptedAccessKey: counterModeEncrypt(
-        newAccessKey,
+        accessKey,
         granteeKeys.accessKeyDecryptionKey,
       ),
     })
@@ -708,7 +706,8 @@ export async function revokeGranteesFromAct(
   const historyTagUid = historyResult.tagUid
 
   return {
-    encryptedReference: uint8ArrayToHex(newEncryptedRef),
+    // Unchanged — see #496: revocation must not re-encrypt the reference.
+    encryptedReference,
     historyReference: newHistoryReference,
     granteeListReference: granteeListResult.reference,
     actReference: actResult.reference,

--- a/lib/src/swarm-id-client.ts
+++ b/lib/src/swarm-id-client.ts
@@ -3049,20 +3049,22 @@ export class SwarmIdClient {
   /**
    * Revokes grantees from an existing ACT.
    *
-   * This method removes public keys from the ACT's access list and performs
-   * key rotation to ensure revoked grantees cannot decrypt new versions.
-   * Returns new references including a new encrypted reference.
+   * This method removes public keys from the ACT's access list, producing a new
+   * ACT/history without the revoked entries.
    *
-   * IMPORTANT: The original encrypted reference can still be decrypted by
-   * revoked grantees if they have cached it. Key rotation only protects
-   * access through the new references.
+   * IMPORTANT: Revocation cannot un-share already-published content. A former
+   * grantee kept the access key while granted and the reference lives in
+   * immutable history, so they can still decrypt content published before
+   * revocation. Revocation only stops access to content published afterwards.
+   * The returned `encryptedReference` is unchanged — it is NOT re-encrypted, as
+   * that would leak the keystream to former grantees (#496).
    *
    * @param historyReference - The current history reference
-   * @param encryptedReference - The current encrypted reference (needed for key rotation)
+   * @param encryptedReference - The current encrypted reference
    * @param revokeGrantees - Array of grantee public keys to revoke as compressed hex strings
    * @param requestOptions - Optional request configuration (timeout, headers, endlesslyRetry)
    * @returns A promise resolving to the new references after revocation
-   * @returns return.encryptedReference - The new encrypted reference (key rotated)
+   * @returns return.encryptedReference - The content reference, unchanged
    * @returns return.historyReference - The new history reference after revocation
    * @returns return.granteeListReference - The new grantee list reference
    * @returns return.actReference - The new ACT reference after revocation
@@ -3075,8 +3077,7 @@ export class SwarmIdClient {
    * const revokeKeys = ['03a1b2c3...'] // Public keys to revoke
    * const result = await client.actRevokeGrantees(historyReference, encryptedReference, revokeKeys)
    * console.log('New History Reference:', result.historyReference)
-   * console.log('New Encrypted Reference:', result.encryptedReference)
-   * // All references are new due to key rotation
+   * // encryptedReference is unchanged; historyReference/actReference are new
    * ```
    */
   async actRevokeGrantees(

--- a/lib/src/swarm-id-proxy.ts
+++ b/lib/src/swarm-id-proxy.ts
@@ -3882,7 +3882,7 @@ export class SwarmIdProxy {
         parseCompressedPublicKey(hex),
       )
 
-      // Revoke grantees from ACT (performs key rotation)
+      // Revoke grantees from ACT (drops their entries; reference unchanged, #496)
       const result = await this.withModeAwareWriteLock(
         { useWorkers: true },
         async (target) => {


### PR DESCRIPTION
## Why

`revokeGranteesFromAct` decrypted the content reference and re-encrypted the **same** plaintext under a freshly rotated access key. Because `counterModeEncrypt` is nonce-free CTR, this put one plaintext (the content reference `R`) under two keystreams:

```
C_ref_old = R ⊕ KS(oldAccessKey)
C_ref_new = R ⊕ KS(newAccessKey)
```

A revoked grantee kept `oldAccessKey` while granted and can read both ciphertexts from immutable history, so they recover `R` (they always could) and then `KS(newAccessKey) = C_ref_new ⊕ R` — the new keystream — letting them decrypt content published under the new key after revocation. Full details in #496.

This is **SwarmID-specific** — upstream Bee never re-encrypts the reference on revoke.

## What

- Drop the reference decrypt/re-encrypt and the access-key rotation. Revocation now rebuilds the ACT with the surviving entries under the **same** access key and returns `encryptedReference` **unchanged**.
- Re-keying was also pointless: immutability keeps `C_ref_old` readable to any former grantee forever, so it can never un-share.
- Chose this over "rotate the key, return the old-key reference" because the reference is a pure passthrough to the dApp with **no re-upload path anywhere in the call graph** — rotating while returning an old-key reference would silently break current-content reads for the publisher and remaining grantees too, not just revoked users.
- Updated the stale "key rotation" docs on the type, function JSDoc, proxy handler, and client API.

## Tests

- New failing-first exploit test that reconstructs the revoked grantee's cached access key and asserts no second ciphertext of the reference exists.
- Updated the old "should rotate keys" test whose `not.toBe` assertion pinned the buggy behavior.
- Full ACT suite 132/132 (incl. the e2e flow asserting a remaining grantee still decrypts after a revoke), full lib unit suite 967/967, typecheck + lint clean.

## Note on forward secrecy (follow-up)

This fixes the keystream leak but **does not** add forward secrecy: a former grantee can still decrypt content published *after* revocation if it is encrypted under a key they already hold. That is inherent here — immutable history plus no re-upload path means a cached access key already reads everything, and the removed rotation only ever created a *false* sense of forward protection while leaking. True forward secrecy needs a re-upload flow (fresh object at a new address under a new key) **plus** nonce'd reference encryption so re-encryption is safe — the same nonce-free-CTR root cause tracked in **#408**. I'd open that as its own issue rather than fold it in here.

Closes #496

🤖 Generated with [Claude Code](https://claude.com/claude-code)