### PR TITLE
chore: bump @snaha/bee-compose to ^0.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "format:lib": "pnpm --filter @snaha/swarm-id format"
   },
   "devDependencies": {
-    "@snaha/bee-compose": "^0.1.3",
+    "@snaha/bee-compose": "^0.1.5",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "concurrently": "^9.1.2",
     "prettier": "^3.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@snaha/bee-compose':
-        specifier: ^0.1.3
-        version: 0.1.3
+        specifier: ^0.1.5
+        version: 0.1.5
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^6.0.2
         version: 6.0.2(prettier-plugin-svelte@3.4.0(prettier@3.8.1)(svelte@5.48.2))(prettier@3.8.1)(svelte@5.48.2)
@@ -1649,8 +1649,8 @@ packages:
   '@sideway/pinpoint@2.0.0':
     resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
 
-  '@snaha/bee-compose@0.1.3':
-    resolution: {integrity: sha512-+ld2cXWVjnwHAE0pslplHTO8PuFxUDXwEMwB9lYYDBqcCxel4iwGKTd9MCvRHSZkJGliRRX608FYk/hk53+sbQ==}
+  '@snaha/bee-compose@0.1.5':
+    resolution: {integrity: sha512-m5A+eqD5rRDaF2RaRWJ0eHOcOsYhXLRbZN25/ydhyGEDB2wy0tNYeMVq5cBXlvWRbuHy1IsDa9MfGMCO6whrFQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5889,7 +5889,7 @@ snapshots:
 
   '@sideway/pinpoint@2.0.0': {}
 
-  '@snaha/bee-compose@0.1.3':
+  '@snaha/bee-compose@0.1.5':
     dependencies:
       commander: 12.1.0
 


### PR DESCRIPTION
0.1.3 shipped stock Bee images without the `reachabilityOverridePublic` build flag, so worker reachability stayed "Unknown" inside the docker bridge network and every non-deferred (SOC) upload ran out the 30 s pushsync deadline — sync publishes always failed on the local cluster with `PartitionLeaseLostError`. 0.1.4+ recompiles Bee with the override (see `.claude/rules/bee-cluster.md`), fixing pushsync receipts out of the box.

Verified after `pnpm dev:bee:fresh`: all 4 nodes report reachability "Public", queen topology shows 3 connected peers, and a full account sync publish completes in seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)