### PR TITLE
feat: sign back in to a signed-out account with the security method

### DIFF
--- a/lib/src/schemas.test.ts
+++ b/lib/src/schemas.test.ts
@@ -140,17 +140,31 @@ describe("LocalAccountSchemaV1 signed-in/signed-out union", () => {
     access: { type: "password", kdfSalt: "00", kdfIterations: 100000 },
     encryptedSeed: "aabbccdd",
   }
+  // The remnant a sign-out persists beyond the vault: the AES-encrypted
+  // snapshot of the synced state, restored on sign-back-in.
+  const SIGNED_OUT = {
+    ...VAULT,
+    encryptedState: '{"format":"test-snapshot","payload":"aabb"}',
+    signedOutAt: 1700000000001,
+  }
 
-  it("accepts a signed-out record that retains the vault", () => {
-    const result = LocalAccountSchemaV1.safeParse(
-      serializedAccount({ ...VAULT, signedOutAt: 1700000000001 }),
-    )
+  it("accepts a signed-out record that retains the vault and state snapshot", () => {
+    const result = LocalAccountSchemaV1.safeParse(serializedAccount(SIGNED_OUT))
     expect(result.success).toBe(true)
     if (result.success) {
       expect(result.data.signedOutAt).toBe(1700000000001)
       expect(result.data.access).toEqual(VAULT.access)
       expect(result.data.encryptedSeed).toBe(VAULT.encryptedSeed)
+      expect(result.data.encryptedState).toBe(SIGNED_OUT.encryptedState)
     }
+  })
+
+  it("rejects a signed-out record without the encrypted state snapshot", () => {
+    expect(
+      LocalAccountSchemaV1.safeParse(
+        serializedAccount({ ...VAULT, signedOutAt: 1700000000001 }),
+      ).success,
+    ).toBe(false)
   })
 
   // A record written before the sign-out shrank to the minimal remnant (full
@@ -159,8 +173,7 @@ describe("LocalAccountSchemaV1 signed-in/signed-out union", () => {
   it("strips the synced fields off a signed-out record", () => {
     const result = LocalAccountSchemaV1.safeParse(
       serializedAccount({
-        ...VAULT,
-        signedOutAt: 1700000000001,
+        ...SIGNED_OUT,
         postageStamps: [],
       }),
     )
@@ -203,7 +216,11 @@ describe("LocalAccountSchemaV1 signed-in/signed-out union", () => {
     (_label, partialVault) => {
       expect(
         LocalAccountSchemaV1.safeParse(
-          serializedAccount({ ...partialVault, signedOutAt: 1700000000001 }),
+          serializedAccount({
+            ...partialVault,
+            encryptedState: SIGNED_OUT.encryptedState,
+            signedOutAt: 1700000000001,
+          }),
         ).success,
       ).toBe(false)
     },

--- a/lib/src/schemas.test.ts
+++ b/lib/src/schemas.test.ts
@@ -141,11 +141,43 @@ describe("LocalAccountSchemaV1 signed-in/signed-out union", () => {
     encryptedSeed: "aabbccdd",
   }
 
-  it("accepts a signed-out record: no vault, signedOutAt set", () => {
+  it("accepts a signed-out record that retains the vault", () => {
     const result = LocalAccountSchemaV1.safeParse(
-      serializedAccount({ signedOutAt: 1700000000001 }),
+      serializedAccount({ ...VAULT, signedOutAt: 1700000000001 }),
     )
     expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.signedOutAt).toBe(1700000000001)
+      expect(result.data.access).toEqual(VAULT.access)
+      expect(result.data.encryptedSeed).toBe(VAULT.encryptedSeed)
+    }
+  })
+
+  // A record written before the sign-out shrank to the minimal remnant (full
+  // synced fields + signedOutAt) still parses — under the signed-out arm, which
+  // strips the synced fields (incl. the plaintext derivationKey) on parse.
+  it("strips the synced fields off a signed-out record", () => {
+    const result = LocalAccountSchemaV1.safeParse(
+      serializedAccount({
+        ...VAULT,
+        signedOutAt: 1700000000001,
+        postageStamps: [],
+      }),
+    )
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data).not.toHaveProperty("derivationKey")
+      expect(result.data).not.toHaveProperty("publicKey")
+      expect(result.data).not.toHaveProperty("postageStamps")
+    }
+  })
+
+  it("rejects a vault-less signed-out record (pre-retention shape)", () => {
+    expect(
+      LocalAccountSchemaV1.safeParse(
+        serializedAccount({ signedOutAt: 1700000000001 }),
+      ).success,
+    ).toBe(false)
   })
 
   it("rejects a record with neither vault nor signedOutAt", () => {
@@ -163,34 +195,39 @@ describe("LocalAccountSchemaV1 signed-in/signed-out union", () => {
     ).toBe(false)
   })
 
-  it("rejects a signed-out record that retains vault fields", () => {
-    expect(
-      LocalAccountSchemaV1.safeParse(
-        serializedAccount({ ...VAULT, signedOutAt: 1700000000001 }),
-      ).success,
-    ).toBe(false)
-  })
+  it.each([
+    ["access", { access: VAULT.access }],
+    ["encryptedSeed", { encryptedSeed: VAULT.encryptedSeed }],
+  ])(
+    "rejects a signed-out record with only %s of the vault",
+    (_label, partialVault) => {
+      expect(
+        LocalAccountSchemaV1.safeParse(
+          serializedAccount({ ...partialVault, signedOutAt: 1700000000001 }),
+        ).success,
+      ).toBe(false)
+    },
+  )
 })
 
 describe("isSignedOutAccount", () => {
-  it("is signed out when the vault is absent", () => {
+  it("is signed out when signedOutAt is set (vault retained)", () => {
     expect(isSignedOutAccount(createSignedOutAccount())).toBe(true)
   })
 
-  it("is signed in while the vault is present", () => {
+  it("is signed in without signedOutAt", () => {
     expect(isSignedOutAccount(createAccount({}))).toBe(false)
   })
 
-  // The point of the union model: the guard narrows, so the signed-in branch
-  // sees non-optional vault fields and the signed-out branch a non-optional
-  // `signedOutAt` — no `!`/`??` juggling at call sites.
+  // The point of the union model: the guard narrows, so the signed-out branch
+  // sees a non-optional `signedOutAt` — and BOTH branches keep the vault, so
+  // the sign-back-in unlock can read it without `!`/`??` juggling.
   it("narrows each union variant", () => {
     const account: Account = createSignedOutAccount()
     if (isSignedOutAccount(account)) {
       expectTypeOf(account.signedOutAt).toEqualTypeOf<number>()
-    } else {
-      expectTypeOf(account.access).toEqualTypeOf<AccessMethod>()
-      expectTypeOf(account.encryptedSeed).toEqualTypeOf<string>()
     }
+    expectTypeOf(account.access).toEqualTypeOf<AccessMethod>()
+    expectTypeOf(account.encryptedSeed).toEqualTypeOf<string>()
   })
 })

--- a/lib/src/schemas.ts
+++ b/lib/src/schemas.ts
@@ -226,7 +226,8 @@ export const AccessMethodSchemaV1 = z.discriminatedUnion("type", [
  * under the key the access method derives (hex: IV || ciphertext — width varies
  * with the seed size: 12-word seed → 88 chars, 24-word → 120, so no fixed
  * length). The vault never leaves the device: `SyncedAccountSchemaV1` has no
- * vault fields, and a sign-out wipes the vault while the synced data lives on.
+ * vault fields. A sign-out RETAINS the vault (it is encrypted at rest) while
+ * stripping the synced data, so signing back in only takes the access method.
  */
 export const LocalVaultSchemaV1 = z.object({
   access: AccessMethodSchemaV1,
@@ -308,31 +309,37 @@ const SignedInAccountSchemaV1 = SyncedAccountSchemaV1.extend({
 })
 
 /**
- * Signed-out variant: the synced data plus the moment the user signed this
- * account out on THIS device. The vault was wiped, but the account row stays
- * so the user can see it and sign back in (recovery phrase + new access
- * method). The vault keys are declared undefined-only so a record that kept
- * half a vault is quarantined rather than loaded as signed-out. When a future
- * "sign back in with the security method" flow wants to RETAIN the vault
- * through a sign-out, it extends this variant with `LocalVaultSchemaV1.shape`.
+ * Signed-out variant: the minimal remnant of a sign-out. The vault SURVIVES
+ * (it is encrypted at rest, so retaining it matches the sign-out security
+ * posture) and lets the user sign back in with the existing access method —
+ * no recovery phrase. Everything else — `derivationKey` (secret material),
+ * `publicKey`, the collections, settings, and clocks — is stripped from disk
+ * and re-derived from the seed / re-folded from Swarm on sign-back-in. The
+ * display fields (`name`, `createdAt`) stay so the account chooser can list
+ * the row. Being a plain object (not a `SyncedAccountSchemaV1` extension),
+ * parsing a pre-shrink record under this arm strips its synced fields.
  */
-const SignedOutAccountSchemaV1 = SyncedAccountSchemaV1.extend({
-  access: z.undefined().optional(),
-  encryptedSeed: z.undefined().optional(),
+const SignedOutAccountSchemaV1 = z.object({
+  id: StoredEthAddress,
+  name: z.string(),
+  createdAt: z.number(),
+  ...LocalVaultSchemaV1.shape,
   signedOutAt: z.number(),
 })
 
 /**
  * Local Account Schema V1 — parse entrypoint for stored account records (what
- * localStorage holds): the synced projection plus the device-local tail,
- * modeled as a union so the signed-in/signed-out states are encoded in the
- * data itself — a signed-in account carries the vault and no `signedOutAt`, a
- * signed-out one the reverse; half-signed-out states are unrepresentable.
+ * localStorage holds), modeled as a union so the signed-in/signed-out states
+ * are encoded in the data itself: a signed-in account is the synced projection
+ * plus the vault and no `signedOutAt`; a signed-out one is the minimal remnant
+ * (display fields + vault) with `signedOutAt` set. Both carry the vault —
+ * `signedOutAt` presence alone discriminates; vault-less records (the
+ * pre-retention sign-out shape) fail both arms and are quarantined.
  *
  * This only validates at parse (load) time — the accounts loader SKIPS a
  * violating record rather than failing the document — but unlike a refinement
  * the union also carries into the TYPE system: `Account` is a discriminated
- * union (discriminate on `access`/`signedOutAt` presence, or narrow with
+ * union (discriminate on `signedOutAt` presence, or narrow with
  * `isSignedOutAccount`), so writers can't produce a half-signed-out record
  * without a type error.
  */
@@ -426,7 +433,7 @@ export type AccountStateSnapshot = z.infer<typeof AccountStateSnapshotSchemaV1>
  * account with no default, or whose default is freshly-purchased-but-not-yet-
  * usable, therefore reads as local.
  */
-export function isLocalAccount(account: Account): boolean {
+export function isLocalAccount(account: SignedInAccount): boolean {
   const batchID = account.defaultPostageStampBatchID
   if (batchID === undefined) return true
   const stamp = account.postageStamps.find((s) => s.batchID.equals(batchID))
@@ -439,16 +446,16 @@ export function isLocalAccount(account: Account): boolean {
 }
 
 /**
- * An account is "signed out" on this device when its seed vault has been
- * wiped: no keys remain, so nothing can be unlocked or signed until the user
- * signs back in with the recovery phrase (and sets a new access method). The
- * vault absence itself is the source of truth; `signedOutAt` only records
- * when. Narrows: the false branch exposes the vault fields as non-optional.
+ * An account is "signed out" on this device when `signedOutAt` is set: the
+ * synced data was stripped from disk, but the encrypted vault survives, so the
+ * user signs back in with the existing access method (which re-derives and
+ * re-folds the rest). Narrows: the true branch exposes `signedOutAt` as a
+ * number; the vault fields are non-optional on BOTH branches.
  */
 export function isSignedOutAccount(
   account: Account,
 ): account is SignedOutAccount {
-  return account.access === undefined
+  return account.signedOutAt !== undefined
 }
 
 // ============================================================================

--- a/lib/src/schemas.ts
+++ b/lib/src/schemas.ts
@@ -312,18 +312,22 @@ const SignedInAccountSchemaV1 = SyncedAccountSchemaV1.extend({
  * Signed-out variant: the minimal remnant of a sign-out. The vault SURVIVES
  * (it is encrypted at rest, so retaining it matches the sign-out security
  * posture) and lets the user sign back in with the existing access method —
- * no recovery phrase. Everything else — `derivationKey` (secret material),
- * `publicKey`, the collections, settings, and clocks — is stripped from disk
- * and re-derived from the seed / re-folded from Swarm on sign-back-in. The
- * display fields (`name`, `createdAt`) stay so the account chooser can list
- * the row. Being a plain object (not a `SyncedAccountSchemaV1` extension),
- * parsing a pre-shrink record under this arm strips its synced fields.
+ * no recovery phrase. The synced state (collections, settings, clocks, and
+ * the secret `derivationKey`) is stripped from disk as PLAINTEXT but kept as
+ * `encryptedState`: an AES-GCM snapshot keyed off the derivation-key chain,
+ * decrypted and restored on sign-back-in so a sign-out can never lose data —
+ * even offline or when the Swarm copy is gone. Required: a signed-out record
+ * without the snapshot is malformed and quarantined at load. The display
+ * fields (`name`, `createdAt`) stay so the account chooser can list the row.
+ * Being a plain object (not a `SyncedAccountSchemaV1` extension), parsing a
+ * pre-shrink record under this arm strips its plaintext synced fields.
  */
 const SignedOutAccountSchemaV1 = z.object({
   id: StoredEthAddress,
   name: z.string(),
   createdAt: z.number(),
   ...LocalVaultSchemaV1.shape,
+  encryptedState: z.string(),
   signedOutAt: z.number(),
 })
 

--- a/lib/src/swarm-id-proxy.ts
+++ b/lib/src/swarm-id-proxy.ts
@@ -39,7 +39,6 @@ import type {
   GetPostageBatchMessage,
   CreateFeedManifestMessage,
   AppMetadata,
-  Account,
   PostageStamp,
   PostageBatch,
   ConnectedApp,
@@ -134,7 +133,9 @@ import {
   DEFAULT_BEE_NODE_URL,
   DEFAULT_GNOSIS_RPC_URL,
   UtilizationUpdateMessageSchema,
+  isSignedOutAccount,
   type AccountStateSnapshot,
+  type SignedInAccount,
 } from "./schemas"
 import { buildAuthUrl } from "./utils/url"
 import {
@@ -1264,7 +1265,7 @@ export class SwarmIdProxy {
     try {
       const accounts = createAccountsStorageManager().load()
       const account = accounts.find((a) => a.id.toHex() === accountId)
-      if (!account) return []
+      if (!account || isSignedOutAccount(account)) return []
       // Bound the partition rival set to recently-active devices: removed
       // (tombstoned) devices won't write, and long-dead ghosts from old sessions
       // (the device list is append-only) would each add an absent intent read to
@@ -1308,7 +1309,7 @@ export class SwarmIdProxy {
       const manager = createAccountsStorageManager()
       const accounts = manager.load()
       const account = accounts.find((a) => a.id.toHex() === accountId)
-      if (!account) return
+      if (!account || isSignedOutAccount(account)) return
 
       // Feed owner = backup signer (derived from the swarm encryption key).
       // Phase 3a: discovery is the append-only device roster, not a shared doc.
@@ -1538,14 +1539,17 @@ export class SwarmIdProxy {
    * descending and returning the most recent.
    */
   private findConnectionForParent():
-    | { account: Account; app: ConnectedApp }
+    | { account: SignedInAccount; app: ConnectedApp }
     | undefined {
     if (!this.parentOrigin) {
       return undefined
     }
     const accounts = createAccountsStorageManager().load()
-    const matches: { account: Account; app: ConnectedApp }[] = []
+    const matches: { account: SignedInAccount; app: ConnectedApp }[] = []
     for (const account of accounts) {
+      // A signed-out account keeps no connected apps (and no derivationKey to
+      // serve them with) — its record is just the vault remnant.
+      if (isSignedOutAccount(account)) continue
       for (const app of account.connectedApps) {
         if (app.appUrl === this.parentOrigin && this.isConnectionValid(app)) {
           matches.push({ account, app })
@@ -1601,6 +1605,7 @@ export class SwarmIdProxy {
       const accounts = manager.load()
       let changed = false
       const updated = accounts.map((account) => {
+        if (isSignedOutAccount(account)) return account
         const connectedApps = account.connectedApps.map((app) => {
           if (app.appUrl === this.parentOrigin) {
             changed = true

--- a/lib/src/test-fixtures.ts
+++ b/lib/src/test-fixtures.ts
@@ -69,7 +69,8 @@ export function createAccount(
 
 /**
  * Signed-out counterpart of `createAccount`: the minimal sign-out remnant —
- * the retained vault plus display fields, everything synced stripped.
+ * the retained vault, the encrypted state snapshot, and display fields;
+ * everything synced stripped.
  */
 export function createSignedOutAccount(
   overrides?: Partial<SignedOutAccount>,
@@ -80,6 +81,7 @@ export function createSignedOutAccount(
     createdAt: 1700000000000,
     access: { type: "password", kdfSalt: "00", kdfIterations: 100000 },
     encryptedSeed: "aabbccdd",
+    encryptedState: '{"format":"test-snapshot","payload":"aabb"}',
     signedOutAt: 1700000000001,
     ...overrides,
   }

--- a/lib/src/test-fixtures.ts
+++ b/lib/src/test-fixtures.ts
@@ -67,12 +67,19 @@ export function createAccount(
   }
 }
 
-/** Signed-out counterpart of `createAccount`: no vault, `signedOutAt` set. */
+/**
+ * Signed-out counterpart of `createAccount`: the minimal sign-out remnant —
+ * the retained vault plus display fields, everything synced stripped.
+ */
 export function createSignedOutAccount(
   overrides?: Partial<SignedOutAccount>,
 ): SignedOutAccount {
   return {
-    ...createSyncedAccount(),
+    id: new EthAddress(TEST_ETH_ADDRESS_HEX),
+    name: "Test Account",
+    createdAt: 1700000000000,
+    access: { type: "password", kdfSalt: "00", kdfIterations: 100000 },
+    encryptedSeed: "aabbccdd",
     signedOutAt: 1700000000001,
     ...overrides,
   }

--- a/lib/src/utils/backup-encryption.ts
+++ b/lib/src/utils/backup-encryption.ts
@@ -20,7 +20,7 @@ import {
   deserializeAccountStateSnapshot,
 } from "./account-state-snapshot"
 import type { AccountStateSnapshotResult } from "./account-state-snapshot"
-import type { Account } from "../schemas"
+import type { SignedInAccount } from "../schemas"
 
 // ============================================================================
 // Constants
@@ -152,7 +152,7 @@ export type BackupHeaderWithoutCiphertext = Omit<
 >
 
 export function buildBackupHeader(
-  account: Account,
+  account: SignedInAccount,
 ): BackupHeaderWithoutCiphertext {
   return {
     version: BACKUP_VERSION as typeof BACKUP_VERSION,
@@ -174,7 +174,7 @@ export function buildBackupHeader(
  * 4. Builds a header with account metadata + ciphertext
  */
 export async function createEncryptedExport(
-  account: Account,
+  account: SignedInAccount,
   swarmEncryptionKeyHex: string,
 ): Promise<EncryptedSwarmIdExport> {
   const now = Date.now()

--- a/lib/src/utils/postage-stamp-association.ts
+++ b/lib/src/utils/postage-stamp-association.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type { BatchId } from "@ethersphere/bee-js"
-import type { Account, ConnectedApp, PostageStamp } from "../schemas"
+import type { ConnectedApp, PostageStamp, SignedInAccount } from "../schemas"
 
 /**
  * Resolve which postage stamp an app should upload with.
@@ -17,7 +17,7 @@ import type { Account, ConnectedApp, PostageStamp } from "../schemas"
  */
 export function resolveStampForApp(
   app: Pick<ConnectedApp, "postageStampBatchID">,
-  account: Pick<Account, "defaultPostageStampBatchID">,
+  account: Pick<SignedInAccount, "defaultPostageStampBatchID">,
   stamps: PostageStamp[],
 ): PostageStamp | undefined {
   const candidates = [
@@ -40,7 +40,7 @@ export function resolveStampForApp(
  */
 export function collectAccountStampBatchIds(
   account: Pick<
-    Account,
+    SignedInAccount,
     "defaultPostageStampBatchID" | "postageStamps" | "connectedApps"
   >,
 ): BatchId[] {

--- a/lib/src/utils/storage-managers.test.ts
+++ b/lib/src/utils/storage-managers.test.ts
@@ -75,11 +75,13 @@ describe("serializeAccount — device-local seed vault", () => {
 
     expect(reparsed.access).toEqual(account.access)
     expect(reparsed.encryptedSeed).toBe(account.encryptedSeed)
+    expect(reparsed.encryptedState).toBe(account.encryptedState)
     expect(reparsed.signedOutAt).toBe(1700000000123)
   })
 
-  // Pins the sign-out privacy contract: nothing but the vault and the display
-  // fields survives in localStorage — no derivationKey, collections, or clocks.
+  // Pins the sign-out privacy contract: nothing but the vault, the encrypted
+  // state snapshot, and the display fields survives in localStorage — no
+  // plaintext derivationKey, collections, or clocks.
   it("serializes a signed-out account to exactly the minimal remnant keys", () => {
     const serialized = serializeAccount(createSignedOutAccount())
 
@@ -87,6 +89,7 @@ describe("serializeAccount — device-local seed vault", () => {
       "access",
       "createdAt",
       "encryptedSeed",
+      "encryptedState",
       "id",
       "name",
       "signedOutAt",

--- a/lib/src/utils/storage-managers.test.ts
+++ b/lib/src/utils/storage-managers.test.ts
@@ -65,7 +65,7 @@ describe("serializeAccount — device-local seed vault", () => {
     }
   })
 
-  it("round-trips a signed-out account (vault wiped, signedOutAt set)", () => {
+  it("round-trips a signed-out account (vault retained, signedOutAt set)", () => {
     const account = createSignedOutAccount({ signedOutAt: 1700000000123 })
 
     const serialized = serializeAccount(account)
@@ -73,9 +73,24 @@ describe("serializeAccount — device-local seed vault", () => {
       JSON.parse(JSON.stringify(serialized)),
     )
 
-    expect(reparsed.access).toBeUndefined()
-    expect(reparsed.encryptedSeed).toBeUndefined()
+    expect(reparsed.access).toEqual(account.access)
+    expect(reparsed.encryptedSeed).toBe(account.encryptedSeed)
     expect(reparsed.signedOutAt).toBe(1700000000123)
+  })
+
+  // Pins the sign-out privacy contract: nothing but the vault and the display
+  // fields survives in localStorage — no derivationKey, collections, or clocks.
+  it("serializes a signed-out account to exactly the minimal remnant keys", () => {
+    const serialized = serializeAccount(createSignedOutAccount())
+
+    expect(Object.keys(serialized).sort()).toEqual([
+      "access",
+      "createdAt",
+      "encryptedSeed",
+      "id",
+      "name",
+      "signedOutAt",
+    ])
   })
 })
 
@@ -113,6 +128,33 @@ describe("createAccountsStorageManager().load() — invalid records", () => {
     stubLocalStorage({
       version: 1,
       data: [serializeAccount(good), corrupt],
+    })
+
+    const loaded = createAccountsStorageManager().load()
+
+    expect(loaded).toHaveLength(1)
+    expect(loaded[0].id.equals(good.id)).toBe(true)
+  })
+
+  // Pre-vault-retention releases wiped the vault on sign-out; those records
+  // can't be signed back into and are quarantined by the loader (pre-prod,
+  // no migration).
+  it("skips a vault-less signed-out record from an old release", () => {
+    vi.spyOn(console, "error").mockImplementation(() => undefined)
+    const good = createAccount()
+    const {
+      access: _access,
+      encryptedSeed: _encryptedSeed,
+      ...oldSignedOut
+    } = serializeAccount(
+      createAccount({ id: new EthAddress(TEST_ETH_ADDRESS_2_HEX) }),
+    )
+    stubLocalStorage({
+      version: 1,
+      data: [
+        serializeAccount(good),
+        { ...oldSignedOut, signedOutAt: 1700000000001 },
+      ],
     })
 
     const loaded = createAccountsStorageManager().load()

--- a/lib/src/utils/storage-managers.ts
+++ b/lib/src/utils/storage-managers.ts
@@ -120,8 +120,9 @@ export function serializeSyncedAccount(
 /**
  * Serialize Account for storage (nested: includes its connected apps and
  * postage stamps inline). A signed-out account persists only its minimal
- * remnant — display fields plus the encrypted vault — so no synced data (in
- * particular the plaintext `derivationKey`) stays on disk while signed out.
+ * remnant — display fields, the encrypted vault, and the encrypted state
+ * snapshot — so no synced data (in particular the plaintext `derivationKey`)
+ * stays on disk in the clear while signed out.
  */
 export function serializeAccount(account: Account): Record<string, unknown> {
   if (isSignedOutAccount(account)) {
@@ -131,6 +132,7 @@ export function serializeAccount(account: Account): Record<string, unknown> {
       createdAt: account.createdAt,
       access: account.access,
       encryptedSeed: account.encryptedSeed,
+      encryptedState: account.encryptedState,
       signedOutAt: account.signedOutAt,
     }
   }

--- a/lib/src/utils/storage-managers.ts
+++ b/lib/src/utils/storage-managers.ts
@@ -25,6 +25,7 @@ import { STORAGE_KEY_ACCOUNTS, STORAGE_KEY_NETWORK_SETTINGS } from "../types"
 import {
   LocalAccountSchemaV1,
   NetworkSettingsSchemaV1,
+  isSignedOutAccount,
   type NetworkSettings,
 } from "../schemas"
 import { PARTITION_COUNT } from "./batch-utilization"
@@ -60,7 +61,11 @@ const parseAccountsV1: VersionParser<Account> = (data: unknown) => {
   }
 
   return accounts.map((account) => {
-    if (account.partitionCount === undefined && account.devices.length > 0) {
+    if (
+      !isSignedOutAccount(account) &&
+      account.partitionCount === undefined &&
+      account.devices.length > 0
+    ) {
       return {
         ...account,
         partitionCount: PARTITION_COUNT,
@@ -114,22 +119,32 @@ export function serializeSyncedAccount(
 
 /**
  * Serialize Account for storage (nested: includes its connected apps and
- * postage stamps inline).
+ * postage stamps inline). A signed-out account persists only its minimal
+ * remnant — display fields plus the encrypted vault — so no synced data (in
+ * particular the plaintext `derivationKey`) stays on disk while signed out.
  */
 export function serializeAccount(account: Account): Record<string, unknown> {
+  if (isSignedOutAccount(account)) {
+    return {
+      id: account.id.toString(),
+      name: account.name,
+      createdAt: account.createdAt,
+      access: account.access,
+      encryptedSeed: account.encryptedSeed,
+      signedOutAt: account.signedOutAt,
+    }
+  }
   return {
     ...serializeSyncedAccount(account),
     // Local storage keeps the live per-app session secrets the portable
     // projection strips.
     connectedApps: account.connectedApps.map(serializeConnectedApp),
     // The device-local tail of the record: the seed vault (the account's only
-    // secret material — plain JSON, no byte classes) while signed in, or
-    // `signedOutAt` after a sign-out wiped it. This group stays on the device:
-    // the portable copy that backups and the sync feed publish is
+    // secret material — plain JSON, no byte classes). This group stays on the
+    // device: the portable copy that backups and the sync feed publish is
     // `SyncedAccount` — the record without it.
     access: account.access,
     encryptedSeed: account.encryptedSeed,
-    signedOutAt: account.signedOutAt,
   }
 }
 

--- a/ui/src/lib/components/account-switcher.svelte
+++ b/ui/src/lib/components/account-switcher.svelte
@@ -7,10 +7,10 @@
   import UserRoundMinus from '@lucide/svelte/icons/user-round-minus'
   import UserRoundPlus from '@lucide/svelte/icons/user-round-plus'
 
-  import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'
 
   import Polycon from '$lib/components/polycon.svelte'
+  import SignBackInDialog from '$lib/components/sign-back-in-dialog.svelte'
   import SignOutDialog from '$lib/components/sign-out-dialog.svelte'
   import { Badge } from '$lib/components/ui/badge'
   import { Button } from '$lib/components/ui/button'
@@ -33,6 +33,8 @@
   /** Replaces the panel actions with the create/import choice. */
   let addingAccount = $state(false)
   let signingOut = $state(false)
+  /** Signed-out account being unlocked to sign back in. */
+  let signingBackIn = $state<Account | undefined>(undefined)
 
   const others = $derived(
     accountsStore.accounts.filter((candidate) => !candidate.id.equals(account.id)),
@@ -48,8 +50,8 @@
 
   function select(candidate: Account) {
     if (candidate.isSignedOut) {
-      // No keys on this device — signing back in means importing the phrase.
-      void goto(resolve(routes.ACCOUNT_IMPORT))
+      // The vault survived the sign-out — unlock it to sign back in.
+      signingBackIn = candidate
       return
     }
     sessionStore.setCurrentAccount(candidate.id)
@@ -146,4 +148,15 @@
 
 {#if signingOut}
   <SignOutDialog {account} onClose={() => (signingOut = false)} />
+{/if}
+
+{#if signingBackIn}
+  <SignBackInDialog
+    account={signingBackIn}
+    onsignedin={(restored) => {
+      sessionStore.setCurrentAccount(restored.id)
+      signingBackIn = undefined
+    }}
+    onclose={() => (signingBackIn = undefined)}
+  />
 {/if}

--- a/ui/src/lib/components/sign-back-in-dialog.svelte
+++ b/ui/src/lib/components/sign-back-in-dialog.svelte
@@ -5,34 +5,85 @@
 
 <!--
   Sign-back-in ceremony for a signed-out account: unlock the retained vault
-  with the existing security method, then restore the synced state from Swarm
-  (`signBackIn`). A thrown restore error (e.g. network unreachable) shows in
-  the unlock dialog for a retry.
+  with the existing security method, then restore the synced state — from the
+  encrypted snapshot the sign-out kept, or (fallback) from Swarm. When neither
+  has any data (`NoSyncedDataError`), the dialog swaps to an explicit warning
+  instead of silently restoring an empty account; "Sign in anyway" retries
+  with `allowEmpty`. Other restore errors (e.g. network unreachable) surface
+  in the unlock dialog for a retry.
 -->
 <script lang="ts">
+  import { Button } from '$lib/components/ui/button'
+  import { Dialog } from '$lib/components/ui/dialog'
   import UnlockDialog from '$lib/components/unlock-dialog.svelte'
-  import { signBackIn } from '$lib/sign-back-in'
+  import { NoSyncedDataError, signBackIn } from '$lib/sign-back-in'
   import type { Account } from '$lib/types'
 
   interface Props {
     account: Account
-    /** Called with the restored live account; the caller unmounts the dialog. */
-    onsignedin: (account: Account) => void | Promise<void>
+    /** Called with the restored live account and the entropy that unlocked it
+     * (the connect flow completes the app handshake with it); the caller
+     * unmounts the dialog. */
+    onsignedin: (account: Account, entropy: Uint8Array) => void | Promise<void>
     onclose: () => void
   }
 
   let { account, onsignedin, onclose }: Props = $props()
 
+  /** Entropy stashed across the empty-account warning; zeroed on cancel. */
+  let pendingEntropy = $state<Uint8Array | undefined>(undefined)
+
   async function onunlocked(entropy: Uint8Array) {
-    const live = await signBackIn(account, entropy)
-    await onsignedin(live)
+    try {
+      const live = await signBackIn(account, entropy)
+      await onsignedin(live, entropy)
+    } catch (caught) {
+      if (caught instanceof NoSyncedDataError) {
+        // Not a retry-able unlock error: swap to the explicit warning below.
+        pendingEntropy = entropy
+        return
+      }
+      throw caught
+    }
+  }
+
+  async function signInEmpty() {
+    const entropy = pendingEntropy
+    if (!entropy) {
+      return
+    }
+    const live = await signBackIn(account, entropy, { allowEmpty: true })
+    pendingEntropy = undefined
+    await onsignedin(live, entropy)
+  }
+
+  function cancelEmpty() {
+    pendingEntropy?.fill(0)
+    pendingEntropy = undefined
+    onclose()
   }
 </script>
 
-<UnlockDialog
-  {account}
-  title="Sign in as {account.name}"
-  description="Unlock with your security method to sign back in on this device."
-  {onunlocked}
-  {onclose}
-/>
+{#if pendingEntropy}
+  <Dialog onclose={cancelEmpty} title="No synced data found">
+    <p class="text-sm">
+      No synced data was found for <span class="font-medium">{account.name}</span> — neither on this device
+      nor on the Swarm network.
+    </p>
+    <p class="text-sm">
+      You can sign in anyway, but the account will start empty: no drives and no app connections.
+    </p>
+    <div class="flex w-full flex-col gap-2">
+      <Button variant="destructive" class="w-full" onclick={signInEmpty}>Sign in anyway</Button>
+      <Button variant="outline" class="w-full" onclick={cancelEmpty}>Cancel</Button>
+    </div>
+  </Dialog>
+{:else}
+  <UnlockDialog
+    {account}
+    title="Sign in as {account.name}"
+    description="Unlock with your security method to sign back in on this device."
+    {onunlocked}
+    {onclose}
+  />
+{/if}

--- a/ui/src/lib/components/sign-back-in-dialog.svelte
+++ b/ui/src/lib/components/sign-back-in-dialog.svelte
@@ -1,0 +1,38 @@
+<!--
+  Copyright 2026 The Swarm Authors. All rights reserved.
+  SPDX-License-Identifier: Apache-2.0
+-->
+
+<!--
+  Sign-back-in ceremony for a signed-out account: unlock the retained vault
+  with the existing security method, then restore the synced state from Swarm
+  (`signBackIn`). A thrown restore error (e.g. network unreachable) shows in
+  the unlock dialog for a retry.
+-->
+<script lang="ts">
+  import UnlockDialog from '$lib/components/unlock-dialog.svelte'
+  import { signBackIn } from '$lib/sign-back-in'
+  import type { Account } from '$lib/types'
+
+  interface Props {
+    account: Account
+    /** Called with the restored live account; the caller unmounts the dialog. */
+    onsignedin: (account: Account) => void | Promise<void>
+    onclose: () => void
+  }
+
+  let { account, onsignedin, onclose }: Props = $props()
+
+  async function onunlocked(entropy: Uint8Array) {
+    const live = await signBackIn(account, entropy)
+    await onsignedin(live)
+  }
+</script>
+
+<UnlockDialog
+  {account}
+  title="Sign in as {account.name}"
+  description="Unlock with your security method to sign back in on this device."
+  {onunlocked}
+  {onclose}
+/>

--- a/ui/src/lib/components/sign-out-dialog.svelte
+++ b/ui/src/lib/components/sign-out-dialog.svelte
@@ -4,16 +4,19 @@
 -->
 
 <!--
-  Sign out a (synced) account on this device: strips the account data but
-  keeps the encrypted vault, so signing back in only takes the security
-  method — no phrase acknowledgment needed. The row stays in the list
-  ("Signed out").
+  Sign out a (synced) account on this device: strips the plaintext account
+  data but keeps the encrypted vault plus an encrypted snapshot of the synced
+  state, so signing back in only takes the security method and restores the
+  state losslessly — no phrase acknowledgment needed. The row stays in the
+  list ("Signed out").
 -->
 <script lang="ts">
+  import LoaderCircle from '@lucide/svelte/icons/loader-circle'
   import LogOut from '@lucide/svelte/icons/log-out'
 
   import { Button } from '$lib/components/ui/button'
   import { Dialog } from '$lib/components/ui/dialog'
+  import { encryptSignOutSnapshot } from '$lib/sign-out-snapshot'
   import { sessionStore } from '$lib/stores/session.svelte'
   import { toastStore } from '$lib/stores/toast.svelte'
   import type { Account } from '$lib/types'
@@ -25,17 +28,30 @@
 
   let { account, onClose }: Props = $props()
 
-  function confirm() {
-    // Capture once: the prop is a reactive getter, and callers derive it from
-    // the session (a signed-out current account reads as "no session"), so
-    // after signOut() the prop chain can already yield undefined.
-    const target = account
-    target.signOut()
-    if (sessionStore.currentAccountId === target.id.toHex()) {
-      sessionStore.clearCurrentAccount()
+  let busy = $state(false)
+
+  async function confirm() {
+    if (busy) {
+      return
     }
-    toastStore.show('Signed out')
-    onClose()
+    busy = true
+    try {
+      // Capture once: the prop is a reactive getter, and callers derive it from
+      // the session (a signed-out current account reads as "no session"), so
+      // after signOut() the prop chain can already yield undefined.
+      const target = account
+      // Snapshot the synced state BEFORE the sign-out strips it — this is what
+      // sign-back-in restores, so a sign-out can never lose data.
+      const encryptedState = await encryptSignOutSnapshot(target)
+      target.signOut(encryptedState)
+      if (sessionStore.currentAccountId === target.id.toHex()) {
+        sessionStore.clearCurrentAccount()
+      }
+      toastStore.show('Signed out')
+      onClose()
+    } finally {
+      busy = false
+    }
   }
 </script>
 
@@ -49,8 +65,12 @@
     <span class="font-medium">Secret Recovery Phrase</span> is the only way back in.
   </p>
   <div class="flex w-full flex-col gap-2">
-    <Button variant="destructive" class="w-full" onclick={confirm}>
-      <LogOut />
+    <Button variant="destructive" class="w-full" disabled={busy} onclick={confirm}>
+      {#if busy}
+        <LoaderCircle class="animate-spin" />
+      {:else}
+        <LogOut />
+      {/if}
       Sign out
     </Button>
     <Button variant="outline" class="w-full" onclick={onClose}>Cancel</Button>

--- a/ui/src/lib/components/sign-out-dialog.svelte
+++ b/ui/src/lib/components/sign-out-dialog.svelte
@@ -4,9 +4,11 @@
 -->
 
 <!--
-  Sign out a (synced) account on this device: wipes the seed vault, so the
-  confirm is gated on the user acknowledging they can get back in with their
-  Secret Recovery Phrase. The row stays in the account list ("Signed out").
+  Sign out a (synced) account on this device: strips the account data but
+  keeps the encrypted vault, so signing back in only takes the security
+  method. The confirm is still gated on the user acknowledging they have
+  their Secret Recovery Phrase — it remains the only way back in if the
+  security method itself is lost. The row stays in the list ("Signed out").
 -->
 <script lang="ts">
   import LogOut from '@lucide/svelte/icons/log-out'
@@ -42,12 +44,12 @@
 
 <Dialog onclose={onClose} title="Sign out">
   <p class="text-sm">
-    This signs <span class="font-medium">{account.name}</span> out on this device and removes its security
-    keys from it. Your account and its drives keep living on the Swarm network.
+    This signs <span class="font-medium">{account.name}</span> out on this device and removes its account
+    data from it. Your account and its drives keep living on the Swarm network.
   </p>
   <p class="text-sm">
-    To sign back in you will need your <span class="font-medium">Secret Recovery Phrase</span> and to
-    set up a new security method.
+    To sign back in, unlock with your security method. If you ever lose it, your
+    <span class="font-medium">Secret Recovery Phrase</span> is the only way back in.
   </p>
   <label class="flex cursor-pointer items-start gap-2 text-sm">
     <input type="checkbox" bind:checked={acknowledged} class="mt-0.5 cursor-pointer" />

--- a/ui/src/lib/components/sign-out-dialog.svelte
+++ b/ui/src/lib/components/sign-out-dialog.svelte
@@ -6,9 +6,8 @@
 <!--
   Sign out a (synced) account on this device: strips the account data but
   keeps the encrypted vault, so signing back in only takes the security
-  method. The confirm is still gated on the user acknowledging they have
-  their Secret Recovery Phrase — it remains the only way back in if the
-  security method itself is lost. The row stays in the list ("Signed out").
+  method — no phrase acknowledgment needed. The row stays in the list
+  ("Signed out").
 -->
 <script lang="ts">
   import LogOut from '@lucide/svelte/icons/log-out'
@@ -25,8 +24,6 @@
   }
 
   let { account, onClose }: Props = $props()
-
-  let acknowledged = $state(false)
 
   function confirm() {
     // Capture once: the prop is a reactive getter, and callers derive it from
@@ -51,12 +48,8 @@
     To sign back in, unlock with your security method. If you ever lose it, your
     <span class="font-medium">Secret Recovery Phrase</span> is the only way back in.
   </p>
-  <label class="flex cursor-pointer items-start gap-2 text-sm">
-    <input type="checkbox" bind:checked={acknowledged} class="mt-0.5 cursor-pointer" />
-    I have my Secret Recovery Phrase.
-  </label>
   <div class="flex w-full flex-col gap-2">
-    <Button variant="destructive" class="w-full" disabled={!acknowledged} onclick={confirm}>
+    <Button variant="destructive" class="w-full" onclick={confirm}>
       <LogOut />
       Sign out
     </Button>

--- a/ui/src/lib/components/unlock-dialog.svelte
+++ b/ui/src/lib/components/unlock-dialog.svelte
@@ -46,13 +46,15 @@
     onclose,
   }: Props = $props()
 
-  // The unlock ceremony only runs for a signed-in account, so the method is
-  // present at mount. Read ONCE via `untrack` (not `$derived`): the method is
-  // fixed for a ceremony, and an untracked read can never be re-triggered by a
-  // mid-ceremony sign-out (e.g. cross-tab) — so the dialog cannot re-read
-  // `accessMethod` on a wiped vault and throw. `unlockAccount` still rejects a
-  // wiped vault at confirm, surfacing it as a dialog error rather than a crash.
+  // The method is fixed for a ceremony — read ONCE via `untrack` (not
+  // `$derived`) so a mid-ceremony record change (e.g. cross-tab) can never
+  // re-render the dialog against different access metadata.
   const access = untrack(() => account.accessMethod)
+  // Snapshot the sign-out state to detect a mid-ceremony transition below:
+  // this dialog serves both signed-in unlocks and sign-back-in ceremonies, so
+  // what invalidates a ceremony is the state CHANGING under it, not being
+  // signed out per se.
+  const initialSignedOutAt = untrack(() => account.signedOutAt)
 
   let password = $state('')
   let busy = $state(false)
@@ -79,11 +81,13 @@
         unlockAccount(account, access.type === 'password' ? password : undefined),
         (seed) => seed.fill(0),
       )
-      // Signed out mid-flight (e.g. cross-tab): `unlockAccount` captured the
-      // vault before the wipe so it still resolves — but completing the
-      // connection with a now-signed-out account would re-arm app session
-      // material the sign-out just cleared.
-      if (account.isSignedOut) {
+      // Bail if the account's sign-out state flipped mid-flight (e.g.
+      // cross-tab) — supersession itself is the attempt guard's job. A
+      // signed-in unlock completing after a sign-out would re-arm app session
+      // material the sign-out just cleared; a sign-back-in completing after
+      // another tab already signed back in (or re-signed-out) would act on a
+      // state it no longer knows.
+      if (account.signedOutAt !== initialSignedOutAt) {
         entropy.fill(0)
         return
       }

--- a/ui/src/lib/crypto/backup.test.ts
+++ b/ui/src/lib/crypto/backup.test.ts
@@ -1,7 +1,7 @@
 // Copyright 2026 The Swarm Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { EthAddress } from '@ethersphere/bee-js'
-import type { Account as AccountRecord } from '@snaha/swarm-id'
+import type { SignedInAccount } from '@snaha/swarm-id'
 import { describe, expect, it } from 'vitest'
 
 import { daysToMs } from '../duration'
@@ -12,7 +12,7 @@ import { walletFromPhrase } from './mnemonic'
 const PHRASE = 'test test test test test test test test test test test junk'
 const OTHER_PHRASE = 'legal winner thank year wave sausage worth useful legal winner thank yellow'
 
-function accountFor(phrase: string): AccountRecord {
+function accountFor(phrase: string): SignedInAccount {
   const wallet = walletFromPhrase(phrase)
   return {
     id: new EthAddress(wallet.address),

--- a/ui/src/lib/crypto/mnemonic.ts
+++ b/ui/src/lib/crypto/mnemonic.ts
@@ -23,7 +23,15 @@ export function isValidPhrase(phrase: string): boolean {
 }
 
 export function walletFromPhrase(phrase: string): DerivedWallet {
-  const mnemonic = Mnemonic.fromPhrase(normalizePhrase(phrase))
+  return walletFromMnemonic(Mnemonic.fromPhrase(normalizePhrase(phrase)))
+}
+
+/** Rebuild the wallet from decrypted vault entropy (the sign-back-in path). */
+export function walletFromEntropy(entropy: Uint8Array): DerivedWallet {
+  return walletFromMnemonic(Mnemonic.fromEntropy(entropy))
+}
+
+function walletFromMnemonic(mnemonic: Mnemonic): DerivedWallet {
   const wallet = HDNodeWallet.fromMnemonic(mnemonic)
   return {
     address: wallet.address,

--- a/ui/src/lib/crypto/unlock.ts
+++ b/ui/src/lib/crypto/unlock.ts
@@ -18,14 +18,9 @@ import type { Account } from '$lib/types'
  * or wallet.
  */
 export async function unlockAccount(account: Account, password?: string): Promise<Uint8Array> {
-  const vault = account.vault
-  if (vault === undefined) {
-    // Signed-out account: the vault was wiped, there is nothing to unlock.
-    // Callers hide unlock affordances for signed-out accounts, so reaching
-    // this is a programming error, not a user-facing state.
-    throw new Error('This account is signed out on this device.')
-  }
-  const { access, encryptedSeed } = vault
+  // The vault survives a sign-out, so this works for signed-out accounts too —
+  // that IS the sign-back-in ceremony.
+  const { access, encryptedSeed } = account.vault
 
   let key: CryptoKey
   if (access.type === 'password') {

--- a/ui/src/lib/dev/account-refresh.ts
+++ b/ui/src/lib/dev/account-refresh.ts
@@ -80,7 +80,12 @@ export async function foldCurrentAccount(force: boolean): Promise<void> {
  * still converges on peer changes (#338).
  */
 async function foldAllAccounts(): Promise<void> {
-  await Promise.all(accountsStore.accounts.map((account) => foldAccount(account.id.toHex(), false)))
+  // Signed-out accounts kept no derivationKey — nothing to derive feeds from.
+  await Promise.all(
+    accountsStore.accounts
+      .filter((account) => !account.isSignedOut)
+      .map((account) => foldAccount(account.id.toHex(), false)),
+  )
 }
 
 /**

--- a/ui/src/lib/dev/refresh-account-from-swarm.ts
+++ b/ui/src/lib/dev/refresh-account-from-swarm.ts
@@ -50,6 +50,11 @@ export async function refreshAccountFromSwarm(accountId: string): Promise<Refres
   if (!account) {
     return { ok: false, kind: 'error', error: 'No local account for this id' }
   }
+  if (account.isSignedOut) {
+    // The sign-out stripped the derivationKey — folding would derive garbage
+    // feed owners. Sign-back-in restores the state itself.
+    return { ok: false, kind: 'error', error: 'Account is signed out on this device' }
+  }
 
   const bee = new Bee(networkSettingsStore.beeNodeUrl)
 

--- a/ui/src/lib/sign-back-in.test.ts
+++ b/ui/src/lib/sign-back-in.test.ts
@@ -1,0 +1,199 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * The sign-out → sign-back-in restore chain, fully offline: the encrypted
+ * snapshot kept by `signOut()` must restore the synced state losslessly from
+ * the unlocked entropy alone (no network), and the network fallback must
+ * refuse to silently restore an empty account (`NoSyncedDataError`) unless
+ * the caller explicitly allows it.
+ */
+import { BatchId, EthAddress, PrivateKey } from '@ethersphere/bee-js'
+import { deriveAccountDerivationKey, foldAccountFromSwarm } from '@snaha/swarm-id'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { strip0x } from './crypto/hex'
+import { walletFromPhrase } from './crypto/mnemonic'
+import { NoSyncedDataError, signBackIn } from './sign-back-in'
+import { decryptSignOutSnapshot, encryptSignOutSnapshot } from './sign-out-snapshot'
+import { accountsStore } from './stores/accounts.svelte'
+
+vi.mock('$app/environment', () => ({ browser: false }))
+// Isolate from the dev sync/fold subsystems — signBackIn only pokes them.
+vi.mock('$lib/dev/sync-hooks', () => ({ triggerSync: vi.fn() }))
+vi.mock('$lib/dev/account-refresh', () => ({ noteAccountFolded: vi.fn() }))
+
+// The fold is network I/O — stub it; everything else in the lib stays real.
+vi.mock('@snaha/swarm-id', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@snaha/swarm-id')>()),
+  foldAccountFromSwarm: vi.fn(),
+}))
+
+// `signBackIn`'s fallback probes reachability via `new Bee(url).isConnected()`.
+let beeConnected = true
+vi.mock('@ethersphere/bee-js', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@ethersphere/bee-js')>()
+  return {
+    ...original,
+    Bee: class {
+      isConnected(): Promise<boolean> {
+        return Promise.resolve(beeConnected)
+      }
+    },
+  }
+})
+
+vi.hoisted(() => {
+  const backing = new Map<string, string>()
+  const localStorageStub = {
+    getItem: (key: string) => backing.get(key) ?? null,
+    setItem: (key: string, value: string) => void backing.set(key, value),
+    removeItem: (key: string) => void backing.delete(key),
+    clear: () => backing.clear(),
+  }
+  Object.assign(globalThis, {
+    window: {
+      localStorage: localStorageStub,
+      addEventListener: () => undefined,
+      removeEventListener: () => undefined,
+      dispatchEvent: () => true,
+    },
+    localStorage: localStorageStub,
+  })
+})
+
+const PHRASE = 'test test test test test test test test test test test junk'
+const wallet = walletFromPhrase(PHRASE)
+
+async function signedInRecord() {
+  return {
+    id: new EthAddress(wallet.address),
+    name: 'Snapshot Account',
+    createdAt: 1700000000000,
+    derivationKey: await deriveAccountDerivationKey(strip0x(wallet.privateKey)),
+    publicKey: strip0x(wallet.publicKey),
+    access: { type: 'password', kdfSalt: '00', kdfIterations: 1 } as const,
+    encryptedSeed: 'aabbccdd',
+    devices: [
+      { deviceId: '550e8400-e29b-41d4-a716-446655440000', createdAt: 1, lastSignedInAt: 1 },
+    ],
+    connectedApps: [
+      {
+        appUrl: 'https://app.example.com',
+        appName: 'Test App',
+        lastConnectedAt: 1700000000000,
+        appSecret: 'live-session-secret',
+        connectedUntil: 4102444800000,
+      },
+    ],
+    postageStamps: [
+      {
+        batchID: new BatchId('c'.repeat(64)),
+        signerKey: new PrivateKey('d'.repeat(64)),
+        utilization: 0,
+        usable: true,
+        depth: 20,
+        amount: 100000000n,
+        bucketDepth: 16,
+        blockNumber: 1,
+        immutableFlag: false,
+        exists: true,
+        createdAt: 1700000000000,
+      },
+    ],
+    defaultPostageStampBatchID: new BatchId('c'.repeat(64)),
+    accountNameAt: 1700000001000,
+  }
+}
+
+/** Sign the freshly-added account out the way the dialog does. */
+async function signedOutAccount() {
+  const live = accountsStore.add(await signedInRecord())
+  live.signOut(await encryptSignOutSnapshot(live))
+  return live
+}
+
+/** A signed-out remnant whose snapshot cannot decrypt — forces the fallback. */
+async function signedOutWithCorruptSnapshot() {
+  const { id, name, createdAt, access, encryptedSeed } = await signedInRecord()
+  return accountsStore.add({
+    id,
+    name,
+    createdAt,
+    access,
+    encryptedSeed,
+    encryptedState: '{"format":"swarm-id-signout-state","version":1,"salt":"00","payload":"00"}',
+    signedOutAt: 1700000000001,
+  })
+}
+
+beforeEach(() => {
+  accountsStore.clear()
+  vi.mocked(foldAccountFromSwarm).mockResolvedValue(undefined)
+  beeConnected = true
+})
+
+describe('sign-out snapshot', () => {
+  it('round-trips the synced state and strips live session secrets', async () => {
+    const live = accountsStore.add(await signedInRecord())
+    const encryptedState = await encryptSignOutSnapshot(live)
+    expect(encryptedState).not.toContain('live-session-secret')
+    expect(encryptedState).not.toContain(live.derivationKey)
+
+    const restored = await decryptSignOutSnapshot(encryptedState, live.derivationKey)
+
+    expect(restored.postageStamps[0].batchID.toHex()).toBe('c'.repeat(64))
+    expect(restored.devices).toHaveLength(1)
+    expect(restored.accountNameAt).toBe(1700000001000)
+    expect(restored.connectedApps[0].appSecret).toBeUndefined()
+    expect(restored.connectedApps[0].connectedUntil).toBeUndefined()
+  })
+
+  it('fails to decrypt with a different derivation key', async () => {
+    const live = accountsStore.add(await signedInRecord())
+    const encryptedState = await encryptSignOutSnapshot(live)
+
+    await expect(decryptSignOutSnapshot(encryptedState, '1'.repeat(64))).rejects.toThrow()
+  })
+})
+
+describe('signBackIn', () => {
+  it('restores from the snapshot without touching the network', async () => {
+    const live = await signedOutAccount()
+    expect(live.isSignedOut).toBe(true)
+    expect(live.postageStamps).toHaveLength(0)
+
+    const restored = await signBackIn(live, wallet.entropy)
+
+    expect(restored).toBe(live) // instance reused in place
+    expect(live.isSignedOut).toBe(false)
+    expect(live.postageStamps).toHaveLength(1)
+    expect(live.defaultPostageStampBatchID?.toHex()).toBe('c'.repeat(64))
+    expect(live.devices).toHaveLength(1)
+    expect(foldAccountFromSwarm).not.toHaveBeenCalled()
+  })
+
+  it('surfaces NoSyncedDataError when the snapshot is corrupt and the network has nothing', async () => {
+    const live = await signedOutWithCorruptSnapshot()
+
+    await expect(signBackIn(live, wallet.entropy)).rejects.toBeInstanceOf(NoSyncedDataError)
+    expect(live.isSignedOut).toBe(true) // nothing restored
+  })
+
+  it('restores a fresh shell only with allowEmpty', async () => {
+    const live = await signedOutWithCorruptSnapshot()
+
+    await signBackIn(live, wallet.entropy, { allowEmpty: true })
+
+    expect(live.isSignedOut).toBe(false)
+    expect(live.postageStamps).toHaveLength(0)
+    expect(live.derivationKey).toHaveLength(64)
+  })
+
+  it('throws a retry-able network error when unreachable instead of NoSyncedDataError', async () => {
+    const live = await signedOutWithCorruptSnapshot()
+    beeConnected = false
+
+    await expect(signBackIn(live, wallet.entropy)).rejects.toThrow(/Swarm network/)
+    expect(live.isSignedOut).toBe(true)
+  })
+})

--- a/ui/src/lib/sign-back-in.ts
+++ b/ui/src/lib/sign-back-in.ts
@@ -1,0 +1,89 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Sign a signed-out account back in from its retained vault. The sign-out
+ * stripped every synced field from disk, so the unlocked entropy re-derives
+ * the master key and `derivationKey`, the synced state is folded back from
+ * Swarm (the same read the phrase-import flow does), and the full record
+ * replaces the minimal remnant via `accountsStore.add` — which reuses the
+ * live instance, clearing `signedOutAt` in place for every held reference.
+ */
+import { Bee, EthAddress } from '@ethersphere/bee-js'
+import {
+  PARTITION_COUNT,
+  type SyncedAccount,
+  deriveAccountDerivationKey,
+  foldAccountFromSwarm,
+  foldedToSyncedAccount,
+} from '@snaha/swarm-id'
+
+import { strip0x } from '$lib/crypto/hex'
+import { walletFromEntropy } from '$lib/crypto/mnemonic'
+import { noteAccountFolded } from '$lib/dev/account-refresh'
+import { triggerSync } from '$lib/dev/sync-hooks'
+import { accountsStore } from '$lib/stores/accounts.svelte'
+import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
+import type { Account } from '$lib/types'
+
+/**
+ * Restore `account` to signed-in from its unlocked entropy. Throws (for the
+ * unlock dialog to surface) when the Swarm network is unreachable — signing
+ * back in from a stale local copy is not an option, since sign-out kept none.
+ */
+export async function signBackIn(account: Account, entropy: Uint8Array): Promise<Account> {
+  const vault = account.vault
+  const wallet = walletFromEntropy(entropy)
+  if (!account.id.equals(new EthAddress(wallet.address))) {
+    // The vault decrypted to some other account's seed — a corrupted record,
+    // not a wrong credential (that fails inside `unlockAccount` already).
+    throw new Error('The unlocked seed does not match this account.')
+  }
+  const derivationKey = await deriveAccountDerivationKey(strip0x(wallet.privateKey))
+  const bee = new Bee(networkSettingsStore.beeNodeUrl)
+  const accountId = account.id.toHex()
+
+  // The fold's roster reader swallows read failures into an empty roster, so
+  // it can't by itself tell "never synced" from "network down". The
+  // reachability probe disambiguates, but its answer only matters when the
+  // fold finds nothing — so run it alongside the fold instead of serially in
+  // front. `.catch(false)` both prevents a floating rejection and treats a
+  // probe error as "unreachable".
+  const connectedPromise = bee.isConnected().catch(() => false)
+  const folded = await foldAccountFromSwarm({ bee, derivationKey, accountId })
+  if (!folded && !(await connectedPromise)) {
+    throw new Error("Couldn't reach the Swarm network. Check your connection and try again.")
+  }
+
+  const restored: SyncedAccount = folded
+    ? foldedToSyncedAccount({ id: account.id, derivationKey, account: folded.account })
+    : {
+        // Reachable but nothing published under this account (it never
+        // synced) — restore a fresh shell, same as the import flow's
+        // set-up-fresh path.
+        id: account.id,
+        name: account.name,
+        createdAt: account.createdAt,
+        derivationKey,
+        publicKey: strip0x(wallet.publicKey),
+        devices: [],
+        connectedApps: [],
+        postageStamps: [],
+        partitionCount: PARTITION_COUNT,
+      }
+  if (folded) {
+    // Stamp the fold cooldown so the forced fold right after sign-in skips
+    // within the grace window instead of re-folding back-to-back.
+    noteAccountFolded(accountId)
+  }
+
+  const live = accountsStore.add({
+    ...restored,
+    access: vault.access,
+    encryptedSeed: vault.encryptedSeed,
+  })
+  // `add` persists but doesn't fire the sync hook, so publish once to
+  // re-register this device in the Swarm roster (mirrors the import flow's
+  // finalize). No-ops harmlessly until the account has a stamp to sign with.
+  triggerSync(accountId)
+  return live
+}

--- a/ui/src/lib/sign-back-in.ts
+++ b/ui/src/lib/sign-back-in.ts
@@ -2,11 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 /**
  * Sign a signed-out account back in from its retained vault. The sign-out
- * stripped every synced field from disk, so the unlocked entropy re-derives
- * the master key and `derivationKey`, the synced state is folded back from
- * Swarm (the same read the phrase-import flow does), and the full record
- * replaces the minimal remnant via `accountsStore.add` — which reuses the
- * live instance, clearing `signedOutAt` in place for every held reference.
+ * stripped every synced field from plaintext disk but kept them as an
+ * encrypted snapshot (`encryptedState`), so the unlocked entropy re-derives
+ * the master key and `derivationKey`, decrypts the snapshot, and restores the
+ * full record via `accountsStore.add` — which reuses the live instance,
+ * clearing `signedOutAt` in place for every held reference. No network
+ * needed; the background fold reconciles with peers afterwards.
+ *
+ * Only when the snapshot is missing or corrupt (tampered storage) does the
+ * restore fall back to folding the state from Swarm — and an empty fold there
+ * surfaces as `NoSyncedDataError` instead of silently restoring an empty
+ * account, unless the caller explicitly opted into `allowEmpty`.
  */
 import { Bee, EthAddress } from '@ethersphere/bee-js'
 import {
@@ -21,16 +27,36 @@ import { strip0x } from '$lib/crypto/hex'
 import { walletFromEntropy } from '$lib/crypto/mnemonic'
 import { noteAccountFolded } from '$lib/dev/account-refresh'
 import { triggerSync } from '$lib/dev/sync-hooks'
+import { decryptSignOutSnapshot } from '$lib/sign-out-snapshot'
 import { accountsStore } from '$lib/stores/accounts.svelte'
 import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
 import type { Account } from '$lib/types'
 
 /**
- * Restore `account` to signed-in from its unlocked entropy. Throws (for the
- * unlock dialog to surface) when the Swarm network is unreachable — signing
- * back in from a stale local copy is not an option, since sign-out kept none.
+ * The account is reachable on the network but has no synced data there, and
+ * no local snapshot could restore it. Restoring would produce an EMPTY
+ * account — callers surface an explicit warning and retry with `allowEmpty`
+ * only on user confirmation.
  */
-export async function signBackIn(account: Account, entropy: Uint8Array): Promise<Account> {
+export class NoSyncedDataError extends Error {
+  constructor() {
+    super('No synced data was found for this account on the Swarm network.')
+    this.name = 'NoSyncedDataError'
+  }
+}
+
+/**
+ * Restore `account` to signed-in from its unlocked entropy. Throws (for the
+ * unlock dialog to surface) when the snapshot is unusable AND the network
+ * fold cannot restore the state — `NoSyncedDataError` when the network
+ * answered "nothing there" (see above), a plain retry-able error when it was
+ * unreachable.
+ */
+export async function signBackIn(
+  account: Account,
+  entropy: Uint8Array,
+  opts?: { allowEmpty?: boolean },
+): Promise<Account> {
   const vault = account.vault
   const wallet = walletFromEntropy(entropy)
   if (!account.id.equals(new EthAddress(wallet.address))) {
@@ -39,42 +65,14 @@ export async function signBackIn(account: Account, entropy: Uint8Array): Promise
     throw new Error('The unlocked seed does not match this account.')
   }
   const derivationKey = await deriveAccountDerivationKey(strip0x(wallet.privateKey))
-  const bee = new Bee(networkSettingsStore.beeNodeUrl)
   const accountId = account.id.toHex()
 
-  // The fold's roster reader swallows read failures into an empty roster, so
-  // it can't by itself tell "never synced" from "network down". The
-  // reachability probe disambiguates, but its answer only matters when the
-  // fold finds nothing — so run it alongside the fold instead of serially in
-  // front. `.catch(false)` both prevents a floating rejection and treats a
-  // probe error as "unreachable".
-  const connectedPromise = bee.isConnected().catch(() => false)
-  const folded = await foldAccountFromSwarm({ bee, derivationKey, accountId })
-  if (!folded && !(await connectedPromise)) {
-    throw new Error("Couldn't reach the Swarm network. Check your connection and try again.")
-  }
-
-  const restored: SyncedAccount = folded
-    ? foldedToSyncedAccount({ id: account.id, derivationKey, account: folded.account })
-    : {
-        // Reachable but nothing published under this account (it never
-        // synced) — restore a fresh shell, same as the import flow's
-        // set-up-fresh path.
-        id: account.id,
-        name: account.name,
-        createdAt: account.createdAt,
-        derivationKey,
-        publicKey: strip0x(wallet.publicKey),
-        devices: [],
-        connectedApps: [],
-        postageStamps: [],
-        partitionCount: PARTITION_COUNT,
-      }
-  if (folded) {
-    // Stamp the fold cooldown so the forced fold right after sign-in skips
-    // within the grace window instead of re-folding back-to-back.
-    noteAccountFolded(accountId)
-  }
+  const restored =
+    (await restoreFromSnapshot(account, derivationKey)) ??
+    (await restoreFromSwarm(account, derivationKey, {
+      publicKey: strip0x(wallet.publicKey),
+      allowEmpty: opts?.allowEmpty === true,
+    }))
 
   const live = accountsStore.add({
     ...restored,
@@ -86,4 +84,75 @@ export async function signBackIn(account: Account, entropy: Uint8Array): Promise
   // finalize). No-ops harmlessly until the account has a stamp to sign with.
   triggerSync(accountId)
   return live
+}
+
+/**
+ * The normal path: decrypt the snapshot the sign-out kept. Undefined when it
+ * is missing or unusable. Deliberately does NOT stamp the fold cooldown — the
+ * snapshot is local, so the next fold tick still reconciles with peers.
+ */
+async function restoreFromSnapshot(
+  account: Account,
+  derivationKey: string,
+): Promise<SyncedAccount | undefined> {
+  const encryptedState = account.encryptedState
+  if (encryptedState === undefined) {
+    return undefined
+  }
+  try {
+    const restored = await decryptSignOutSnapshot(encryptedState, derivationKey)
+    // A snapshot for a different id would restore someone else's state onto
+    // this row — treat it as corrupt and fall back to the network.
+    return restored.id.equals(account.id) ? restored : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Fallback: fold the state from Swarm (the same read as first sign-in on a
+ * new device). Empty fold on a reachable network throws `NoSyncedDataError`
+ * unless `allowEmpty` — restoring a fresh shell silently would read as data
+ * loss.
+ */
+async function restoreFromSwarm(
+  account: Account,
+  derivationKey: string,
+  opts: { publicKey: string; allowEmpty: boolean },
+): Promise<SyncedAccount> {
+  const bee = new Bee(networkSettingsStore.beeNodeUrl)
+  const accountId = account.id.toHex()
+
+  // The fold's roster reader swallows read failures into an empty roster, so
+  // it can't by itself tell "never synced" from "network down". The
+  // reachability probe disambiguates, but its answer only matters when the
+  // fold finds nothing — so run it alongside the fold instead of serially in
+  // front. `.catch(false)` both prevents a floating rejection and treats a
+  // probe error as "unreachable".
+  const connectedPromise = bee.isConnected().catch(() => false)
+  const folded = await foldAccountFromSwarm({ bee, derivationKey, accountId })
+  if (folded) {
+    // Stamp the fold cooldown so the forced fold right after sign-in skips
+    // within the grace window instead of re-folding back-to-back.
+    noteAccountFolded(accountId)
+    return foldedToSyncedAccount({ id: account.id, derivationKey, account: folded.account })
+  }
+  if (!(await connectedPromise)) {
+    throw new Error("Couldn't reach the Swarm network. Check your connection and try again.")
+  }
+  if (!opts.allowEmpty) {
+    throw new NoSyncedDataError()
+  }
+  // Explicitly accepted: restore a fresh shell with nothing but the identity.
+  return {
+    id: account.id,
+    name: account.name,
+    createdAt: account.createdAt,
+    derivationKey,
+    publicKey: opts.publicKey,
+    devices: [],
+    connectedApps: [],
+    postageStamps: [],
+    partitionCount: PARTITION_COUNT,
+  }
 }

--- a/ui/src/lib/sign-out-snapshot.ts
+++ b/ui/src/lib/sign-out-snapshot.ts
@@ -1,0 +1,80 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * The encrypted snapshot a sign-out keeps of the synced account state, so
+ * sign-back-in restores it losslessly without the network. Same shape as the
+ * .swarmid backup (`$lib/crypto/backup`): the portable projection
+ * (`serializeSyncedAccount` — never the seed vault or live per-app session
+ * secrets) AES-GCM encrypted. The key derives from the account's
+ * `derivationKey` — in memory at sign-out (no unlock happens there) and
+ * re-derived from the seed at sign-back-in — instead of the phrase entropy.
+ */
+import {
+  type SyncedAccount,
+  SyncedAccountSchemaV1,
+  hexToUint8Array,
+  isSignedOutAccount,
+  serializeSyncedAccount,
+  uint8ArrayToHex,
+} from '@snaha/swarm-id'
+
+import { decryptSeed, deriveKeyFromSecret, encryptSeed, randomSalt } from '$lib/crypto/encryption'
+import type { Account } from '$lib/types'
+
+const SNAPSHOT_VERSION = 1
+const SNAPSHOT_KEY_INFO = 'swarm-id-signout-state-v1'
+
+interface SnapshotEnvelope {
+  format: 'swarm-id-signout-state'
+  version: number
+  salt: string
+  payload: string
+}
+
+function deriveSnapshotKey(derivationKey: string, salt: Uint8Array): Promise<CryptoKey> {
+  return deriveKeyFromSecret(hexToUint8Array(derivationKey), salt, SNAPSHOT_KEY_INFO)
+}
+
+/** Serialize and encrypt the account's synced state for the sign-out remnant. */
+export async function encryptSignOutSnapshot(account: Account): Promise<string> {
+  const record = account.toRecord()
+  if (isSignedOutAccount(record)) {
+    throw new Error('Cannot snapshot a signed-out account: its state is already stripped.')
+  }
+  const data = serializeSyncedAccount(record)
+
+  const salt = randomSalt()
+  const key = await deriveSnapshotKey(account.derivationKey, salt)
+
+  const envelope: SnapshotEnvelope = {
+    format: 'swarm-id-signout-state',
+    version: SNAPSHOT_VERSION,
+    salt: uint8ArrayToHex(salt),
+    payload: await encryptSeed(new TextEncoder().encode(JSON.stringify(data)), key),
+  }
+  return JSON.stringify(envelope)
+}
+
+/**
+ * Decrypt a sign-out snapshot back into the synced state. Throws on a corrupt
+ * envelope or a key mismatch — the caller falls back to folding from Swarm.
+ */
+export async function decryptSignOutSnapshot(
+  encryptedState: string,
+  derivationKey: string,
+): Promise<SyncedAccount> {
+  const envelope = JSON.parse(encryptedState) as SnapshotEnvelope
+  if (
+    envelope.format !== 'swarm-id-signout-state' ||
+    envelope.version !== SNAPSHOT_VERSION ||
+    typeof envelope.salt !== 'string' ||
+    typeof envelope.payload !== 'string'
+  ) {
+    throw new Error('Not a sign-out state snapshot.')
+  }
+
+  const key = await deriveSnapshotKey(derivationKey, hexToUint8Array(envelope.salt))
+  const plaintext = await decryptSeed(envelope.payload, key)
+  const raw: unknown = JSON.parse(new TextDecoder().decode(plaintext))
+  return SyncedAccountSchemaV1.parse(raw)
+}

--- a/ui/src/lib/stores/accounts.svelte.test.ts
+++ b/ui/src/lib/stores/accounts.svelte.test.ts
@@ -5,10 +5,11 @@
  *
  * - Store-level: the persist read-merge-write (two-tab race) and tolerance of
  *   a malformed (tampered) current-account id.
- * - Class-level: the signed-out invariants — `accessMethod` only exists while
- *   the vault does, and neither a getter read nor a late `setAccess` (e.g. a
- *   change-method ceremony finishing after a cross-tab sign-out) may act on —
- *   or resurrect — a wiped vault.
+ * - Class-level: the sign-out invariants — the vault (and `accessMethod`)
+ *   survives a sign-out so the sign-back-in ceremony can unlock it, while
+ *   every synced field (incl. the secret `derivationKey`) is stripped from
+ *   memory and the projected record; a late `setAccess` (e.g. a change-method
+ *   ceremony finishing after a cross-tab sign-out) may not undo the sign-out.
  */
 import { EthAddress } from '@ethersphere/bee-js'
 import {
@@ -167,26 +168,67 @@ function signedInRecord(): SignedInAccount {
 }
 
 function signedOutRecord(): SignedOutAccount {
-  const { access: _access, encryptedSeed: _encryptedSeed, ...synced } = signedInRecord()
-  return { ...synced, signedOutAt: 1700000000001 }
+  const { id, name, createdAt, access, encryptedSeed } = signedInRecord()
+  return { id, name, createdAt, access, encryptedSeed, signedOutAt: 1700000000001 }
 }
 
-describe('Account.accessMethod', () => {
+describe('Account sign-out state', () => {
   it('returns the vault access method while signed in', () => {
     const account = new Account(signedInRecord(), noCommit)
     expect(account.accessMethod.type).toBe('password')
   })
 
-  it('throws for an account loaded as signed out', () => {
+  it('keeps the access method readable for an account loaded as signed out', () => {
     const account = new Account(signedOutRecord(), noCommit)
     expect(account.isSignedOut).toBe(true)
-    expect(() => account.accessMethod).toThrow(/signed out/)
+    expect(account.accessMethod.type).toBe('password')
   })
 
-  it('throws once signOut() wipes the vault', () => {
+  it('hydrates a signed-out record with empty synced fields', () => {
+    const account = new Account(signedOutRecord(), noCommit)
+    expect(account.derivationKey).toBe('')
+    expect(account.publicKey).toBe('')
+    expect(account.connectedApps).toEqual([])
+    expect(account.postageStamps).toEqual([])
+    expect(account.devices).toEqual([])
+  })
+})
+
+describe('Account.signOut', () => {
+  it('retains the vault and strips the synced fields from memory', () => {
     const account = new Account(signedInRecord(), noCommit)
     account.signOut()
-    expect(() => account.accessMethod).toThrow(/signed out/)
+    expect(account.isSignedOut).toBe(true)
+    expect(account.accessMethod.type).toBe('password')
+    expect(account.vault.encryptedSeed).toBe('aabbccdd')
+    expect(account.derivationKey).toBe('')
+    expect(account.connectedApps).toEqual([])
+  })
+
+  it('projects exactly the minimal remnant record', () => {
+    const account = new Account(signedInRecord(), noCommit)
+    account.signOut()
+    expect(Object.keys(account.toRecord()).sort()).toEqual([
+      'access',
+      'createdAt',
+      'encryptedSeed',
+      'id',
+      'name',
+      'signedOutAt',
+    ])
+  })
+
+  it('signs back in when a full record replaces it through accountsStore.add', () => {
+    const live = accountsStore.add(record(X_ID_HEX, 'x'))
+    live.signOut()
+    expect(live.isSignedOut).toBe(true)
+
+    const restored = accountsStore.add(record(X_ID_HEX, 'x'))
+
+    expect(restored).toBe(live) // instance reused, held references stay valid
+    expect(live.isSignedOut).toBe(false)
+    expect(live.signedOutAt).toBeUndefined()
+    expect(live.derivationKey).toBe('f'.repeat(64))
   })
 })
 
@@ -197,14 +239,15 @@ describe('Account.setAccess', () => {
     expect(account.accessMethod.type).toBe('passkey')
   })
 
-  it('throws on a signed-out account instead of re-arming the vault', () => {
+  it('throws on a signed-out account instead of undoing the sign-out', () => {
     const account = new Account(signedInRecord(), noCommit)
     account.signOut()
     expect(() =>
       account.setAccess({ type: 'password', kdfSalt: '11', kdfIterations: 100000 }, 'bbccddee'),
     ).toThrow(/signed out/)
-    // The sign-out survived: still no vault, and the record projects signed out.
+    // The sign-out survived, and the original vault is untouched.
     expect(account.isSignedOut).toBe(true)
+    expect(account.vault.encryptedSeed).toBe('aabbccdd')
     expect(account.toRecord()).toMatchObject({ signedOutAt: expect.any(Number) })
   })
 })

--- a/ui/src/lib/stores/accounts.svelte.test.ts
+++ b/ui/src/lib/stores/accounts.svelte.test.ts
@@ -167,9 +167,20 @@ function signedInRecord(): SignedInAccount {
   }
 }
 
+const ENCRYPTED_STATE =
+  '{"format":"swarm-id-signout-state","version":1,"salt":"00","payload":"aabb"}'
+
 function signedOutRecord(): SignedOutAccount {
   const { id, name, createdAt, access, encryptedSeed } = signedInRecord()
-  return { id, name, createdAt, access, encryptedSeed, signedOutAt: 1700000000001 }
+  return {
+    id,
+    name,
+    createdAt,
+    access,
+    encryptedSeed,
+    encryptedState: ENCRYPTED_STATE,
+    signedOutAt: 1700000000001,
+  }
 }
 
 describe('Account sign-out state', () => {
@@ -195,23 +206,25 @@ describe('Account sign-out state', () => {
 })
 
 describe('Account.signOut', () => {
-  it('retains the vault and strips the synced fields from memory', () => {
+  it('retains the vault and the snapshot, strips the synced fields from memory', () => {
     const account = new Account(signedInRecord(), noCommit)
-    account.signOut()
+    account.signOut(ENCRYPTED_STATE)
     expect(account.isSignedOut).toBe(true)
     expect(account.accessMethod.type).toBe('password')
     expect(account.vault.encryptedSeed).toBe('aabbccdd')
+    expect(account.encryptedState).toBe(ENCRYPTED_STATE)
     expect(account.derivationKey).toBe('')
     expect(account.connectedApps).toEqual([])
   })
 
   it('projects exactly the minimal remnant record', () => {
     const account = new Account(signedInRecord(), noCommit)
-    account.signOut()
+    account.signOut(ENCRYPTED_STATE)
     expect(Object.keys(account.toRecord()).sort()).toEqual([
       'access',
       'createdAt',
       'encryptedSeed',
+      'encryptedState',
       'id',
       'name',
       'signedOutAt',
@@ -220,7 +233,7 @@ describe('Account.signOut', () => {
 
   it('signs back in when a full record replaces it through accountsStore.add', () => {
     const live = accountsStore.add(record(X_ID_HEX, 'x'))
-    live.signOut()
+    live.signOut(ENCRYPTED_STATE)
     expect(live.isSignedOut).toBe(true)
 
     const restored = accountsStore.add(record(X_ID_HEX, 'x'))
@@ -228,6 +241,7 @@ describe('Account.signOut', () => {
     expect(restored).toBe(live) // instance reused, held references stay valid
     expect(live.isSignedOut).toBe(false)
     expect(live.signedOutAt).toBeUndefined()
+    expect(live.encryptedState).toBeUndefined()
     expect(live.derivationKey).toBe('f'.repeat(64))
   })
 })
@@ -241,7 +255,7 @@ describe('Account.setAccess', () => {
 
   it('throws on a signed-out account instead of undoing the sign-out', () => {
     const account = new Account(signedInRecord(), noCommit)
-    account.signOut()
+    account.signOut(ENCRYPTED_STATE)
     expect(() =>
       account.setAccess({ type: 'password', kdfSalt: '11', kdfIterations: 100000 }, 'bbccddee'),
     ).toThrow(/signed out/)

--- a/ui/src/lib/stores/accounts.svelte.ts
+++ b/ui/src/lib/stores/accounts.svelte.ts
@@ -24,13 +24,11 @@ type AccountSettings = { appSessionDuration?: number }
 
 /**
  * The device-local tail of the account record, mirroring the lib's `Account`
- * union: the seed vault while signed in, or the sign-out marker once
- * `signOut()` wiped it. Held as ONE union-typed field (not three independently
- * writable ones) so a half-signed-out live object is unrepresentable.
+ * union: the seed vault — which SURVIVES a sign-out so the user can sign back
+ * in with the existing access method — plus the sign-out marker while signed
+ * out. Held as ONE field so the vault and the marker can't drift apart.
  */
-type DeviceAuth =
-  | { vault: LocalVault; signedOutAt?: undefined }
-  | { vault?: undefined; signedOutAt: number }
+type DeviceAuth = { vault: LocalVault; signedOutAt?: number }
 
 /**
  * The account aggregate root. Fields are reactive (`$state`) so component reads
@@ -68,9 +66,12 @@ export class Account {
   derivationKey = $state('')
   name = $state('')
   publicKey = $state('')
-  // Device-local auth state: the seed vault while signed in, the sign-out
-  // marker after `signOut()` wiped it (exposed via the getters below).
-  #deviceAuth = $state<DeviceAuth>({ signedOutAt: 0 })
+  // Device-local auth state: the seed vault plus the sign-out marker (exposed
+  // via the getters below). The placeholder is overwritten by `applyRecord` in
+  // the constructor before any read.
+  #deviceAuth = $state<DeviceAuth>({
+    vault: { access: { type: 'password', kdfSalt: '', kdfIterations: 0 }, encryptedSeed: '' },
+  })
   settings = $state<AccountSettings | undefined>(undefined)
   defaultPostageStampBatchID = $state<BatchId | undefined>(undefined)
   devices = $state<Device[]>([])
@@ -106,12 +107,18 @@ export class Account {
    */
   applyRecord(record: AccountRecord) {
     this.createdAt = record.createdAt
-    this.derivationKey = record.derivationKey
     this.name = record.name
+    this.#deviceAuth = {
+      vault: { access: record.access, encryptedSeed: record.encryptedSeed },
+      signedOutAt: record.signedOutAt,
+    }
+    if (isSignedOutAccount(record)) {
+      // The stored record is the minimal sign-out remnant — no synced fields.
+      this.#resetSyncedFields()
+      return
+    }
+    this.derivationKey = record.derivationKey
     this.publicKey = record.publicKey
-    this.#deviceAuth = isSignedOutAccount(record)
-      ? { signedOutAt: record.signedOutAt }
-      : { vault: { access: record.access, encryptedSeed: record.encryptedSeed } }
     this.settings = record.settings
     this.defaultPostageStampBatchID = record.defaultPostageStampBatchID
     this.devices = record.devices
@@ -125,11 +132,42 @@ export class Account {
   }
 
   /**
+   * Reset every synced field to its empty default — a signed-out account keeps
+   * only the vault and display fields, in memory as on disk, so no stale (or
+   * secret: `derivationKey`) synced data lingers past a sign-out.
+   */
+  #resetSyncedFields() {
+    this.derivationKey = ''
+    this.publicKey = ''
+    this.settings = undefined
+    this.defaultPostageStampBatchID = undefined
+    this.devices = []
+    this.connectedApps = []
+    this.postageStamps = []
+    this.accountNameAt = undefined
+    this.defaultStampAt = undefined
+    this.settingsAt = undefined
+    this.lastModified = undefined
+    this.partitionCount = undefined
+  }
+
+  /**
    * Project the live instance back onto the lib's `Account` record union —
    * `applyRecord`'s inverse, what `persist()` hands the storage manager. The
    * union return type makes a half-signed-out projection a type error.
    */
   toRecord(): AccountRecord {
+    const { vault, signedOutAt } = this.#deviceAuth
+    if (signedOutAt !== undefined) {
+      // The minimal sign-out remnant — display fields plus the retained vault.
+      return {
+        id: this.id,
+        name: this.name,
+        createdAt: this.createdAt,
+        ...vault,
+        signedOutAt,
+      }
+    }
     const synced: SyncedAccount = {
       id: this.id,
       name: this.name,
@@ -147,10 +185,7 @@ export class Account {
       lastModified: this.lastModified,
       partitionCount: this.partitionCount,
     }
-    const auth = this.#deviceAuth
-    return auth.vault === undefined
-      ? { ...synced, signedOutAt: auth.signedOutAt }
-      : { ...synced, ...auth.vault }
+    return { ...synced, ...vault }
   }
 
   /** Active (non-revoked) connected apps — what the UI displays. */
@@ -168,38 +203,31 @@ export class Account {
     return this.stamps.length === 0
   }
 
-  /** Device-local seed vault; `undefined` once `signOut()` wiped it. */
-  get vault(): LocalVault | undefined {
+  /** Device-local seed vault — survives a sign-out (encrypted at rest). */
+  get vault(): LocalVault {
     return this.#deviceAuth.vault
   }
 
   /**
-   * How the seed is unlocked on this device, asserted present. The unlock
-   * ceremonies and the whole signed-in account UI (`HomeAccount`,
-   * `UnlockDialog`) only ever render for a signed-in account — `routes/+page`
-   * maps a signed-out current account to no session — so those callers read
-   * the method directly instead of `?`-chaining a union getter. Two-state
-   * callers use `isSignedOut` / `vault` instead. Throws if the vault was wiped,
-   * surfacing a routing bug rather than silently reading `undefined`.
+   * How the seed is unlocked on this device. Always present — the vault
+   * survives a sign-out, which is what lets the sign-back-in ceremony unlock
+   * with the existing method instead of the recovery phrase.
    */
   get accessMethod(): AccessMethod {
-    const vault = this.#deviceAuth.vault
-    if (vault === undefined) {
-      throw new Error(
-        'Cannot read the access method: this account is signed out on this device (its seed vault was wiped). Read `accessMethod` only in signed-in-only UI; guard with `isSignedOut` otherwise.',
-      )
-    }
-    return vault.access
+    return this.#deviceAuth.vault.access
   }
 
-  /** When `signOut()` wiped the vault; `undefined` while signed in. */
+  /** When `signOut()` stripped the synced data; `undefined` while signed in. */
   get signedOutAt(): number | undefined {
     return this.#deviceAuth.signedOutAt
   }
 
-  /** Signed out on this device: the seed vault was wiped by `signOut()`. */
+  /**
+   * Signed out on this device: `signOut()` stripped the synced data, but the
+   * vault remains — unlocking it signs back in.
+   */
   get isSignedOut(): boolean {
-    return this.#deviceAuth.vault === undefined
+    return this.#deviceAuth.signedOutAt !== undefined
   }
 
   rename(name: string) {
@@ -212,15 +240,14 @@ export class Account {
 
   /**
    * Swap the unlock method: new access metadata + seed re-encrypted for it.
-   * Throws on a signed-out account — sign-out wiped the vault, and a late
-   * change-method ceremony re-arming it here would silently undo the
-   * sign-out. Signing back in replaces the whole record through the import
-   * flow (`accountsStore.add`) instead.
+   * Throws on a signed-out account — a late change-method ceremony landing
+   * here would silently undo the sign-out. Sign back in first (the
+   * sign-back-in flow replaces the whole record via `accountsStore.add`).
    */
   setAccess(access: AccessMethod, encryptedSeed: string) {
     if (this.isSignedOut) {
       throw new Error(
-        'Cannot set an access method: this account is signed out on this device (its seed vault was wiped). Signing back in requires the recovery phrase, not a method change.',
+        'Cannot set an access method: this account is signed out on this device. Sign back in first.',
       )
     }
     this.#deviceAuth = { vault: { access, encryptedSeed } }
@@ -229,21 +256,16 @@ export class Account {
   }
 
   /**
-   * Sign this account out on THIS device: wipe the seed vault and clear the
-   * live per-app session material so the dApp proxy can no longer authenticate
-   * from here. The row stays in the account list — signing back in requires
-   * the recovery phrase and a new access method. Deliberately NOT
-   * `disconnectApp` (no `updatedAt` bump): a device-local de-auth must not
-   * propagate as a synced disconnect. `skipSync` for the same reason — and
-   * with the keys gone there is nothing left to publish with anyway.
+   * Sign this account out on THIS device: keep the encrypted seed vault (so
+   * signing back in only takes the access method) but strip every synced
+   * field — including the secret `derivationKey` and the live per-app session
+   * material the dApp proxy authenticates from. The row stays in the account
+   * list as a minimal remnant. `skipSync`: a device-local de-auth must not
+   * propagate, and the record no longer carries anything to publish with.
    */
   signOut() {
-    this.#deviceAuth = { signedOutAt: Date.now() }
-    this.connectedApps = this.connectedApps.map((app) => ({
-      ...app,
-      appSecret: undefined,
-      connectedUntil: undefined,
-    }))
+    this.#deviceAuth = { vault: this.#deviceAuth.vault, signedOutAt: Date.now() }
+    this.#resetSyncedFields()
     this.#commit({ skipSync: true })
   }
 

--- a/ui/src/lib/stores/accounts.svelte.ts
+++ b/ui/src/lib/stores/accounts.svelte.ts
@@ -25,10 +25,14 @@ type AccountSettings = { appSessionDuration?: number }
 /**
  * The device-local tail of the account record, mirroring the lib's `Account`
  * union: the seed vault — which SURVIVES a sign-out so the user can sign back
- * in with the existing access method — plus the sign-out marker while signed
- * out. Held as ONE field so the vault and the marker can't drift apart.
+ * in with the existing access method — plus, while signed out, the sign-out
+ * marker and the encrypted snapshot of the synced state (restored on
+ * sign-back-in). Held as ONE union-typed field so a signed-out state without
+ * its snapshot is unrepresentable.
  */
-type DeviceAuth = { vault: LocalVault; signedOutAt?: number }
+type DeviceAuth =
+  | { vault: LocalVault; signedOutAt?: undefined; encryptedState?: undefined }
+  | { vault: LocalVault; signedOutAt: number; encryptedState: string }
 
 /**
  * The account aggregate root. Fields are reactive (`$state`) so component reads
@@ -108,15 +112,18 @@ export class Account {
   applyRecord(record: AccountRecord) {
     this.createdAt = record.createdAt
     this.name = record.name
-    this.#deviceAuth = {
-      vault: { access: record.access, encryptedSeed: record.encryptedSeed },
-      signedOutAt: record.signedOutAt,
-    }
+    const vault = { access: record.access, encryptedSeed: record.encryptedSeed }
     if (isSignedOutAccount(record)) {
       // The stored record is the minimal sign-out remnant — no synced fields.
+      this.#deviceAuth = {
+        vault,
+        signedOutAt: record.signedOutAt,
+        encryptedState: record.encryptedState,
+      }
       this.#resetSyncedFields()
       return
     }
+    this.#deviceAuth = { vault }
     this.derivationKey = record.derivationKey
     this.publicKey = record.publicKey
     this.settings = record.settings
@@ -157,17 +164,20 @@ export class Account {
    * union return type makes a half-signed-out projection a type error.
    */
   toRecord(): AccountRecord {
-    const { vault, signedOutAt } = this.#deviceAuth
-    if (signedOutAt !== undefined) {
-      // The minimal sign-out remnant — display fields plus the retained vault.
+    const auth = this.#deviceAuth
+    if (auth.signedOutAt !== undefined) {
+      // The minimal sign-out remnant — display fields, the retained vault,
+      // and the encrypted snapshot of the synced state.
       return {
         id: this.id,
         name: this.name,
         createdAt: this.createdAt,
-        ...vault,
-        signedOutAt,
+        ...auth.vault,
+        encryptedState: auth.encryptedState,
+        signedOutAt: auth.signedOutAt,
       }
     }
+    const { vault } = auth
     const synced: SyncedAccount = {
       id: this.id,
       name: this.name,
@@ -223,6 +233,14 @@ export class Account {
   }
 
   /**
+   * The encrypted snapshot of the synced state a sign-out kept; `undefined`
+   * while signed in. Sign-back-in decrypts and restores it.
+   */
+  get encryptedState(): string | undefined {
+    return this.#deviceAuth.encryptedState
+  }
+
+  /**
    * Signed out on this device: `signOut()` stripped the synced data, but the
    * vault remains — unlocking it signs back in.
    */
@@ -259,12 +277,20 @@ export class Account {
    * Sign this account out on THIS device: keep the encrypted seed vault (so
    * signing back in only takes the access method) but strip every synced
    * field — including the secret `derivationKey` and the live per-app session
-   * material the dApp proxy authenticates from. The row stays in the account
-   * list as a minimal remnant. `skipSync`: a device-local de-auth must not
-   * propagate, and the record no longer carries anything to publish with.
+   * material the dApp proxy authenticates from. What is stripped survives as
+   * `encryptedState`, the AES-encrypted snapshot the caller built from this
+   * account BEFORE calling (encryption is async WebCrypto; this mutator stays
+   * synchronous), so sign-back-in can restore losslessly without the network.
+   * The row stays in the account list as a minimal remnant. `skipSync`: a
+   * device-local de-auth must not propagate, and the record no longer carries
+   * anything to publish with.
    */
-  signOut() {
-    this.#deviceAuth = { vault: this.#deviceAuth.vault, signedOutAt: Date.now() }
+  signOut(encryptedState: string) {
+    this.#deviceAuth = {
+      vault: this.#deviceAuth.vault,
+      signedOutAt: Date.now(),
+      encryptedState,
+    }
     this.#resetSyncedFields()
     this.#commit({ skipSync: true })
   }

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -8,7 +8,6 @@
   import UserRoundMinus from '@lucide/svelte/icons/user-round-minus'
   import UserRoundPlus from '@lucide/svelte/icons/user-round-plus'
 
-  import { goto } from '$app/navigation'
   import { resolve } from '$app/paths'
   import { page } from '$app/state'
 
@@ -19,6 +18,7 @@
   import HomeDrives from '$lib/components/home-drives.svelte'
   import ProductPage from '$lib/components/product-page.svelte'
   import SettingsMenu from '$lib/components/settings-menu.svelte'
+  import SignBackInDialog from '$lib/components/sign-back-in-dialog.svelte'
   import SwarmWordmark from '$lib/components/swarm-wordmark.svelte'
   import { Button } from '$lib/components/ui/button'
   import { Tabs } from '$lib/components/ui/tabs'
@@ -37,12 +37,14 @@
   /** Shows the create/import choice while other accounts exist on the device. */
   let addingAccount = $state(false)
   let tab = $state('apps')
+  /** Signed-out account being unlocked to sign back in. */
+  let signingBackIn = $state<Account | undefined>(undefined)
 
   const accounts = $derived(accountsStore.accounts)
   // The active session's account, if any: with one the page IS the app
   // (apps/drives/account tabs); without one it is the account chooser. A
   // signed-out current account (sign-out in another tab arrives via the
-  // storage listener) has no keys left, so there is no session to show.
+  // storage listener) has no synced data left, so there is no session to show.
   const account = $derived.by(() => {
     const current = sessionStore.currentAccountId
       ? accountsStore.get(sessionStore.currentAccountId)
@@ -57,8 +59,8 @@
 
   function select(chosen: Account) {
     if (chosen.isSignedOut) {
-      // No keys on this device — signing back in means importing the phrase.
-      void goto(resolve(routes.ACCOUNT_IMPORT))
+      // The vault survived the sign-out — unlock it to sign back in.
+      signingBackIn = chosen
       return
     }
     sessionStore.setCurrentAccount(chosen.id)
@@ -149,4 +151,15 @@
       {/if}
     </div>
   </div>
+{/if}
+
+{#if signingBackIn}
+  <SignBackInDialog
+    account={signingBackIn}
+    onsignedin={(restored) => {
+      sessionStore.setCurrentAccount(restored.id)
+      signingBackIn = undefined
+    }}
+    onclose={() => (signingBackIn = undefined)}
+  />
 {/if}

--- a/ui/src/routes/account/import/+page.svelte
+++ b/ui/src/routes/account/import/+page.svelte
@@ -26,6 +26,7 @@
   import { noteAccountFolded } from '$lib/dev/account-refresh'
   import { generateDockerName } from '$lib/docker-name'
   import routes from '$lib/routes'
+  import { signBackIn } from '$lib/sign-back-in'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { connectStore } from '$lib/stores/connect.svelte'
   import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
@@ -48,9 +49,14 @@
       const normalized = normalizePhrase(phrase)
       const wallet = walletFromPhrase(normalized)
 
-      // Already set up on this device — just switch to it.
+      // Already set up on this device — just switch to it. A signed-out
+      // record first restores its synced state (the phrase already proved the
+      // entropy, so this is the same restore the unlock ceremony performs).
       const existing = accountsStore.get(wallet.address)
       if (existing) {
+        if (existing.isSignedOut) {
+          await signBackIn(existing, wallet.entropy)
+        }
         sessionStore.setCurrentAccount(existing.id)
 
         // Came from a dApp connect popup — the phrase already unlocked the

--- a/ui/src/routes/account/import/+page.svelte
+++ b/ui/src/routes/account/import/+page.svelte
@@ -52,10 +52,13 @@
       // Already set up on this device — just switch to it. A signed-out
       // record first restores its synced state (the phrase already proved the
       // entropy, so this is the same restore the unlock ceremony performs).
+      // `allowEmpty`: the phrase is the explicit recovery authority, so a
+      // missing snapshot + empty network restores a fresh shell rather than
+      // blocking the recovery.
       const existing = accountsStore.get(wallet.address)
       if (existing) {
         if (existing.isSignedOut) {
-          await signBackIn(existing, wallet.entropy)
+          await signBackIn(existing, wallet.entropy, { allowEmpty: true })
         }
         sessionStore.setCurrentAccount(existing.id)
 

--- a/ui/src/routes/connect/+page.svelte
+++ b/ui/src/routes/connect/+page.svelte
@@ -21,6 +21,7 @@
   import UnlockDialog from '$lib/components/unlock-dialog.svelte'
   import { completeConnect, hasReusableConnection, reuseConnection } from '$lib/connect-handshake'
   import routes from '$lib/routes'
+  import { signBackIn } from '$lib/sign-back-in'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { connectStore } from '$lib/stores/connect.svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
@@ -75,12 +76,9 @@
     if (!request) {
       return
     }
-    if (account.isSignedOut) {
-      // No keys on this device — signing back in means importing the phrase.
-      await goto(resolve(routes.ACCOUNT_IMPORT))
-      return
-    }
     // A still-valid prior connection carries the secret — no unlock needed.
+    // (A signed-out account kept no connections, so it always falls through
+    // to the unlock, which doubles as its sign-back-in ceremony.)
     if (reuseConnection(account, request)) {
       sessionStore.setCurrentAccount(account.id)
       await goto(resolve(routes.CONNECT_DONE))
@@ -93,6 +91,12 @@
     const account = unlocking
     if (!account || !request) {
       return
+    }
+    if (account.isSignedOut) {
+      // Unlocking a signed-out account signs it back in for the whole device
+      // (restores the synced state from Swarm), not just for this app. The
+      // store reuses the instance, so `account` is signed in afterwards.
+      await signBackIn(account, entropy)
     }
     await completeConnect(account, entropy, request)
     sessionStore.setCurrentAccount(account.id)
@@ -183,11 +187,11 @@
   </main>
 </div>
 
-<!-- Drop the unlock dialog if this account is signed out from another tab mid-
-     ceremony (`unlocking` is a captured reference, not session-derived): the
-     account then reads as signed-out in the list and selecting it routes to
-     import, matching the chooser. -->
-{#if unlocking && !unlocking.isSignedOut}
+<!-- Serves signed-in unlocks AND sign-back-in ceremonies (a signed-out
+     account's vault survives, so the same unlock works); a mid-ceremony
+     cross-tab sign-out/sign-in is caught inside the dialog by its
+     signedOutAt transition check. -->
+{#if unlocking}
   <UnlockDialog
     account={unlocking}
     title="Connect as {unlocking.name}"

--- a/ui/src/routes/connect/+page.svelte
+++ b/ui/src/routes/connect/+page.svelte
@@ -17,11 +17,11 @@
   import AccountList from '$lib/components/account-list.svelte'
   import AppHeader from '$lib/components/app-header.svelte'
   import AppIcon from '$lib/components/app-icon.svelte'
+  import SignBackInDialog from '$lib/components/sign-back-in-dialog.svelte'
   import { Button } from '$lib/components/ui/button'
   import UnlockDialog from '$lib/components/unlock-dialog.svelte'
   import { completeConnect, hasReusableConnection, reuseConnection } from '$lib/connect-handshake'
   import routes from '$lib/routes'
-  import { signBackIn } from '$lib/sign-back-in'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { connectStore } from '$lib/stores/connect.svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
@@ -87,21 +87,21 @@
     unlocking = account
   }
 
-  async function onUnlockedConnect(entropy: Uint8Array) {
-    const account = unlocking
-    if (!account || !request) {
+  /** Shared tail of both ceremonies: hand the secret over and close up. */
+  async function finishConnect(account: Account, entropy: Uint8Array) {
+    if (!request) {
       return
-    }
-    if (account.isSignedOut) {
-      // Unlocking a signed-out account signs it back in for the whole device
-      // (restores the synced state from Swarm), not just for this app. The
-      // store reuses the instance, so `account` is signed in afterwards.
-      await signBackIn(account, entropy)
     }
     await completeConnect(account, entropy, request)
     sessionStore.setCurrentAccount(account.id)
     unlocking = undefined
     await goto(resolve(routes.CONNECT_DONE))
+  }
+
+  async function onUnlockedConnect(entropy: Uint8Array) {
+    if (unlocking) {
+      await finishConnect(unlocking, entropy)
+    }
   }
 
   function startAdding() {
@@ -187,16 +187,25 @@
   </main>
 </div>
 
-<!-- Serves signed-in unlocks AND sign-back-in ceremonies (a signed-out
-     account's vault survives, so the same unlock works); a mid-ceremony
-     cross-tab sign-out/sign-in is caught inside the dialog by its
-     signedOutAt transition check. -->
+<!-- A signed-out account goes through the sign-back-in ceremony (unlock +
+     state restore, incl. the no-synced-data warning) and then completes the
+     connection; a signed-in one just unlocks. A mid-ceremony cross-tab
+     sign-out/sign-in is caught inside the unlock dialog by its signedOutAt
+     transition check. -->
 {#if unlocking}
-  <UnlockDialog
-    account={unlocking}
-    title="Connect as {unlocking.name}"
-    description="Unlock your account to approve the connection to {request?.appName}."
-    onunlocked={onUnlockedConnect}
-    onclose={() => (unlocking = undefined)}
-  />
+  {#if unlocking.isSignedOut}
+    <SignBackInDialog
+      account={unlocking}
+      onsignedin={finishConnect}
+      onclose={() => (unlocking = undefined)}
+    />
+  {:else}
+    <UnlockDialog
+      account={unlocking}
+      title="Connect as {unlocking.name}"
+      description="Unlock your account to approve the connection to {request?.appName}."
+      onunlocked={onUnlockedConnect}
+      onclose={() => (unlocking = undefined)}
+    />
+  {/if}
 {/if}

--- a/ui/src/routes/dev/+page.svelte
+++ b/ui/src/routes/dev/+page.svelte
@@ -397,6 +397,9 @@
   // Custom signer key settings
   let useCustomSigner = $state(false)
   let customSignerKey = $state('')
+  // Unchecked = stack the batch onto the account WITHOUT stealing the default
+  // pointer, so an account can hold multiple drives.
+  let assignSetDefault = $state(true)
   let customSignerError = $state<string | undefined>(undefined)
 
   // Mock stamp widget settings — `devSettingsStore` is the single source of
@@ -746,44 +749,57 @@ Check console logs for details:
           ? new PrivateKey(customSignerKey)
           : new PrivateKey(selectedSigner)
 
-      if (!postageStampsStore.getStamp(batchId)) {
+      // Existence is per-ACCOUNT (`hasLiveStamp`), not the cross-account
+      // runtime view: a batch already owned by another account must still be
+      // added to THIS one, else only the default pointer would move and dangle
+      // at a batch the account doesn't own.
+      if (!account.hasLiveStamp(batchId)) {
+        // Stamp data source: another account's live copy, or the node list.
+        const stored = postageStampsStore.getStamp(batchId)
         const beeStamp = beeStamps.find((s) => s.batchID === selectedStampId)
-        if (!beeStamp) {
+        if (stored) {
+          account.addStamp({ ...stored, signerKey: signerKeyToUse })
+        } else if (beeStamp) {
+          account.addStamp({
+            batchID: batchId,
+            signerKey: signerKeyToUse,
+            utilization: Utils.getStampUsage(
+              beeStamp.utilization,
+              beeStamp.depth,
+              beeStamp.bucketDepth,
+            ),
+            usable: beeStamp.usable,
+            depth: beeStamp.depth,
+            amount: BigInt(beeStamp.amount),
+            bucketDepth: beeStamp.bucketDepth,
+            blockNumber: beeStamp.blockNumber,
+            immutableFlag: beeStamp.immutableFlag,
+            exists: beeStamp.exists,
+          })
+        } else {
           assignError = 'Stamp data not found. Reload stamps first.'
           return
         }
-        account.addStamp({
-          batchID: batchId,
-          signerKey: signerKeyToUse,
-          utilization: Utils.getStampUsage(
-            beeStamp.utilization,
-            beeStamp.depth,
-            beeStamp.bucketDepth,
-          ),
-          usable: beeStamp.usable,
-          depth: beeStamp.depth,
-          amount: BigInt(beeStamp.amount),
-          bucketDepth: beeStamp.bucketDepth,
-          blockNumber: beeStamp.blockNumber,
-          immutableFlag: beeStamp.immutableFlag,
-          exists: beeStamp.exists,
-        })
       } else if (useCustomSigner) {
-        const beeStamp = postageStampsStore.getStamp(batchId)
-        if (!beeStamp) {
-          assignError = 'Stamp not found in local storage.'
+        const owned = account.stamps.find((s) => s.batchID.equals(batchId))
+        if (!owned) {
+          assignError = 'Stamp not found on the account.'
           return
         }
         // Compare by value — `signerKey` is a bee-js PrivateKey, so `!==` would
         // always be true (distinct instances) and re-add the stamp needlessly.
-        if (!beeStamp.signerKey.equals(signerKeyToUse)) {
+        if (!owned.signerKey.equals(signerKeyToUse)) {
           account.removeStamp(batchId)
-          account.addStamp({ ...beeStamp, signerKey: signerKeyToUse })
+          account.addStamp({ ...owned, signerKey: signerKeyToUse })
         }
       }
 
-      account.setDefaultStamp(batchId)
-      assignMessage = `✅ Set account stamp for ${accountId.toHex().slice(0, 8)}…`
+      if (assignSetDefault) {
+        account.setDefaultStamp(batchId)
+        assignMessage = `✅ Set account stamp for ${accountId.toHex().slice(0, 8)}…`
+      } else {
+        assignMessage = `✅ Added stamp to ${accountId.toHex().slice(0, 8)}…`
+      }
     } catch (error) {
       assignError = error instanceof Error ? error.message : String(error)
     }
@@ -1258,11 +1274,16 @@ Check console logs for details:
             {/if}
           </label>
         {/if}
+
+        <label class="flex cursor-pointer items-center gap-2 text-sm">
+          <input type="checkbox" bind:checked={assignSetDefault} />
+          Set as account default
+        </label>
       </div>
 
       <div class="flex items-center gap-2">
         <Button onclick={assignAccountStamp} disabled={!selectedStampId || !selectedAccountId}>
-          Set account stamp
+          {assignSetDefault ? 'Set account stamp' : 'Add stamp to account'}
         </Button>
         <Button
           variant="destructive"


### PR DESCRIPTION
Sign-out now retains the encrypted vault (`access` + `encryptedSeed`) plus an **encrypted snapshot of the synced state** (`encryptedState`, AES-GCM keyed off the same `derivationKey` chain the Swarm sync uses), while stripping all plaintext account data from localStorage — the stored record shrinks to `id`, `name`, `createdAt`, the vault, the snapshot, and `signedOutAt`. Notably this removes the plaintext `derivationKey`, which previously stayed on disk after sign-out.

Signing back in no longer needs the Secret Recovery Phrase: selecting a signed-out account (account chooser, switcher, or dApp connect popup) opens the unlock ceremony; `signBackIn` unlocks the vault, re-derives the `derivationKey` from the seed, decrypts the snapshot, and restores the full record in place — instant, lossless, and offline-capable. The background fold reconciles with peers afterwards. The connect popup completes the app handshake right after, so unlocking there fully signs the device back in.

Only when the snapshot is corrupt does the restore fall back to folding from Swarm — and an empty fold surfaces an explicit "no synced data found / sign in anyway" warning instead of silently restoring an empty account (the phrase-import path opts into the fresh shell, being the explicit recovery authority).

Also:

- The sign-out dialog no longer gates on a recovery-phrase acknowledgment (the phrase stays mentioned as the fallback).
- The phrase-import flow restores an existing signed-out record via the same `signBackIn` (previously it switched to the account without rebuilding anything).
- The unlock dialog's mid-flight guard (#462) is now a `signedOutAt` *transition* check, covering sign-back-in ceremonies too.
- The background fold skips signed-out accounts (no plaintext `derivationKey` to derive feeds with).
- Pre-#460 signed-out records (vault-less, or without a snapshot) fail schema parse and are quarantined by the loader — no migration, we're pre-production.

Verified end-to-end against the local bee cluster: sign-out leaves exactly the seven-key encrypted remnant (no plaintext leaks), sign-back-in restores drives **offline** from the snapshot in ~300 ms, a corrupted snapshot falls back to the Swarm fold, a snapshot-less record is quarantined, and the demo dApp authenticates after a signed-out-account connect.

Closes #460

🤖 Generated with [Claude Code](https://claude.com/claude-code)
