### PR TITLE
test(ui): e2e for drive management and the sign-out journey

### DIFF
--- a/ui/tests/done-page.test.ts
+++ b/ui/tests/done-page.test.ts
@@ -2,62 +2,22 @@
 // SPDX-License-Identifier: Apache-2.0
 import { type Page, expect, test } from '@playwright/test'
 
+import {
+  DRIVE_SETTLE_TIMEOUT_MS,
+  PASSWORD,
+  addMockedDrive,
+  completeCreateFlow,
+  openConnectPopup,
+} from './helpers'
+
 const DEMO_URL = 'http://localhost:3500'
-const PASSWORD = 'testpassword123'
 const APP_NAME = 'Swarm ID Demo'
-// The mocked drive purchase settles after a simulated widget delay.
-const DRIVE_SETTLE_TIMEOUT_MS = 15000
-
-/**
- * Drives the account-creation wizard from /account/new to completion using the
- * Password access method (needs no WebAuthn/wallet test infra). Where the flow
- * lands afterwards depends on the entry point: the done page when standalone,
- * /connect/done inside a connect popup.
- */
-async function completeCreateFlow(page: Page) {
-  await page.getByRole('link', { name: 'Create a new account' }).click()
-  await expect(page).toHaveURL(/\/account\/new$/)
-  // Name is prefilled with a generated one.
-  await page.getByRole('button', { name: 'Continue' }).click()
-
-  await expect(page).toHaveURL(/\/account\/new\/phrase$/)
-  await page.getByRole('button', { name: 'Reveal' }).click()
-  await page.getByRole('button', { name: 'Continue' }).click()
-
-  await expect(page).toHaveURL(/\/account\/new\/access$/)
-  await page.getByRole('tab', { name: 'Password' }).click()
-  await page.locator('#new-password').fill(PASSWORD)
-  await page.locator('#verify-password').fill(PASSWORD)
-  await page.getByRole('button', { name: 'Confirm' }).click()
-}
 
 /** Asserts the shared done view's drive pitch (the no-drive branch). */
 async function expectDrivePitch(page: Page) {
   await expect(page.getByText('Your Swarm ID is ready!')).toBeVisible()
   await expect(page.getByText('Want the full experience?')).toBeVisible()
   await expect(page.getByRole('button', { name: 'Set up a drive' })).toBeVisible()
-}
-
-/** Opens the demo's connect popup and returns the popup page. */
-async function openConnectPopup(page: Page) {
-  await page.getByRole('button', { name: 'Connect Swarm ID' }).click()
-  // The lib renders the iframe button once the client is initialized — before
-  // that, the popover's Connect click is a silent no-op (clientStore.connect
-  // bails while `client` is undefined).
-  await expect(page.locator('#swarm-id-button iframe')).toBeVisible({ timeout: 10000 })
-  let popup: Page | undefined
-  await expect(async () => {
-    const popupPromise = page.waitForEvent('popup', { timeout: 5000 }).catch(() => undefined)
-    await page.getByRole('button', { name: 'Connect', exact: true }).click()
-    popup = await popupPromise
-    if (!popup) {
-      // Clicking Connect closes the popover — reopen it for the retry.
-      await page.getByRole('button', { name: 'Connect Swarm ID' }).click()
-      throw new Error('connect popup did not open')
-    }
-  }).toPass({ timeout: 30000 })
-  await popup!.waitForLoadState()
-  return popup!
 }
 
 test('create flow ends on the done page with the drive pitch', async ({ page }) => {
@@ -99,10 +59,7 @@ test('connect flow shows the done screen variants and closes the popup', async (
   // Give the account a drive via the mocked Add-drive flow (dev default:
   // mock enabled, no widget popup).
   await page.goto('/')
-  await page.getByRole('tab', { name: 'Storage' }).click()
-  await page.getByRole('button', { name: 'Add drive' }).click()
-  await page.getByRole('dialog').getByRole('combobox').nth(1).selectOption({ index: 1 })
-  await page.getByRole('button', { name: 'Proceed' }).click()
+  await addMockedDrive(page)
   // Drive cards are labelled "Drive <4 hex chars>" (batch-ID-derived name).
   await expect(page.getByText(/^Drive [0-9a-f]{4}$/)).toBeVisible({
     timeout: DRIVE_SETTLE_TIMEOUT_MS,
@@ -141,10 +98,7 @@ test('connect flow shows the done screen variants and closes the popup', async (
 
   // A second drive, so the NEXT (first-again) connect must ask which drive
   // the app should use.
-  await page.getByRole('tab', { name: 'Storage' }).click()
-  await page.getByRole('button', { name: 'Add drive' }).click()
-  await page.getByRole('dialog').getByRole('combobox').nth(1).selectOption({ index: 1 })
-  await page.getByRole('button', { name: 'Proceed' }).click()
+  await addMockedDrive(page)
   await expect(page.getByText(/^Drive [0-9a-f]{4}$/)).toHaveCount(2, {
     timeout: DRIVE_SETTLE_TIMEOUT_MS,
   })

--- a/ui/tests/done-page.test.ts
+++ b/ui/tests/done-page.test.ts
@@ -13,6 +13,19 @@ import {
 const DEMO_URL = 'http://localhost:3500'
 const APP_NAME = 'Swarm ID Demo'
 
+/**
+ * "Go to app" closes the popup from its click handler — under load the window
+ * can be gone before the click roundtrip returns, so tolerate that error and
+ * assert the closure itself.
+ */
+async function goToApp(popup: Page) {
+  await popup
+    .getByRole('button', { name: 'Go to app' })
+    .click()
+    .catch(() => undefined)
+  await expect.poll(() => popup.isClosed()).toBe(true)
+}
+
 /** Asserts the shared done view's drive pitch (the no-drive branch). */
 async function expectDrivePitch(page: Page) {
   await expect(page.getByText('Your Swarm ID is ready!')).toBeVisible()
@@ -36,6 +49,33 @@ test('create flow ends on the done page with the drive pitch', async ({ page }) 
   await expect(page).toHaveURL(/\/$/)
 })
 
+test('first connect with a single drive confirms without picker or pitch', async ({ page }) => {
+  // Account created standalone with exactly one drive, never connected.
+  await page.goto('/')
+  await page.getByRole('link', { name: 'Get started' }).first().click()
+  await completeCreateFlow(page)
+  await page.getByRole('button', { name: 'Stay local for now' }).click()
+  await expect(page).toHaveURL(/\/$/)
+  await addMockedDrive(page)
+  await expect(page.getByText(/^Drive [0-9a-f]{4}$/)).toBeVisible({
+    timeout: DRIVE_SETTLE_TIMEOUT_MS,
+  })
+
+  // First connect + one drive → the drive question answers itself: plain
+  // confirmation, no picker, no pitch.
+  await page.goto(DEMO_URL)
+  const popup = await openConnectPopup(page)
+  await expect(popup.getByText('Previously used with this app')).not.toBeVisible()
+  await popup.getByRole('button', { name: /0x[0-9a-fA-F]{4}/ }).click()
+  await popup.getByRole('textbox', { name: 'Account password' }).fill(PASSWORD)
+  await popup.getByRole('button', { name: 'Confirm' }).click()
+
+  await expect(popup.getByText(`Your Swarm ID is now connected to ${APP_NAME}!`)).toBeVisible()
+  await expect(popup.getByText('Select drive')).not.toBeVisible()
+  await expect(popup.getByText('Want the full experience?')).not.toBeVisible()
+  await goToApp(popup)
+})
+
 test('connect flow shows the done screen variants and closes the popup', async ({ page }) => {
   await page.goto(DEMO_URL)
 
@@ -49,8 +89,7 @@ test('connect flow shows the done screen variants and closes the popup', async (
   await expect(popup.getByText('Want the full experience?')).toBeVisible()
   await expect(popup.getByRole('button', { name: 'Set up a drive' })).toBeVisible()
 
-  await popup.getByRole('button', { name: 'Go to app' }).click()
-  await expect.poll(() => popup.isClosed()).toBe(true)
+  await goToApp(popup)
 
   // The demo picked up the session — the sidebar shows the account.
   const accountButton = page.getByRole('button', { name: /0x|[0-9a-f]{6}\.\.\./ }).first()
@@ -84,8 +123,7 @@ test('connect flow shows the done screen variants and closes the popup', async (
   await expect(popup.getByText(`Your Swarm ID is now connected to ${APP_NAME}!`)).toBeVisible()
   await expect(popup.getByText('Select drive')).not.toBeVisible()
   await expect(popup.getByText('Want the full experience?')).not.toBeVisible()
-  await popup.getByRole('button', { name: 'Go to app' }).click()
-  await expect.poll(() => popup.isClosed()).toBe(true)
+  await goToApp(popup)
 
   // REMOVING the app from the account (Apps tab → Remove) revokes the
   // association entirely — unlike a disconnect, the account must no longer
@@ -119,8 +157,7 @@ test('connect flow shows the done screen variants and closes the popup', async (
   expect(await drivePicker.locator('option', { hasText: '(default)' }).count()).toBe(1)
   // Choose the non-default drive; the choice must land on the app entry.
   await drivePicker.selectOption({ index: 1 })
-  await popup.getByRole('button', { name: 'Go to app' }).click()
-  await expect.poll(() => popup.isClosed()).toBe(true)
+  await goToApp(popup)
 
   await page.goto('/')
   const appDrive = await page.evaluate(() => {

--- a/ui/tests/drives.test.ts
+++ b/ui/tests/drives.test.ts
@@ -1,0 +1,107 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Drive (postage stamp) management on the Storage tab, against the mocked
+ * purchase flow (/dev defaults: mock enabled, no widget popup): add, rename,
+ * set default, remove, and the failed-purchase outcome.
+ */
+import { expect, test } from '@playwright/test'
+
+import { DRIVE_SETTLE_TIMEOUT_MS, addMockedDrive, completeCreateFlow } from './helpers'
+
+async function createLocalAccount(page: import('@playwright/test').Page) {
+  await page.goto('/')
+  await page.getByRole('link', { name: 'Get started' }).first().click()
+  await completeCreateFlow(page)
+  await page.getByRole('button', { name: 'Stay local for now' }).click()
+  await expect(page).toHaveURL(/\/$/)
+}
+
+/** The stored drive state, read back through localStorage. */
+function storedDrives(page: import('@playwright/test').Page) {
+  return page.evaluate(() => {
+    const doc = JSON.parse(localStorage.getItem('swarm-id-accounts') ?? '{}') as {
+      data?: {
+        defaultPostageStampBatchID?: string
+        postageStamps?: { batchID: string; name?: string; deletedAt?: number }[]
+      }[]
+    }
+    const record = doc.data?.[0]
+    return {
+      default: record?.defaultPostageStampBatchID,
+      live: (record?.postageStamps ?? [])
+        .filter((stamp) => stamp.deletedAt === undefined)
+        .map((stamp) => ({ batchID: stamp.batchID, name: stamp.name })),
+    }
+  })
+}
+
+test('drive management: add, rename, set default, remove', async ({ page }) => {
+  await createLocalAccount(page)
+
+  // The first drive settles and becomes the account default.
+  await addMockedDrive(page)
+  await expect(page.getByText(/^Drive [0-9a-f]{4}$/)).toBeVisible({
+    timeout: DRIVE_SETTLE_TIMEOUT_MS,
+  })
+  await expect(page.getByText('Default', { exact: true })).toBeVisible()
+
+  // Rename it (the name input renders in the expanded card).
+  await page.getByRole('button', { name: 'Expand drive' }).click()
+  const nameInput = page.getByRole('textbox', { name: 'Drive name' })
+  await nameInput.fill('Photos')
+  await nameInput.press('Enter')
+  await expect(page.getByText('Drive renamed')).toBeVisible()
+  await page.getByRole('button', { name: 'Collapse drive' }).click()
+  await expect(page.getByText('Photos', { exact: true })).toBeVisible()
+
+  // A second drive; make IT the default via its actions menu. An EXPANDED
+  // card renders its name as an input (hasText can't see input values), so
+  // interactions anchor on the one card showing "Collapse drive".
+  const expandedCard = page
+    .locator('div.overflow-hidden.rounded-lg')
+    .filter({ has: page.getByRole('button', { name: 'Collapse drive' }) })
+  await addMockedDrive(page)
+  const newCard = page.locator('div.overflow-hidden.rounded-lg', {
+    hasText: /Drive [0-9a-f]{4}/,
+  })
+  await expect(newCard).toBeVisible({ timeout: DRIVE_SETTLE_TIMEOUT_MS })
+  await newCard.getByRole('button', { name: 'Expand drive' }).click()
+  await expandedCard.getByRole('button', { name: 'Drive actions' }).click()
+  await page.getByRole('menuitem', { name: 'Set as default' }).click()
+
+  const afterDefault = await storedDrives(page)
+  expect(afterDefault.live).toHaveLength(2)
+  const photos = afterDefault.live.find((drive) => drive.name === 'Photos')
+  expect(photos).toBeDefined()
+  expect(afterDefault.default).not.toBe(photos?.batchID)
+
+  // Remove the renamed (now non-default) drive — collapse the other card
+  // first so the expanded-card anchor stays unique.
+  await expandedCard.getByRole('button', { name: 'Collapse drive' }).click()
+  const photosCard = page.locator('div.overflow-hidden.rounded-lg', { hasText: 'Photos' })
+  await photosCard.getByRole('button', { name: 'Expand drive' }).click()
+  await expandedCard.getByRole('button', { name: 'Drive actions' }).click()
+  await page.getByRole('menuitem', { name: 'Remove' }).click()
+  await page.getByRole('dialog').getByRole('button', { name: 'Remove drive' }).click()
+
+  await expect(page.getByText('Photos', { exact: true })).not.toBeVisible()
+  const afterRemove = await storedDrives(page)
+  expect(afterRemove.live).toHaveLength(1)
+  expect(afterRemove.default).toBe(afterRemove.live[0].batchID)
+})
+
+test('a failed mock purchase surfaces the error and adds nothing', async ({ page }) => {
+  // The dev-settings store reads the mock outcome at app init (same-tab
+  // localStorage writes fire no storage event) — plant it before any load.
+  await page.addInitScript(() => localStorage.setItem('dev-mock-stamp-result', 'error'))
+  await createLocalAccount(page)
+
+  await addMockedDrive(page)
+
+  await expect(page.getByText('Mock error: Purchase failed')).toBeVisible({
+    timeout: DRIVE_SETTLE_TIMEOUT_MS,
+  })
+  const drives = await storedDrives(page)
+  expect(drives.live).toHaveLength(0)
+})

--- a/ui/tests/helpers.ts
+++ b/ui/tests/helpers.ts
@@ -1,0 +1,69 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Shared journey helpers for the e2e suites: the password create flow, the
+ * demo's connect popup, and the mocked drive purchase (`/dev` defaults: mock
+ * enabled, no widget popup).
+ */
+import { type Page, expect } from '@playwright/test'
+
+export const PASSWORD = 'testpassword123'
+/** The mocked drive purchase settles after a simulated widget delay. */
+export const DRIVE_SETTLE_TIMEOUT_MS = 15000
+
+/**
+ * Drives the account-creation wizard from /account/new to completion using the
+ * Password access method (needs no WebAuthn/wallet test infra). Where the flow
+ * lands afterwards depends on the entry point: the done page when standalone,
+ * /connect/done inside a connect popup.
+ */
+export async function completeCreateFlow(page: Page) {
+  await page.getByRole('link', { name: 'Create a new account' }).click()
+  await expect(page).toHaveURL(/\/account\/new$/)
+  // Name is prefilled with a generated one.
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await expect(page).toHaveURL(/\/account\/new\/phrase$/)
+  await page.getByRole('button', { name: 'Reveal' }).click()
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await expect(page).toHaveURL(/\/account\/new\/access$/)
+  await page.getByRole('tab', { name: 'Password' }).click()
+  await page.locator('#new-password').fill(PASSWORD)
+  await page.locator('#verify-password').fill(PASSWORD)
+  await page.getByRole('button', { name: 'Confirm' }).click()
+}
+
+/** Opens the demo's connect popup and returns the popup page. */
+export async function openConnectPopup(page: Page) {
+  await page.getByRole('button', { name: 'Connect Swarm ID' }).click()
+  // The lib renders the iframe button once the client is initialized — before
+  // that, the popover's Connect click is a silent no-op (clientStore.connect
+  // bails while `client` is undefined).
+  await expect(page.locator('#swarm-id-button iframe')).toBeVisible({ timeout: 10000 })
+  let popup: Page | undefined
+  await expect(async () => {
+    const popupPromise = page.waitForEvent('popup', { timeout: 5000 }).catch(() => undefined)
+    await page.getByRole('button', { name: 'Connect', exact: true }).click()
+    popup = await popupPromise
+    if (!popup) {
+      // Clicking Connect closes the popover — reopen it for the retry.
+      await page.getByRole('button', { name: 'Connect Swarm ID' }).click()
+      throw new Error('connect popup did not open')
+    }
+  }).toPass({ timeout: 30000 })
+  await popup!.waitForLoadState()
+  return popup!
+}
+
+/**
+ * Starts a mocked Add-drive purchase from the home page (Storage tab). The
+ * purchase settles asynchronously — callers assert the outcome (a "Drive
+ * xxxx" card, or the error phase) with `DRIVE_SETTLE_TIMEOUT_MS`.
+ */
+export async function addMockedDrive(page: Page) {
+  await page.getByRole('tab', { name: 'Storage' }).click()
+  await page.getByRole('button', { name: 'Add drive' }).click()
+  await page.getByRole('dialog').getByRole('combobox').nth(1).selectOption({ index: 1 })
+  await page.getByRole('button', { name: 'Proceed' }).click()
+}

--- a/ui/tests/sign-out.test.ts
+++ b/ui/tests/sign-out.test.ts
@@ -1,0 +1,105 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * The sign-out → sign-back-in journey: sign-out strips the account to an
+ * encrypted remnant (vault + state snapshot + storage-warning fields, no
+ * plaintext derivationKey), and unlocking with the existing password restores
+ * everything from the snapshot — no recovery phrase, no network. The
+ * storage-warning remnant outranks the "Signed out" badge in the chooser.
+ */
+import { type Page, expect, test } from '@playwright/test'
+
+import { DRIVE_SETTLE_TIMEOUT_MS, PASSWORD, addMockedDrive, completeCreateFlow } from './helpers'
+
+async function createAccountWithDrive(page: Page) {
+  await page.goto('/')
+  await page.getByRole('link', { name: 'Get started' }).first().click()
+  await completeCreateFlow(page)
+  await page.getByRole('button', { name: 'Stay local for now' }).click()
+  await expect(page).toHaveURL(/\/$/)
+  // A drive makes the account non-local — sign-out is only offered then.
+  await addMockedDrive(page)
+  await expect(page.getByText(/^Drive [0-9a-f]{4}$/)).toBeVisible({
+    timeout: DRIVE_SETTLE_TIMEOUT_MS,
+  })
+}
+
+async function signOut(page: Page) {
+  await page.getByRole('button', { name: 'Switch account' }).click()
+  await page.getByRole('button', { name: 'Sign out' }).click()
+  await page.getByRole('dialog').getByRole('button', { name: 'Sign out' }).click()
+}
+
+test('sign out keeps only the encrypted remnant and signs back in from it', async ({ page }) => {
+  await createAccountWithDrive(page)
+  await signOut(page)
+
+  // Back on the chooser, the row carries the badge ("Signed out" also shows
+  // briefly as a toast — first() tolerates the overlap).
+  await expect(page.getByText('Signed out').first()).toBeVisible()
+
+  // The stored record is the minimal remnant: vault + snapshot + the
+  // storage-warning fields — and no plaintext secrets.
+  const remnant = await page.evaluate(() => {
+    const doc = JSON.parse(localStorage.getItem('swarm-id-accounts') ?? '{}') as {
+      data?: Record<string, unknown>[]
+    }
+    const record = doc.data?.[0] ?? {}
+    return { keys: Object.keys(record).sort(), raw: JSON.stringify(record) }
+  })
+  // `soonestDriveExpiry` is optional — it only exists when a drive's TTL is
+  // known, and the mocked purchase records none.
+  expect(remnant.keys.filter((key) => key !== 'soonestDriveExpiry')).toEqual([
+    'access',
+    'createdAt',
+    'encryptedSeed',
+    'encryptedState',
+    'id',
+    'name',
+    'signedOutAt',
+    'storageWarning',
+  ])
+  expect(remnant.raw).not.toContain('derivationKey')
+
+  // Sign back in with the password alone; the snapshot restores the drive
+  // without touching the network.
+  await page.getByRole('button', { name: /0x/ }).click()
+  await expect(page.getByText(/Sign in as/)).toBeVisible()
+  await page.getByRole('textbox', { name: 'Account password' }).fill(PASSWORD)
+  await page.getByRole('button', { name: 'Confirm' }).click()
+
+  await page.getByRole('tab', { name: 'Storage' }).click()
+  await expect(page.getByText(/^Drive [0-9a-f]{4}$/)).toBeVisible()
+})
+
+test('the storage warning survives sign-out and outranks the badge', async ({ page }) => {
+  await createAccountWithDrive(page)
+
+  // Fill the drive so the sign-out captures a storage warning, then reload so
+  // the store re-reads the tampered record (same-tab writes fire no event).
+  await page.evaluate(() => {
+    const doc = JSON.parse(localStorage.getItem('swarm-id-accounts') ?? '{}') as {
+      data?: { postageStamps?: { utilization: number }[] }[]
+    }
+    const stamps = doc.data?.[0]?.postageStamps
+    if (stamps?.[0]) stamps[0].utilization = 1
+    localStorage.setItem('swarm-id-accounts', JSON.stringify(doc))
+  })
+  await page.reload()
+  await signOut(page)
+
+  // The warning wins the badge slot; "Signed out" is gone once its toast
+  // auto-dismisses.
+  const checkStorage = page.getByRole('button', { name: 'Check storage' })
+  await expect(checkStorage).toBeVisible()
+  await expect(page.getByText('Signed out')).not.toBeVisible({ timeout: 10000 })
+
+  // Checking storage on a signed-out account signs it back in first.
+  await checkStorage.click({ position: { x: 20, y: 4 } })
+  await expect(page.getByText(/check your storage/i)).toBeVisible()
+  await page.getByRole('textbox', { name: 'Account password' }).fill(PASSWORD)
+  await page.getByRole('button', { name: 'Confirm' }).click()
+
+  await expect(page.getByText('Your drives')).toBeVisible()
+  await expect(page.getByText('1 drive needs attention.')).toBeVisible()
+})


### PR DESCRIPTION
Completes the #466 scope. Items 1–3 (create flow, home smoke, demo↔connect journey) and the Playwright CI workflow already landed with earlier PRs; this adds the two remaining gaps:

**Drive / stamp management** (`tests/drives.test.ts`, mocked purchases): a journey covering add (first drive becomes Default), rename via the expanded card, promoting a second drive to default, and removal through the confirm dialog — with the stored record asserted at each step — plus the failed-purchase outcome (the dev mock result is planted with `addInitScript`, since the settings store reads it at app init and same-tab localStorage writes fire no storage event).

**Sign-out → sign-back-in** (`tests/sign-out.test.ts`): sign-out shrinks the stored record to the encrypted remnant (exact key set, no plaintext `derivationKey`), the chooser shows the "Signed out" badge, and the password alone restores the drives from the encrypted snapshot without the network. A second test pins the storage-warning remnant: a full drive at sign-out swaps the badge for "Check storage", which routes through the sign-back-in ceremony onto the Storage tab with the attention alert.

The password create flow, connect popup, and mocked add-drive helpers move from `done-page.test.ts` into a shared `tests/helpers.ts` (no behavior change).

Suite: 25 tests, three consecutive green runs locally; CI picks the new files up via the existing `playwright.yaml`.

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)