### PR TITLE
refactor(lib): dedupe SOC address derivation and the sequential upload handlers

### DIFF
--- a/lib/src/proxy/download-data.ts
+++ b/lib/src/proxy/download-data.ts
@@ -29,6 +29,7 @@ import { ENCRYPTED_REFS_PER_CHUNK } from "./chunking-encrypted"
 import type { UploadProgress } from "./types"
 import type { SingleOwnerChunk } from "../types"
 import { hexToUint8Array } from "../utils/hex"
+import { socAddress } from "../utils/soc-address"
 
 function readSpan(spanBytes: Uint8Array): number {
   const view = new DataView(
@@ -37,14 +38,6 @@ function readSpan(spanBytes: Uint8Array): number {
     spanBytes.byteLength,
   )
   return Number(view.getBigUint64(0, true))
-}
-
-function makeSocAddress(identifier: Identifier, owner: EthAddress): Reference {
-  return new Reference(
-    Binary.keccak256(
-      Binary.concatBytes(identifier.toUint8Array(), owner.toUint8Array()),
-    ),
-  )
 }
 
 function makeSingleOwnerChunkFromData(
@@ -67,8 +60,8 @@ function makeSingleOwnerChunkFromData(
     throw new Error("SOC owner mismatch")
   }
 
-  const socAddress = makeSocAddress(identifier, recoveredOwner)
-  if (!Binary.equals(address.toUint8Array(), socAddress.toUint8Array())) {
+  const expectedAddress = socAddress(identifier, recoveredOwner)
+  if (!Binary.equals(address.toUint8Array(), expectedAddress)) {
     throw new Error("SOC data does not match given address")
   }
 
@@ -434,15 +427,15 @@ export async function downloadSOC(
 ): Promise<SingleOwnerChunk> {
   const ownerAddress = new EthAddress(owner)
   const id = new Identifier(identifier)
-  const socAddress = makeSocAddress(id, ownerAddress)
+  const address = new Reference(socAddress(id, ownerAddress))
 
   const data = await bee.downloadChunk(
-    socAddress.toHex(),
+    address.toHex(),
     undefined,
     requestOptions,
   )
 
-  return makeSingleOwnerChunkFromData(data, socAddress, ownerAddress)
+  return makeSingleOwnerChunkFromData(data, address, ownerAddress)
 }
 
 export async function downloadEncryptedSOC(
@@ -454,17 +447,17 @@ export async function downloadEncryptedSOC(
 ): Promise<SingleOwnerChunk> {
   const ownerAddress = new EthAddress(owner)
   const id = new Identifier(identifier)
-  const socAddress = makeSocAddress(id, ownerAddress)
+  const address = new Reference(socAddress(id, ownerAddress))
   const keyBytes =
     typeof encryptionKey === "string"
       ? hexToUint8Array(encryptionKey)
       : encryptionKey
 
   const data = await bee.downloadChunk(
-    socAddress.toHex(),
+    address.toHex(),
     undefined,
     requestOptions,
   )
 
-  return makeSingleOwnerChunkFromData(data, socAddress, ownerAddress, keyBytes)
+  return makeSingleOwnerChunkFromData(data, address, ownerAddress, keyBytes)
 }

--- a/lib/src/proxy/feeds/epochs/async-finder.ts
+++ b/lib/src/proxy/feeds/epochs/async-finder.ts
@@ -10,11 +10,12 @@
 
 import { Binary } from "cafe-utility"
 import type { Bee, BeeRequestOptions } from "@ethersphere/bee-js"
-import { EthAddress, Reference, Topic } from "@ethersphere/bee-js"
+import { EthAddress, Topic } from "@ethersphere/bee-js"
 import { EpochIndex, MAX_LEVEL } from "./epoch"
 import type { EpochFinder, EpochLookupResult } from "./types"
 import { downloadEncryptedSOC } from "../../download-data"
 import { findPreviousLeaf } from "./utils"
+import { socAddress } from "../../../utils/soc-address"
 
 const EPOCH_LOOKUP_TIMEOUT_MS = 2000
 
@@ -289,16 +290,11 @@ export class AsyncEpochFinder implements EpochFinder {
       )
       payload = soc.payload
     } else {
-      // Calculate chunk address: Keccak256(identifier || owner)
-      const address = new Reference(
-        Binary.keccak256(
-          Binary.concatBytes(identifier, this.owner.toUint8Array()),
-        ),
-      )
+      const address = socAddress(identifier, this.owner)
 
       // Download chunk
       const chunkData = await this.bee.downloadChunk(
-        address.toHex(),
+        Binary.uint8ArrayToHex(address),
         undefined,
         requestOptions,
       )

--- a/lib/src/proxy/feeds/epochs/finder.ts
+++ b/lib/src/proxy/feeds/epochs/finder.ts
@@ -10,10 +10,11 @@
 
 import { Binary } from "cafe-utility"
 import type { Bee, BeeRequestOptions } from "@ethersphere/bee-js"
-import { EthAddress, Reference, Topic } from "@ethersphere/bee-js"
+import { EthAddress, Topic } from "@ethersphere/bee-js"
 import { EpochIndex, lca, MAX_LEVEL } from "./epoch"
 import type { EpochFinder } from "./types"
 import { findPreviousLeaf } from "./utils"
+import { socAddress } from "../../../utils/soc-address"
 
 const EPOCH_LOOKUP_TIMEOUT_MS = 2000
 
@@ -206,16 +207,11 @@ export class SyncEpochFinder implements EpochFinder {
       Binary.concatBytes(this.topic.toUint8Array(), epochHash),
     )
 
-    // Calculate chunk address: Keccak256(identifier || owner)
-    const address = new Reference(
-      Binary.keccak256(
-        Binary.concatBytes(identifier, this.owner.toUint8Array()),
-      ),
-    )
+    const address = socAddress(identifier, this.owner)
 
     // Download chunk
     const chunkData = await this.bee.downloadChunk(
-      address.toHex(),
+      Binary.uint8ArrayToHex(address),
       undefined,
       requestOptions,
     )

--- a/lib/src/proxy/feeds/epochs/updater.ts
+++ b/lib/src/proxy/feeds/epochs/updater.ts
@@ -12,6 +12,7 @@ import { Binary } from "cafe-utility"
 import { EthAddress, Topic, PrivateKey, Identifier } from "@ethersphere/bee-js"
 import { EpochIndex, MAX_LEVEL } from "./epoch"
 import { uploadSOC, isStamperTarget, type UploadTarget } from "../../upload"
+import { socAddress } from "../../../utils/soc-address"
 import type { EpochUpdater, EpochUpdateHints, EpochUpdateResult } from "./types"
 import { AsyncEpochFinder } from "./async-finder"
 
@@ -32,19 +33,13 @@ export async function makeEpochIdentifier(
   )
 }
 
-/**
- * 32-byte SOC chunk address of one epoch-feed entry:
- * `keccak256(identifier ‖ owner)` — same formula as every SOC address.
- */
+/** 32-byte SOC chunk address of one epoch-feed entry. */
 export async function epochSocAddress(
   topic: Topic,
   epoch: EpochIndex,
   owner: EthAddress,
 ): Promise<Uint8Array> {
-  const identifier = await makeEpochIdentifier(topic, epoch)
-  return Binary.keccak256(
-    Binary.concatBytes(identifier.toUint8Array(), owner.toUint8Array()),
-  )
+  return socAddress(await makeEpochIdentifier(topic, epoch), owner)
 }
 
 /**

--- a/lib/src/proxy/feeds/sequence/finder.ts
+++ b/lib/src/proxy/feeds/sequence/finder.ts
@@ -15,21 +15,12 @@ import type {
   Topic,
   BeeRequestOptions,
 } from "@ethersphere/bee-js"
-import { Reference } from "@ethersphere/bee-js"
 import type { SequentialFinder, SequentialLookupResult } from "./types"
+import { socAddress } from "../../../utils/soc-address"
 
 function makeSequentialIdentifier(topic: Topic, index: bigint): Uint8Array {
   const indexBytes = Binary.numberToUint64(index, "BE")
   return Binary.keccak256(Binary.concatBytes(topic.toUint8Array(), indexBytes))
-}
-
-function makeSequentialAddress(
-  identifier: Uint8Array,
-  owner: EthAddress,
-): Reference {
-  return new Reference(
-    Binary.keccak256(Binary.concatBytes(identifier, owner.toUint8Array())),
-  )
 }
 
 export class SyncSequentialFinder implements SequentialFinder {
@@ -60,7 +51,7 @@ export class SyncSequentialFinder implements SequentialFinder {
     requestOptions?: BeeRequestOptions,
   ): Promise<boolean> {
     const identifier = makeSequentialIdentifier(this.topic, index)
-    const address = makeSequentialAddress(identifier, this.owner)
+    const address = socAddress(identifier, this.owner)
 
     // Bee's /chunks endpoint returns 500 ("read chunk failed") for a genuinely
     // absent chunk — indistinguishable by status from a transient 500 — so a
@@ -74,7 +65,7 @@ export class SyncSequentialFinder implements SequentialFinder {
     for (let attempt = 0; attempt < 2; attempt++) {
       try {
         await this.bee.downloadChunk(
-          Binary.uint8ArrayToHex(address.toUint8Array()),
+          Binary.uint8ArrayToHex(address),
           undefined,
           requestOptions,
         )

--- a/lib/src/proxy/upload.ts
+++ b/lib/src/proxy/upload.ts
@@ -44,6 +44,7 @@ import type { ChunkReference, UploadProgress } from "./types"
 import type { StampWorkerPool } from "./stamp-worker-pool"
 import { tryCreateTag } from "../utils/tag"
 import { uint8ArrayToHex } from "../utils/hex"
+import { socAddress } from "../utils/soc-address"
 import { normalizeUrl } from "../utils/url"
 
 // ============================================================================
@@ -927,10 +928,7 @@ export async function uploadSOC(
   const toSign = Binary.concatBytes(identifier.toUint8Array(), chunkAddress)
   const signature = signer.sign(toSign)
 
-  // Calculate SOC address
-  const socAddressBytes = Binary.keccak256(
-    Binary.concatBytes(identifier.toUint8Array(), owner.toUint8Array()),
-  )
+  const socAddressBytes = socAddress(identifier, owner)
 
   if (isSubsidisedTarget(target)) {
     // Subsidised gateway mode - no stamp needed

--- a/lib/src/swarm-id-proxy.sequential-upload.test.ts
+++ b/lib/src/swarm-id-proxy.sequential-upload.test.ts
@@ -1,0 +1,348 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Characterization of the three sequential-feed upload handlers, driven through
+ * the proxy's postMessage layer.
+ *
+ * The three share almost all of their body — index resolution, timestamp
+ * prefixing, payload bounds, identifier derivation, SOC upload — and differ only
+ * in what they encode into the payload, which encryption key they hand to
+ * `uploadSOC`, and the response they post back. These tests pin both halves: the
+ * shared wire behaviour and each handler's specific differences.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+// Rollup-only virtual module (see rollup.config.js) — not resolvable in vitest
+vi.mock("virtual:stamp-worker-code", () => ({ default: "" }))
+
+import { SwarmIdProxy } from "./swarm-id-proxy"
+import { decryptChunkData } from "./chunk"
+import { hexToUint8Array, uint8ArrayToHex } from "./utils/hex"
+
+const PARENT_ORIGIN = "https://dapp.example.com"
+const GATEWAY_URL = "https://gateway.example"
+
+const APP_SECRET_HEX =
+  "634fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd"
+const OWNER_HEX = "8d3766440f0d7b949a5e32995d09619a7f86e632"
+const TOPIC_HEX =
+  "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
+const REFERENCE_HEX =
+  "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+const ENCRYPTION_KEY_HEX =
+  "0f0e0d0c0b0a09080706050403020100000102030405060708090a0b0c0d0e0f"
+
+/** SOC addresses of the (TOPIC_HEX, index, OWNER_HEX) sequential feed entries. */
+const SEQ_ADDRESS_INDEX_0 =
+  "4e8ce27730e7627748330c4c12eb95cf77f559c2e34fcc0dff68ad7ad2ce2b23"
+const SEQ_ADDRESS_INDEX_3 =
+  "7680f28e4e029b4764faf77e736333ba3827c9c24e950e4ef3efb22181349bde"
+
+const OTHER_SIGNER_HEX =
+  "1111111111111111111111111111111111111111111111111111111111111111"
+const OTHER_OWNER_HEX = "19e7e376e7c213b7e7e7e46cc70a5dd086daff2a"
+const OTHER_SEQ_ADDRESS_INDEX_3 =
+  "2dfc7c02cafea4300e51557bd17339f739a82d06f3bb839d1fb0b497e86b40c1"
+
+const SPAN_BYTES = 8
+const ENCRYPTION_KEY_HEX_LEN = 64
+const AT = 1700000000
+/** `AT` as the 8-byte big-endian prefix the handlers prepend to the payload. */
+const TIMESTAMP_AT_HEX = "000000006553f100"
+
+type MessageListener = (event: MessageEvent) => Promise<void>
+type ProxyMessage = { type: string; requestId?: string } & Record<
+  string,
+  unknown
+>
+
+describe("sequential feed upload handlers", () => {
+  let parentWindow: { postMessage: ReturnType<typeof vi.fn> }
+  let messageListener: MessageListener
+  let socUploads: Array<{ url: string; body: Uint8Array }>
+
+  /** Payload of an uploaded SOC body, decrypting first when a key was used. */
+  const uploadedPayload = (index: number, keyHex?: unknown): Uint8Array => {
+    const body = socUploads[index].body
+    const chunk =
+      typeof keyHex === "string"
+        ? decryptChunkData(hexToUint8Array(keyHex), body)
+        : body
+    const span = new DataView(
+      chunk.buffer,
+      chunk.byteOffset,
+      SPAN_BYTES,
+    ).getBigUint64(0, true)
+    return chunk.slice(SPAN_BYTES, SPAN_BYTES + Number(span))
+  }
+
+  const dispatch = (data: unknown) =>
+    messageListener({
+      data,
+      origin: PARENT_ORIGIN,
+      source: parentWindow,
+    } as MessageEvent)
+
+  const responses = (): ProxyMessage[] =>
+    parentWindow.postMessage.mock.calls.map(([message]) => message)
+
+  const responseFor = (requestId: string): ProxyMessage => {
+    const match = responses().find((message) => message.requestId === requestId)
+    if (!match) throw new Error(`no response for ${requestId}`)
+    return match
+  }
+
+  beforeEach(async () => {
+    vi.restoreAllMocks()
+    socUploads = []
+
+    parentWindow = { postMessage: vi.fn() }
+    const listeners: Record<string, unknown> = {}
+    vi.stubGlobal("window", {
+      addEventListener: vi.fn((type: string, listener: unknown) => {
+        listeners[type] = listener
+      }),
+      removeEventListener: vi.fn(),
+      parent: parentWindow,
+      location: { origin: "https://id.example.com" },
+    })
+    vi.stubGlobal("fetch", async (url: string, init?: RequestInit) => {
+      socUploads.push({ url, body: init?.body as Uint8Array })
+      return new Response(JSON.stringify({ reference: "" }), { status: 200 })
+    })
+
+    const proxy = new SwarmIdProxy()
+    messageListener = listeners["message"] as MessageListener
+
+    await dispatch({
+      type: "parentIdentify",
+      requestId: "identify",
+      metadata: { name: "Test App" },
+      subsidisedGatewayUrl: GATEWAY_URL,
+    })
+
+    // No postage batch + a subsidised gateway puts uploads on the gateway path,
+    // so the handlers run without a stamper.
+    const state = proxy as unknown as {
+      authenticated: boolean
+      appSecret: string
+      bee: { downloadChunk: (reference: string) => Promise<Uint8Array> }
+    }
+    state.authenticated = true
+    state.appSecret = APP_SECRET_HEX
+    // Empty feed: every index lookup misses.
+    state.bee = {
+      downloadChunk: async () => {
+        throw new Error("chunk not found")
+      },
+    }
+    parentWindow.postMessage.mockClear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe("shared behaviour", () => {
+    it("uploads at the requested index and reports it back", async () => {
+      await dispatch({
+        type: "seqFeedUploadPayload",
+        requestId: "r1",
+        topic: TOPIC_HEX,
+        data: new Uint8Array([1, 2, 3]),
+        index: 3,
+        at: AT,
+      })
+
+      expect(responseFor("r1")).toMatchObject({
+        reference: SEQ_ADDRESS_INDEX_3,
+        feedIndex: "3",
+        owner: OWNER_HEX,
+      })
+      expect(
+        socUploads[0].url.startsWith(`${GATEWAY_URL}/soc/${OWNER_HEX}/`),
+      ).toBe(true)
+    })
+
+    it("falls back to index 0 on an empty feed", async () => {
+      await dispatch({
+        type: "seqFeedUploadRawPayload",
+        requestId: "r2",
+        topic: TOPIC_HEX,
+        data: new Uint8Array([1, 2, 3]),
+        at: AT,
+      })
+
+      expect(responseFor("r2")).toMatchObject({
+        reference: SEQ_ADDRESS_INDEX_0,
+        feedIndex: "0",
+      })
+    })
+
+    it("prefixes a big-endian timestamp unless hasTimestamp is false", async () => {
+      const data = new Uint8Array([1, 2, 3, 4])
+
+      await dispatch({
+        type: "seqFeedUploadRawPayload",
+        requestId: "r3",
+        topic: TOPIC_HEX,
+        data,
+        index: 3,
+        at: AT,
+      })
+      await dispatch({
+        type: "seqFeedUploadRawPayload",
+        requestId: "r4",
+        topic: TOPIC_HEX,
+        data,
+        index: 3,
+        at: AT,
+        hasTimestamp: false,
+      })
+
+      expect(uint8ArrayToHex(uploadedPayload(0))).toBe(
+        `${TIMESTAMP_AT_HEX}01020304`,
+      )
+      expect(uint8ArrayToHex(uploadedPayload(1))).toBe("01020304")
+    })
+
+    it("rejects a payload that exceeds the chunk size once prefixed", async () => {
+      await dispatch({
+        type: "seqFeedUploadPayload",
+        requestId: "r5",
+        topic: TOPIC_HEX,
+        data: new Uint8Array(4096),
+        index: 3,
+        at: AT,
+      })
+
+      expect(responseFor("r5")).toMatchObject({
+        type: "error",
+        error: "Invalid payload length: 4104 (expected 1-4096)",
+      })
+      expect(socUploads).toHaveLength(0)
+    })
+
+    it("owns the entry with the supplied signer instead of the app secret", async () => {
+      await dispatch({
+        type: "seqFeedUploadReference",
+        requestId: "r6",
+        topic: TOPIC_HEX,
+        reference: REFERENCE_HEX,
+        index: 3,
+        at: AT,
+        signer: OTHER_SIGNER_HEX,
+      })
+
+      expect(responseFor("r6")).toMatchObject({
+        owner: OTHER_OWNER_HEX,
+        reference: OTHER_SEQ_ADDRESS_INDEX_3,
+      })
+    })
+  })
+
+  describe("seqFeedUploadPayload", () => {
+    it("encrypts by default and returns the generated key", async () => {
+      await dispatch({
+        type: "seqFeedUploadPayload",
+        requestId: "p1",
+        topic: TOPIC_HEX,
+        data: new Uint8Array([1, 2, 3]),
+        index: 3,
+        at: AT,
+      })
+
+      const response = responseFor("p1")
+      expect(response.type).toBe("seqFeedUploadPayloadResponse")
+      expect(response.encryptionKey).toHaveLength(ENCRYPTION_KEY_HEX_LEN)
+      expect(response.tagUid).toBeUndefined()
+      expect(uint8ArrayToHex(uploadedPayload(0, response.encryptionKey))).toBe(
+        `${TIMESTAMP_AT_HEX}010203`,
+      )
+    })
+
+    it("uploads a plain SOC when options.encrypt is false", async () => {
+      await dispatch({
+        type: "seqFeedUploadPayload",
+        requestId: "p2",
+        topic: TOPIC_HEX,
+        data: new Uint8Array([1, 2, 3]),
+        index: 3,
+        at: AT,
+        options: { encrypt: false },
+      })
+
+      expect(responseFor("p2").encryptionKey).toBeUndefined()
+    })
+  })
+
+  describe("seqFeedUploadRawPayload", () => {
+    it("uploads a plain SOC and returns no key when none is given", async () => {
+      await dispatch({
+        type: "seqFeedUploadRawPayload",
+        requestId: "w1",
+        topic: TOPIC_HEX,
+        data: new Uint8Array([1, 2, 3]),
+        index: 3,
+        at: AT,
+      })
+
+      const response = responseFor("w1")
+      expect(response.type).toBe("seqFeedUploadRawPayloadResponse")
+      expect(response.encryptionKey).toBeUndefined()
+    })
+
+    it("echoes the caller's encryption key back verbatim", async () => {
+      await dispatch({
+        type: "seqFeedUploadRawPayload",
+        requestId: "w2",
+        topic: TOPIC_HEX,
+        data: new Uint8Array([1, 2, 3]),
+        index: 3,
+        at: AT,
+        encryptionKey: ENCRYPTION_KEY_HEX,
+      })
+
+      expect(responseFor("w2").encryptionKey).toBe(ENCRYPTION_KEY_HEX)
+    })
+  })
+
+  describe("seqFeedUploadReference", () => {
+    it("uploads the decoded reference bytes, always encrypted", async () => {
+      await dispatch({
+        type: "seqFeedUploadReference",
+        requestId: "f1",
+        topic: TOPIC_HEX,
+        reference: REFERENCE_HEX,
+        index: 3,
+        at: AT,
+      })
+
+      const response = responseFor("f1")
+      expect(response.type).toBe("seqFeedUploadReferenceResponse")
+      expect(response.reference).toBe(SEQ_ADDRESS_INDEX_3)
+      expect(response.encryptionKey).toHaveLength(ENCRYPTION_KEY_HEX_LEN)
+      expect(uint8ArrayToHex(uploadedPayload(0, response.encryptionKey))).toBe(
+        `${TIMESTAMP_AT_HEX}${REFERENCE_HEX}`,
+      )
+    })
+
+    it("ignores options.encrypt: false", async () => {
+      await dispatch({
+        type: "seqFeedUploadReference",
+        requestId: "f2",
+        topic: TOPIC_HEX,
+        reference: REFERENCE_HEX,
+        index: 3,
+        at: AT,
+        options: { encrypt: false },
+      })
+
+      expect(responseFor("f2").encryptionKey).toHaveLength(
+        ENCRYPTION_KEY_HEX_LEN,
+      )
+    })
+  })
+})

--- a/lib/src/swarm-id-proxy.ts
+++ b/lib/src/swarm-id-proxy.ts
@@ -62,13 +62,14 @@ import {
   MantarayNode,
   NULL_ADDRESS,
 } from "@ethersphere/bee-js"
-import { makeContentAddressedChunk } from "./chunk"
+import { makeContentAddressedChunk, MAX_PAYLOAD_SIZE } from "./chunk"
 import type { BeeRequestOptions } from "@ethersphere/bee-js"
 import {
   uploadData,
   uploadSOC,
   uploadChunk,
   type UploadTarget,
+  type UploadSOCResult,
 } from "./proxy/upload"
 import {
   downloadDataWithChunkAPI,
@@ -192,6 +193,15 @@ function readPartitionTuningOverride():
     return undefined
   }
 }
+
+/**
+ * The fields the three sequential-feed upload messages have in common — every
+ * input the shared upload body reads.
+ */
+type SequentialFeedUploadRequest = Omit<
+  SequentialFeedUploadPayloadMessage,
+  "type" | "data"
+>
 
 /**
  * Swarm ID Proxy - Runs inside the iframe
@@ -3319,15 +3329,30 @@ export class SwarmIdProxy {
     return Binary.concatBytes(timestamp, data)
   }
 
-  private async handleSequentialFeedUploadPayload(
-    message: SequentialFeedUploadPayloadMessage,
+  /**
+   * Shared body of the three sequential-feed upload handlers: resolve the feed
+   * index (explicit, or one past the current tail), prefix the timestamp, and
+   * write the SOC under the mode-aware write lock. Callers supply the payload
+   * bytes, the encryption key the SOC is written with, and the response.
+   */
+  private async handleSequentialFeedUpload(
+    message: SequentialFeedUploadRequest,
     event: MessageEvent,
+    spec: {
+      data: Uint8Array
+      encryptionKey: Uint8Array | true | undefined
+      respond: (
+        result: UploadSOCResult,
+        feedIndex: bigint,
+        owner: EthAddress,
+      ) => IframeToParentMessage
+      errorMessage: string
+    },
   ): Promise<void> {
     const {
       requestId,
       topic,
       signer,
-      data,
       index,
       at,
       hasTimestamp,
@@ -3363,10 +3388,14 @@ export class SwarmIdProxy {
           latest === undefined ? 0n : this.sequentialNextIndex(latest)
       }
 
-      const payload = this.buildSequentialPayload(data, useTimestamp, atValue)
-      if (payload.length < 1 || payload.length > 4096) {
+      const payload = this.buildSequentialPayload(
+        spec.data,
+        useTimestamp,
+        atValue,
+      )
+      if (payload.length < 1 || payload.length > MAX_PAYLOAD_SIZE) {
         throw new Error(
-          `Invalid payload length: ${payload.length} (expected 1-4096)`,
+          `Invalid payload length: ${payload.length} (expected 1-${MAX_PAYLOAD_SIZE})`,
         )
       }
 
@@ -3376,12 +3405,11 @@ export class SwarmIdProxy {
       )
       const identifier = new Identifier(identifierBytes)
 
-      // Upload SOC with optional encryption (enabled by default)
       const result = await this.withModeAwareWriteLock(
         undefined,
         async (target) => {
           return await uploadSOC(target, signerKeyObj, identifier, payload, {
-            encryptionKey: options?.encrypt !== false ? true : undefined,
+            encryptionKey: spec.encryptionKey,
             pin: options?.pin,
             deferred: options?.deferred,
             tag: options?.tag,
@@ -3389,216 +3417,86 @@ export class SwarmIdProxy {
         },
       )
 
-      this.postMessage(event, {
-        type: "seqFeedUploadPayloadResponse",
-        requestId,
-        reference: uint8ArrayToHex(result.socAddress),
-        feedIndex: resolvedIndex.toString(),
-        owner: ownerAddress.toHex(),
-        encryptionKey: result.encryptionKey
-          ? uint8ArrayToHex(result.encryptionKey)
-          : undefined,
-        tagUid: result.tagUid,
-      })
+      this.postMessage(event, spec.respond(result, resolvedIndex, ownerAddress))
     } catch (error) {
       this.sendErrorToParent(
         event,
         requestId,
-        error instanceof Error
-          ? error.message
-          : "Sequential feed upload payload failed",
+        error instanceof Error ? error.message : spec.errorMessage,
       )
     }
+  }
+
+  private async handleSequentialFeedUploadPayload(
+    message: SequentialFeedUploadPayloadMessage,
+    event: MessageEvent,
+  ): Promise<void> {
+    // Encrypted by default, with an auto-generated key.
+    await this.handleSequentialFeedUpload(message, event, {
+      data: message.data,
+      encryptionKey: message.options?.encrypt !== false ? true : undefined,
+      respond: (result, feedIndex, owner) => ({
+        type: "seqFeedUploadPayloadResponse",
+        requestId: message.requestId,
+        reference: uint8ArrayToHex(result.socAddress),
+        feedIndex: feedIndex.toString(),
+        owner: owner.toHex(),
+        encryptionKey: result.encryptionKey
+          ? uint8ArrayToHex(result.encryptionKey)
+          : undefined,
+        tagUid: result.tagUid,
+      }),
+      errorMessage: "Sequential feed upload payload failed",
+    })
   }
 
   private async handleSequentialFeedUploadRawPayload(
     message: SequentialFeedUploadRawPayloadMessage,
     event: MessageEvent,
   ): Promise<void> {
-    const {
-      requestId,
-      topic,
-      signer,
-      data,
-      index,
-      at,
-      hasTimestamp,
-      encryptionKey,
-      lookupTimeoutMs,
-      options,
-      requestOptions,
-    } = message
-
-    try {
-      this.ensureCanUpload()
-
-      const signerKey = signer ?? this.appSecret!
-      const signerKeyObj = new PrivateKey(signerKey)
-      const ownerAddress = signerKeyObj.publicKey().address()
-      const topicBytes = hexToUint8Array(topic)
-
-      const useTimestamp = hasTimestamp !== false
-      const atValue =
-        at !== undefined
-          ? this.parseFeedTimestamp(at)
-          : BigInt(Math.floor(Date.now() / 1000))
-      let resolvedIndex: bigint
-      if (index !== undefined) {
-        resolvedIndex = this.parseFeedIndex(index)
-      } else {
-        const latest = await this.findLatestSequentialIndex(
-          topicBytes,
-          ownerAddress,
-          requestOptions,
-          lookupTimeoutMs,
-        )
-        resolvedIndex =
-          latest === undefined ? 0n : this.sequentialNextIndex(latest)
-      }
-
-      const payload = this.buildSequentialPayload(data, useTimestamp, atValue)
-      if (payload.length < 1 || payload.length > 4096) {
-        throw new Error(
-          `Invalid payload length: ${payload.length} (expected 1-4096)`,
-        )
-      }
-
-      const identifierBytes = this.makeSequentialFeedIdentifier(
-        topicBytes,
-        resolvedIndex,
-      )
-      const identifier = new Identifier(identifierBytes)
-
-      // Upload SOC - use encryption if key provided, otherwise plain SOC
-      const result = await this.withModeAwareWriteLock(
-        undefined,
-        async (target) => {
-          return await uploadSOC(target, signerKeyObj, identifier, payload, {
-            encryptionKey: encryptionKey
-              ? hexToUint8Array(encryptionKey)
-              : undefined,
-            pin: options?.pin,
-            deferred: options?.deferred,
-            tag: options?.tag,
-          })
-        },
-      )
-
-      this.postMessage(event, {
+    // Encrypted only when the caller supplies a key, which is echoed back
+    // verbatim — the caller owns it, so it is never re-derived from the result.
+    await this.handleSequentialFeedUpload(message, event, {
+      data: message.data,
+      encryptionKey: message.encryptionKey
+        ? hexToUint8Array(message.encryptionKey)
+        : undefined,
+      respond: (result, feedIndex, owner) => ({
         type: "seqFeedUploadRawPayloadResponse",
-        requestId,
+        requestId: message.requestId,
         reference: uint8ArrayToHex(result.socAddress),
-        feedIndex: resolvedIndex.toString(),
-        owner: ownerAddress.toHex(),
-        encryptionKey: encryptionKey ? encryptionKey : undefined,
+        feedIndex: feedIndex.toString(),
+        owner: owner.toHex(),
+        encryptionKey: message.encryptionKey
+          ? message.encryptionKey
+          : undefined,
         tagUid: result.tagUid,
-      })
-    } catch (error) {
-      this.sendErrorToParent(
-        event,
-        requestId,
-        error instanceof Error
-          ? error.message
-          : "Sequential feed upload raw payload failed",
-      )
-    }
+      }),
+      errorMessage: "Sequential feed upload raw payload failed",
+    })
   }
 
   private async handleSequentialFeedUploadReference(
     message: SequentialFeedUploadReferenceMessage,
     event: MessageEvent,
   ): Promise<void> {
-    const {
-      requestId,
-      topic,
-      signer,
-      reference,
-      index,
-      at,
-      hasTimestamp,
-      lookupTimeoutMs,
-      options,
-      requestOptions,
-    } = message
-
-    try {
-      this.ensureCanUpload()
-
-      const signerKey = signer ?? this.appSecret!
-      const signerKeyObj = new PrivateKey(signerKey)
-      const ownerAddress = signerKeyObj.publicKey().address()
-      const topicBytes = hexToUint8Array(topic)
-
-      const useTimestamp = hasTimestamp !== false
-      const atValue =
-        at !== undefined
-          ? this.parseFeedTimestamp(at)
-          : BigInt(Math.floor(Date.now() / 1000))
-      let resolvedIndex: bigint
-      if (index !== undefined) {
-        resolvedIndex = this.parseFeedIndex(index)
-      } else {
-        const latest = await this.findLatestSequentialIndex(
-          topicBytes,
-          ownerAddress,
-          requestOptions,
-          lookupTimeoutMs,
-        )
-        resolvedIndex =
-          latest === undefined ? 0n : this.sequentialNextIndex(latest)
-      }
-
-      const referenceBytes = hexToUint8Array(reference)
-      const payload = this.buildSequentialPayload(
-        referenceBytes,
-        useTimestamp,
-        atValue,
-      )
-      if (payload.length < 1 || payload.length > 4096) {
-        throw new Error(
-          `Invalid payload length: ${payload.length} (expected 1-4096)`,
-        )
-      }
-
-      const identifierBytes = this.makeSequentialFeedIdentifier(
-        topicBytes,
-        resolvedIndex,
-      )
-      const identifier = new Identifier(identifierBytes)
-
-      // uploadReference always uses encryption with auto-generated key
-      const result = await this.withModeAwareWriteLock(
-        undefined,
-        async (target) => {
-          return await uploadSOC(target, signerKeyObj, identifier, payload, {
-            encryptionKey: true,
-            pin: options?.pin,
-            deferred: options?.deferred,
-            tag: options?.tag,
-          })
-        },
-      )
-
-      this.postMessage(event, {
+    // Always encrypted with an auto-generated key.
+    await this.handleSequentialFeedUpload(message, event, {
+      data: hexToUint8Array(message.reference),
+      encryptionKey: true,
+      respond: (result, feedIndex, owner) => ({
         type: "seqFeedUploadReferenceResponse",
-        requestId,
+        requestId: message.requestId,
         reference: uint8ArrayToHex(result.socAddress),
-        feedIndex: resolvedIndex.toString(),
-        owner: ownerAddress.toHex(),
+        feedIndex: feedIndex.toString(),
+        owner: owner.toHex(),
         encryptionKey: result.encryptionKey
           ? uint8ArrayToHex(result.encryptionKey)
           : undefined,
         tagUid: result.tagUid,
-      })
-    } catch (error) {
-      this.sendErrorToParent(
-        event,
-        requestId,
-        error instanceof Error
-          ? error.message
-          : "Sequential feed upload reference failed",
-      )
-    }
+      }),
+      errorMessage: "Sequential feed upload reference failed",
+    })
   }
 
   // ============================================================================

--- a/lib/src/sync/partition-intent.ts
+++ b/lib/src/sync/partition-intent.ts
@@ -66,6 +66,7 @@ import { downloadEncryptedSOC } from "../proxy/download-data"
 import { uploadSOC, type UploadTarget } from "../proxy/upload"
 import { UtilizationAwareStamper } from "../utils/batch-utilization"
 import { TimeoutError, withTimeout } from "../utils/promise"
+import { socAddress } from "../utils/soc-address"
 import { INTENT_EPOCH_MS, SYNC_READ_TIMEOUT_MS } from "./timing-constants"
 import {
   PartitionIntentPayloadSchemaV1,
@@ -166,13 +167,9 @@ export function intentSocAddress(
   epochBucket: number,
   owner: EthAddress,
 ): Uint8Array {
-  const identifier = makePartitionIntentIdentifier(
-    partition,
-    deviceId,
-    epochBucket,
-  )
-  return Binary.keccak256(
-    Binary.concatBytes(identifier.toUint8Array(), owner.toUint8Array()),
+  return socAddress(
+    makePartitionIntentIdentifier(partition, deviceId, epochBucket),
+    owner,
   )
 }
 
@@ -195,9 +192,9 @@ export function partitionOccupancyAddress(
   epochBucket: number,
   owner: EthAddress,
 ): Uint8Array {
-  const identifier = makePartitionOccupancyIdentifier(partition, epochBucket)
-  return Binary.keccak256(
-    Binary.concatBytes(identifier.toUint8Array(), owner.toUint8Array()),
+  return socAddress(
+    makePartitionOccupancyIdentifier(partition, epochBucket),
+    owner,
   )
 }
 

--- a/lib/src/sync/partition-state.ts
+++ b/lib/src/sync/partition-state.ts
@@ -57,6 +57,7 @@ import {
   toBucket,
 } from "../utils/batch-utilization"
 import { lockSocBucket } from "../utils/lock-soc"
+import { socAddress } from "../utils/soc-address"
 import {
   INTENT_EPOCH_MS,
   intentEpochBucket,
@@ -226,7 +227,7 @@ export async function writeStatePointer(opts: {
   const epochBucket = statePointerEpochBucket(opts.nowMs)
   const identifier = makeStatePointerIdentifier(topic, epochBucket)
   const owner = opts.backupSigner.publicKey().address()
-  const address = makeStatePointerAddress(identifier, owner)
+  const address = socAddress(identifier, owner)
   const data = new TextEncoder().encode(
     JSON.stringify({
       referenceHex: opts.referenceHex,
@@ -253,16 +254,6 @@ export async function writeStatePointer(opts: {
   })
 }
 
-/** 32-byte SOC address `keccak256(identifier ‖ owner)`. */
-function makeStatePointerAddress(
-  identifier: Identifier,
-  owner: EthAddress,
-): Uint8Array {
-  return Binary.keccak256(
-    Binary.concatBytes(identifier.toUint8Array(), owner.toUint8Array()),
-  )
-}
-
 /**
  * The 32-byte state-pointer SOC address for `partition` at the epoch bucket
  * covering `nowMs`. Exposed so `writePartitionState` can exclude the pointer's
@@ -281,7 +272,7 @@ export function statePointerAddress(
     topic,
     statePointerEpochBucket(nowMs),
   )
-  return makeStatePointerAddress(identifier, owner)
+  return socAddress(identifier, owner)
 }
 
 /**

--- a/lib/src/utils/lock-soc.ts
+++ b/lib/src/utils/lock-soc.ts
@@ -11,6 +11,7 @@
 
 import { Identifier, type EthAddress } from "@ethersphere/bee-js"
 import { Binary } from "cafe-utility"
+import { socAddress } from "./soc-address"
 
 /** Domain separation tag for the lock-SOC identifier. */
 const PARTITION_LOCK_DOMAIN = "swarm-id-partition-lock-v1"
@@ -36,10 +37,7 @@ export function lockSocAddress(
   partition: number,
   owner: EthAddress,
 ): Uint8Array {
-  const identifier = makePartitionLockIdentifier(partition)
-  return Binary.keccak256(
-    Binary.concatBytes(identifier.toUint8Array(), owner.toUint8Array()),
-  )
+  return socAddress(makePartitionLockIdentifier(partition), owner)
 }
 
 /**

--- a/lib/src/utils/soc-address.test.ts
+++ b/lib/src/utils/soc-address.test.ts
@@ -1,0 +1,213 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * Characterization of every SOC chunk address the library derives.
+ *
+ * A SOC address is `keccak256(identifier ‖ owner)`, and each call site below
+ * feeds it a differently-derived identifier. The expected hex is hardcoded and
+ * was produced with an independent keccak256 (ethers), so a site that silently
+ * changes its derivation — or its owner/identifier byte order — fails here
+ * instead of only failing against a live Bee.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest"
+import {
+  BatchId,
+  EthAddress,
+  Identifier,
+  PrivateKey,
+  Topic,
+} from "@ethersphere/bee-js"
+import { epochSocAddress } from "../proxy/feeds/epochs/updater"
+import { EpochIndex } from "../proxy/feeds/epochs/epoch"
+import { SyncEpochFinder } from "../proxy/feeds/epochs/finder"
+import { AsyncEpochFinder } from "../proxy/feeds/epochs/async-finder"
+import { SyncSequentialFinder } from "../proxy/feeds/sequence/finder"
+import { downloadSOC } from "../proxy/download-data"
+import { uploadSOC, type UploadTarget } from "../proxy/upload"
+import {
+  intentSocAddress,
+  partitionOccupancyAddress,
+} from "../sync/partition-intent"
+import { statePointerAddress } from "../sync/partition-state"
+import { lockSocAddress, lockSocBucket } from "./lock-soc"
+import { uint8ArrayToHex } from "./hex"
+
+const OWNER_HEX = "1234567890abcdef1234567890abcdef12345678"
+const TOPIC_HEX =
+  "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
+const IDENTIFIER_HEX =
+  "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"
+const BATCH_ID_HEX =
+  "1111111111111111222222222222222233333333333333334444444444444444"
+const SIGNER_HEX =
+  "634fb5a872396d9693e5c9f9d7233cfa93f395c093371017ff44aa9ae6564cdd"
+const SIGNER_ADDRESS_HEX = "8d3766440f0d7b949a5e32995d09619a7f86e632"
+
+const AT = 1700000000n
+const PARTITION = 5
+const DEVICE_ID = "device-a"
+const EPOCH_BUCKET = 42
+const EPOCH_LEVEL = 7
+
+const EXPECTED = {
+  epochLevel7:
+    "344d56e9d4c6793170227ad9db591c0ce26484cc0a1c4c79e90072004954f5d0",
+  epochLevel0AtAt:
+    "1d27f51ac36ffdfa75acedd6a8d1c26fee5e0cf453133dab409ad4bd7f104888",
+  epochRoot: "89b5d0e5747188535a93b10250aab08f1679f9167819d1906a399bc2f2e18bb7",
+  sequentialIndex0:
+    "6948d229eeb6d868135300aad6e5ea01c4d30bc87d616f27b909d9926739c0e0",
+  sequentialIndex1:
+    "22c7a14c30b160608acf3dd8dcd359846a2567b9f469ffb11838144b3d12642f",
+  lockSoc: "2727899e2cee4b2c96a57c3eb0f92abb29c07af5161caacce024cccec6ce1fed",
+  downloadSoc:
+    "4f5511b1384f206432b6bb4af39b2e3b95c58ca6528da5a9b978963caa3073ac",
+  uploadSoc: "19e92989b9b34ba220aca27c7a36b4f33afe98f060563177795a26fe68bf3a87",
+  intentSoc: "a1b608eb2c0d884676829a108dd03a6e5cf32fa8cf144e010811a6a12898336c",
+  occupancySoc:
+    "75dbe9bfd099c6c40e7fae5c5a0f6ed45a708dae9b470e2e4603cbc4b085ed92",
+  statePointer:
+    "f2d148c521d48f33412243bb99f50fae44b832343b8d5007f808252d5b2ef20c",
+}
+
+const owner = new EthAddress(OWNER_HEX)
+const topic = new Topic(TOPIC_HEX)
+
+/** Bee stub that records every requested chunk address and serves none. */
+function recordingBee(): { addresses: string[]; bee: unknown } {
+  const addresses: string[] = []
+  return {
+    addresses,
+    bee: {
+      url: "http://localhost:1633",
+      downloadChunk: async (reference: string) => {
+        addresses.push(reference.toLowerCase())
+        throw new Error("chunk not found")
+      },
+    },
+  }
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("SOC address derivation", () => {
+  it("epochSocAddress derives the epoch-feed entry address", async () => {
+    const address = await epochSocAddress(
+      topic,
+      new EpochIndex(AT, EPOCH_LEVEL),
+      owner,
+    )
+
+    expect(uint8ArrayToHex(address)).toBe(EXPECTED.epochLevel7)
+  })
+
+  it("SyncEpochFinder probes the level-0 epoch address first", async () => {
+    const { addresses, bee } = recordingBee()
+    const finder = new SyncEpochFinder(bee as never, topic, owner)
+
+    await finder.findAt(AT)
+
+    expect(addresses[0]).toBe(EXPECTED.epochLevel0AtAt)
+  })
+
+  it("AsyncEpochFinder probes the level-0 and root epoch addresses", async () => {
+    const { addresses, bee } = recordingBee()
+    const finder = new AsyncEpochFinder(bee as never, topic, owner)
+
+    await finder.findAt(AT)
+
+    expect(addresses).toContain(EXPECTED.epochLevel0AtAt)
+    expect(addresses).toContain(EXPECTED.epochRoot)
+  })
+
+  it("SyncSequentialFinder walks the per-index addresses in order", async () => {
+    const { addresses, bee } = recordingBee()
+    const finder = new SyncSequentialFinder(bee as never, topic, owner)
+
+    await finder.findAt(0n)
+
+    expect(addresses[0]).toBe(EXPECTED.sequentialIndex0)
+    // Index 0 is read twice (initial + retry) before being called free.
+    expect(addresses[1]).toBe(EXPECTED.sequentialIndex0)
+    expect(addresses).not.toContain(EXPECTED.sequentialIndex1)
+  })
+
+  it("lockSocAddress derives the partition lock SOC address", () => {
+    const address = lockSocAddress(PARTITION, owner)
+
+    expect(uint8ArrayToHex(address)).toBe(EXPECTED.lockSoc)
+  })
+
+  it("lockSocBucket is the first two bytes of the lock SOC address", () => {
+    const FIRST_BYTE_SHIFT = 8
+
+    expect(lockSocBucket(PARTITION, owner)).toBe(
+      (parseInt(EXPECTED.lockSoc.slice(0, 2), 16) << FIRST_BYTE_SHIFT) |
+        parseInt(EXPECTED.lockSoc.slice(2, 4), 16),
+    )
+  })
+
+  it("downloadSOC requests the identifier's SOC address", async () => {
+    const { addresses, bee } = recordingBee()
+
+    await expect(
+      downloadSOC(bee as never, owner, new Identifier(IDENTIFIER_HEX)),
+    ).rejects.toThrow()
+
+    expect(addresses[0]).toBe(EXPECTED.downloadSoc)
+  })
+
+  it("uploadSOC returns the signer-owned SOC address", async () => {
+    const signer = new PrivateKey(SIGNER_HEX)
+    expect(signer.publicKey().address().toHex()).toBe(SIGNER_ADDRESS_HEX)
+
+    const requestedUrls: string[] = []
+    vi.stubGlobal("fetch", async (url: string) => {
+      requestedUrls.push(url)
+      return new Response(JSON.stringify({ reference: "" }), { status: 200 })
+    })
+
+    const target: UploadTarget = {
+      mode: "subsidised",
+      gatewayUrl: "https://gateway.example",
+    }
+    const result = await uploadSOC(
+      target,
+      signer,
+      new Identifier(IDENTIFIER_HEX),
+      new Uint8Array([1, 2, 3]),
+    )
+
+    expect(uint8ArrayToHex(result.socAddress)).toBe(EXPECTED.uploadSoc)
+    expect(requestedUrls[0]).toContain(
+      `/soc/${SIGNER_ADDRESS_HEX}/${IDENTIFIER_HEX}`,
+    )
+  })
+
+  it("intentSocAddress derives the partition intent SOC address", () => {
+    const address = intentSocAddress(PARTITION, DEVICE_ID, EPOCH_BUCKET, owner)
+
+    expect(uint8ArrayToHex(address)).toBe(EXPECTED.intentSoc)
+  })
+
+  it("partitionOccupancyAddress derives the occupancy beacon address", () => {
+    const address = partitionOccupancyAddress(PARTITION, EPOCH_BUCKET, owner)
+
+    expect(uint8ArrayToHex(address)).toBe(EXPECTED.occupancySoc)
+  })
+
+  it("statePointerAddress derives the state-pointer SOC address", () => {
+    const address = statePointerAddress(
+      new BatchId(BATCH_ID_HEX),
+      PARTITION,
+      owner,
+      0,
+    )
+
+    expect(uint8ArrayToHex(address)).toBe(EXPECTED.statePointer)
+  })
+})

--- a/lib/src/utils/soc-address.ts
+++ b/lib/src/utils/soc-address.ts
@@ -1,0 +1,27 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/**
+ * The one derivation every single owner chunk shares. Lives in `utils/` so the
+ * feed finders/updaters, the sync SOCs and the upload/download paths can all
+ * reach it without importing across those layers.
+ */
+
+import type { EthAddress, Identifier } from "@ethersphere/bee-js"
+import { Binary } from "cafe-utility"
+
+/**
+ * 32-byte SOC chunk address: `keccak256(identifier ‖ owner)`. Computable
+ * before an upload, so a stamper can reserve the chunk's slot and a reader can
+ * fetch an entry without a feed walk.
+ */
+export function socAddress(
+  identifier: Identifier | Uint8Array,
+  owner: EthAddress,
+): Uint8Array {
+  const identifierBytes =
+    identifier instanceof Uint8Array ? identifier : identifier.toUint8Array()
+  return Binary.keccak256(
+    Binary.concatBytes(identifierBytes, owner.toUint8Array()),
+  )
+}


### PR DESCRIPTION
Covers two of the four checkboxes in #424 — the dedup items. The three "decompose the god object" bullets (`swarm-id-proxy.ts` / `swarm-id-client.ts` / `batch-utilization.ts` splits) are untouched.

### `socAddress(identifier, owner)`

`keccak256(identifier ‖ owner)` was written out at **nine** call sites, not the four the issue estimated: the epoch updater/finder/async-finder, the sequential finder, `lock-soc`, `download-data`, `upload`, plus `partition-intent` (intent + occupancy) and `partition-state`. All nine now call one helper in `lib/src/utils/soc-address.ts`.

Canonical signature: takes an `Identifier` or raw bytes, returns the 32 bytes. Bytes won (6 of 9 sites wanted them); the three `Reference` sites wrap it themselves. Identifier-deriving wrappers (`makeEpochIdentifier`, `makeSequentialIdentifier`, `makePartitionLockIdentifier`, …) stay where they are.

### Sequential-feed upload handlers

The three ~92-line handlers collapse to one shared body plus three wrappers over what differs: payload bytes, encryption key, response. Message schemas, response types and the `case` labels are unchanged — the wire protocol is identical.

### `buildEncryptedMerkleTree` — left alone

The two copies have **meaningfully diverged**, so per the issue's own caveat they are not deduped here. `upload.ts` carries a correctness fix the `chunking-encrypted.ts` copy lacks: it passes a single-ref batch through instead of wrapping it in a ghost intermediate (a span ≤ 4096 intermediate is misread as a leaf by the download path). Verified: for 65 refs the `chunking-encrypted` copy emits 3 intermediate chunks where `upload.ts` emits 2 — different tree shapes. Separately, the `chunking-encrypted` export is dead code (nothing imports it; only `ENCRYPTED_REFS_PER_CHUNK` from that module is used), so it is a stale copy rather than a second live implementation. Worth a follow-up to delete, which is a public-API change and out of scope here.

### Tests

Commit 1 (`test: …`) is characterization only and passes against the pre-refactor code; commit 2 does not touch it.

- **SOC addresses** — all nine sites asserted against hardcoded hex generated with an *independent* keccak256 (ethers), not recomputed with the formula under test. Private sites are driven through their public surface (finders via a recording bee stub, `uploadSOC` via a stubbed gateway fetch).
- **Upload handlers** — driven through the proxy's postMessage layer: shared index resolution (explicit and empty-feed fallback), timestamp prefixing, payload bounds, custom signer; and each handler's differences — auto-generated key vs. caller key echoed verbatim vs. always-encrypted, plus decrypted payload bytes so `data` vs. decoded `reference` can't be swapped silently.

`pnpm check:all` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)