### PR TITLE
ci: run lib lint, typecheck and unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,18 @@ jobs:
         working-directory: ./lib
         run: pnpm build
 
+      - name: Code linting (lib)
+        working-directory: ./lib
+        run: pnpm lint
+
+      - name: Typecheck (lib)
+        working-directory: ./lib
+        run: pnpm typecheck
+
+      - name: Run lib unit tests
+        working-directory: ./lib
+        run: pnpm test
+
       - name: Build ui
         working-directory: ./ui
         run: pnpm build


### PR DESCRIPTION
CI built `lib` but never ran its checks. The vitest unit suite and eslint/tsc were only enforced locally via `pnpm check:all`; the only lib tests in CI were the integration ones, which sit behind a `lib/**` path filter in a separate workflow.

Adds three steps to `ci.yml` after the lib build: `pnpm lint`, `pnpm typecheck`, `pnpm test`.

Verified locally before enabling — all three are green on `main`: 995 tests across 53 files (~75s), typecheck clean, lint 0 errors (2 pre-existing warnings, non-failing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)