### PR TITLE
fix(lib): repoint proxy Bee client when the node URL changes

### DIFF
--- a/lib/src/swarm-id-proxy.test.ts
+++ b/lib/src/swarm-id-proxy.test.ts
@@ -6,8 +6,24 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 // Rollup-only virtual module (see rollup.config.js) — not resolvable in vitest
 vi.mock("virtual:stamp-worker-code", () => ({ default: "" }))
 
+// Wrap the Bee constructor so tests can observe which node URL the proxy points
+// its client at, without touching any other bee-js export the proxy relies on.
+vi.mock("@ethersphere/bee-js", async (importActual) => {
+  const actual = await importActual<typeof import("@ethersphere/bee-js")>()
+  return {
+    ...actual,
+    Bee: vi.fn(function (url: string) {
+      return new actual.Bee(url)
+    }),
+  }
+})
+
+import { Bee } from "@ethersphere/bee-js"
+
+import { DEFAULT_BEE_NODE_URL } from "./schemas"
 import { SwarmIdProxy } from "./swarm-id-proxy"
 import { deriveSecret, uint8ArrayToHex } from "./utils/key-derivation"
+import { STORAGE_KEY_NETWORK_SETTINGS } from "./types"
 
 const PARENT_ORIGIN = "https://dapp.example.com"
 const ATTACKER_ORIGIN = "https://evil.example.com"
@@ -232,5 +248,68 @@ describe("SwarmIdProxy deriveAppSecret (#520)", () => {
   it("errors when not authenticated instead of leaking a secret", async () => {
     await derive("topic-seed")
     expect(lastMessage()).toMatchObject({ type: "error", requestId: "r1" })
+  })
+})
+
+describe("SwarmIdProxy honours a Bee URL change mid-session (#515)", () => {
+  const NEW_BEE_URL = "https://custom-node.example.com/"
+  let storageListeners: Array<(event: StorageEvent) => void>
+  let store: Map<string, string>
+
+  const BeeMock = vi.mocked(Bee)
+
+  const setNetworkSettings = (beeNodeUrl: string) =>
+    store.set(
+      STORAGE_KEY_NETWORK_SETTINGS,
+      JSON.stringify({ beeNodeUrl, gnosisRpcUrl: "https://rpc.example.com/" }),
+    )
+
+  const fireStorage = (key: string | undefined) =>
+    storageListeners.forEach((listener) => listener({ key } as StorageEvent))
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    BeeMock.mockClear()
+
+    store = new Map()
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => store.get(key) ?? null,
+      setItem: (key: string, value: string) => store.set(key, value),
+      removeItem: (key: string) => store.delete(key),
+    })
+
+    storageListeners = []
+    vi.stubGlobal("window", {
+      addEventListener: (
+        type: string,
+        listener: (event: StorageEvent) => void,
+      ) => {
+        if (type === "storage") storageListeners.push(listener)
+      },
+      removeEventListener: vi.fn(),
+      parent: { postMessage: vi.fn() },
+      location: { origin: "https://id.example.com" },
+    })
+
+    new SwarmIdProxy()
+  })
+
+  it("rebuilds the Bee client at the newly configured node", () => {
+    expect(BeeMock).toHaveBeenLastCalledWith(DEFAULT_BEE_NODE_URL)
+
+    setNetworkSettings(NEW_BEE_URL)
+    fireStorage(STORAGE_KEY_NETWORK_SETTINGS)
+
+    expect(BeeMock).toHaveBeenLastCalledWith(NEW_BEE_URL)
+  })
+
+  it("ignores storage events for other keys and unchanged URLs", () => {
+    const callsAfterConstruction = BeeMock.mock.calls.length
+
+    fireStorage("some-other-key")
+    setNetworkSettings(DEFAULT_BEE_NODE_URL)
+    fireStorage(STORAGE_KEY_NETWORK_SETTINGS)
+
+    expect(BeeMock.mock.calls.length).toBe(callsAfterConstruction)
   })
 })

--- a/lib/src/swarm-id-proxy.ts
+++ b/lib/src/swarm-id-proxy.ts
@@ -51,6 +51,7 @@ import {
   ParentIdentifyMessageSchema,
   PopupToIframeMessageSchema,
   STORAGE_CHALLENGE_KEY,
+  STORAGE_KEY_NETWORK_SETTINGS,
   leaseCacheStorageKey,
 } from "./types"
 import type { PopupToIframeMessage } from "./types"
@@ -341,6 +342,55 @@ export class SwarmIdProxy {
           this.handleAccountStorageChange(),
         )
       }),
+    )
+
+    // The user can change the Bee node URL at runtime via the trusted UI's
+    // network-settings dialog. That localStorage write fires a `storage` event
+    // in this same-origin dApp iframe — repoint the Bee client so the newly
+    // configured node is in effect before the next write (#515). The
+    // network-settings manager has no `subscribe`, so listen for the raw event.
+    if (typeof window !== "undefined") {
+      const onNetworkSettingsChange = (event: StorageEvent): void => {
+        if (event.key !== STORAGE_KEY_NETWORK_SETTINGS) {
+          return
+        }
+        this.applyNetworkSettings()
+      }
+      window.addEventListener("storage", onNetworkSettingsChange)
+      this.unsubscribeStorageListeners.push(() =>
+        window.removeEventListener("storage", onNetworkSettingsChange),
+      )
+    }
+  }
+
+  /**
+   * Re-read network settings and repoint the Bee client at the configured node.
+   * `beeApiUrl` / `gnosisRpcUrl` are read fresh per call by the TTL/contract
+   * helpers, so only the cached `this.bee` needs rebuilding. No-op when the Bee
+   * URL is unchanged, so an RPC-only change doesn't churn the client mid-op.
+   */
+  private applyNetworkSettings(): void {
+    const settings = createNetworkSettingsStorageManager().load()
+    this.gnosisRpcUrl = settings?.gnosisRpcUrl || DEFAULT_GNOSIS_RPC_URL
+
+    const beeNodeUrl = settings?.beeNodeUrl || DEFAULT_BEE_NODE_URL
+    if (beeNodeUrl === this.beeApiUrl) {
+      return
+    }
+    this.beeApiUrl = beeNodeUrl
+
+    // A custom node disables the dApp-provided subsidised gateway (mirrors the
+    // parentIdentify override). ponytail: reverting to the default URL won't
+    // re-enable a dropped subsidised gateway — that needs a fresh parentIdentify
+    // (dApp reload); rare enough to not build for.
+    if (this.beeApiUrl !== DEFAULT_BEE_NODE_URL) {
+      this.subsidisedGatewayUrl = undefined
+    }
+
+    this.bee = new Bee(
+      this.isSubsidisedModeActive()
+        ? this.subsidisedGatewayUrl!
+        : this.beeApiUrl,
     )
   }
 


### PR DESCRIPTION
## Problem

`SwarmIdProxy` read the Bee node URL once in its constructor and reused that single Bee client for every read/write. Changing the Bee API URL in the trusted UI's network-settings dialog never took effect in an already-live dApp proxy — writes kept going to the previously configured node until the iframe was rebuilt.

The trusted UI's own request paths already build `new Bee(url)` at call time, so only the proxy was affected.

## Fix

The proxy now listens for the `swarm-id-network-settings` storage event (fired same-origin when the trusted UI persists the change) and rebuilds its Bee client at the newly configured node before the next write — mirroring the existing subsidised-gateway swap. A custom node disables the subsidised gateway; an unchanged URL is a no-op.

### Known limitations (accepted)
- Switching **back** to the default URL won't re-enable a previously active subsidised gateway (needs a fresh `parentIdentify`, i.e. a dApp reload). Rare; marked with a `// ponytail:` comment.
- Safari storage partitioning means the event never reaches the proxy — same known limitation as auth (#167), no regression.

## Tests
TDD unit tests in `swarm-id-proxy.test.ts` (`#515`): rebuilds the client at the new node on a network-settings storage event; ignores other keys and unchanged URLs. `pnpm check:all` green.

Closes #515

🤖 Generated with [Claude Code](https://claude.com/claude-code)