### PR TITLE
feat(lib): add deriveAppSecret(label) to the client API

### DIFF
--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -308,6 +308,8 @@ export type {
   ActRevokeGranteesResponseMessage,
   ActGetGranteesResponseMessage,
   ConnectionInfoChangedMessage,
+  DeriveAppSecretMessage,
+  DeriveAppSecretResponseMessage,
   SocUploadMessage,
   SocRawUploadMessage,
   SocDownloadMessage,

--- a/lib/src/swarm-id-client.test.ts
+++ b/lib/src/swarm-id-client.test.ts
@@ -292,6 +292,34 @@ describe("SwarmIdClient request seam", () => {
     })
     await expect(promise).rejects.toThrow("Bee node unreachable")
   })
+
+  it("deriveAppSecret round-trips the label and returns the secret (#520)", async () => {
+    const secret = new Uint8Array([9, 8, 7, 6])
+
+    const promise = client.deriveAppSecret("topic-seed")
+
+    const sent = lastPostedMessage()
+    expect(sent).toMatchObject({ type: "deriveAppSecret", label: "topic-seed" })
+
+    deliver({
+      type: "deriveAppSecretResponse",
+      requestId: sent.requestId,
+      secret,
+    })
+    await expect(promise).resolves.toEqual(secret)
+  })
+
+  it("deriveAppSecret rejects when the proxy is not authenticated (#520)", async () => {
+    const promise = client.deriveAppSecret("topic-seed")
+
+    const sent = lastPostedMessage()
+    deliver({
+      type: "error",
+      requestId: sent.requestId,
+      error: "Not authenticated. Please login first.",
+    })
+    await expect(promise).rejects.toThrow("Not authenticated")
+  })
 })
 
 describe("SwarmIdClient init-timeout timers (#421)", () => {

--- a/lib/src/swarm-id-client.ts
+++ b/lib/src/swarm-id-client.ts
@@ -1197,6 +1197,43 @@ export class SwarmIdClient {
     return response.data
   }
 
+  /**
+   * Derive a stable, app-scoped secret for this identity + app origin.
+   *
+   * Computes `HMAC(appSecret, label)` inside the iframe, where `appSecret` is the
+   * app-specific secret that never leaves the trusted context. The result is
+   * deterministic — the same identity, app origin, and label always yield the
+   * same bytes across sessions and devices — yet unguessable to anyone without
+   * the identity. Use it to seed feed topics or other app material without
+   * exposing the recoverable app public key (#520).
+   *
+   * @param label - Application-chosen domain separator (e.g. `"state-feed"`)
+   * @returns A promise resolving to the 32-byte derived secret
+   * @throws {Error} If the client is not initialized or not authenticated
+   *
+   * @example
+   * ```typescript
+   * const seed = await client.deriveAppSecret('state-feed')
+   * const topic = keccak256(seed) // an unguessable, stable feed topic
+   * ```
+   */
+  async deriveAppSecret(label: string): Promise<Uint8Array> {
+    this.ensureReady()
+    const requestId = this.generateRequestId()
+
+    const response = await this.sendRequest<{
+      type: "deriveAppSecretResponse"
+      requestId: string
+      secret: Uint8Array
+    }>({
+      type: "deriveAppSecret",
+      requestId,
+      label,
+    })
+
+    return response.secret
+  }
+
   // ============================================================================
   // File Upload/Download Methods
   // ============================================================================

--- a/lib/src/swarm-id-proxy.test.ts
+++ b/lib/src/swarm-id-proxy.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest"
 vi.mock("virtual:stamp-worker-code", () => ({ default: "" }))
 
 import { SwarmIdProxy } from "./swarm-id-proxy"
+import { deriveSecret, uint8ArrayToHex } from "./utils/key-derivation"
 
 const PARENT_ORIGIN = "https://dapp.example.com"
 const ATTACKER_ORIGIN = "https://evil.example.com"
@@ -166,5 +167,70 @@ describe("SwarmIdProxy initialization failure (#420)", () => {
       type: "initError",
       error: "storage exploded",
     })
+  })
+})
+
+describe("SwarmIdProxy deriveAppSecret (#520)", () => {
+  // 32-byte hex key — appSecret is raw private-key material in hex.
+  const APP_SECRET_HEX = "11".repeat(32)
+  let proxy: SwarmIdProxy
+  let source: { postMessage: ReturnType<typeof vi.fn> }
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+
+    const listeners: Record<string, unknown> = {}
+    vi.stubGlobal("window", {
+      addEventListener: vi.fn((type: string, listener: unknown) => {
+        listeners[type] = listener
+      }),
+      removeEventListener: vi.fn(),
+      parent: { postMessage: vi.fn() },
+      location: { origin: "https://id.example.com" },
+    })
+
+    proxy = new SwarmIdProxy()
+    source = { postMessage: vi.fn() }
+  })
+
+  const derive = (label: string) =>
+    (proxy as never)["handleDeriveAppSecret"](
+      { type: "deriveAppSecret", requestId: "r1", label },
+      { source, origin: PARENT_ORIGIN } as unknown as MessageEvent,
+    )
+
+  const lastMessage = () =>
+    source.postMessage.mock.calls[source.postMessage.mock.calls.length - 1][0]
+
+  it("returns HMAC(appSecret, label) as bytes, stable and label-scoped", async () => {
+    ;(proxy as never)["authenticated"] = true
+    ;(proxy as never)["appSecret"] = APP_SECRET_HEX
+
+    await derive("topic-seed")
+    const first = lastMessage()
+    expect(first).toMatchObject({
+      type: "deriveAppSecretResponse",
+      requestId: "r1",
+    })
+    expect(uint8ArrayToHex(first.secret)).toBe(
+      await deriveSecret(APP_SECRET_HEX, "topic-seed"),
+    )
+
+    // Stable across calls (i.e. across sessions/devices for the same appSecret).
+    await derive("topic-seed")
+    expect(uint8ArrayToHex(lastMessage().secret)).toBe(
+      uint8ArrayToHex(first.secret),
+    )
+
+    // A different label yields a different secret.
+    await derive("other-label")
+    expect(uint8ArrayToHex(lastMessage().secret)).not.toBe(
+      uint8ArrayToHex(first.secret),
+    )
+  })
+
+  it("errors when not authenticated instead of leaking a secret", async () => {
+    await derive("topic-seed")
+    expect(lastMessage()).toMatchObject({ type: "error", requestId: "r1" })
   })
 })

--- a/lib/src/swarm-id-proxy.ts
+++ b/lib/src/swarm-id-proxy.ts
@@ -8,6 +8,7 @@ import type {
   ButtonConfig,
   UploadDataMessage,
   DownloadDataMessage,
+  DeriveAppSecretMessage,
   UploadFileMessage,
   DownloadFileMessage,
   UploadChunkMessage,
@@ -1036,6 +1037,10 @@ export class SwarmIdProxy {
 
       case "downloadData":
         await this.handleDownloadData(message, event)
+        break
+
+      case "deriveAppSecret":
+        await this.handleDeriveAppSecret(message, event)
         break
 
       case "uploadFile":
@@ -2698,6 +2703,39 @@ export class SwarmIdProxy {
         event,
         requestId,
         error instanceof Error ? error.message : "SOC get owner failed",
+      )
+    }
+  }
+
+  /**
+   * Derive a stable, app-scoped secret HMAC(appSecret, label) for the connected
+   * app. `appSecret` is genuinely secret (unlike the recoverable appKey public
+   * key) and never leaves the iframe — only the derived bytes are returned, so
+   * the app can seed an unguessable feed topic without exposing metadata (#520).
+   */
+  private async handleDeriveAppSecret(
+    message: DeriveAppSecretMessage,
+    event: MessageEvent,
+  ): Promise<void> {
+    const { requestId, label } = message
+
+    try {
+      if (!this.authenticated || !this.appSecret) {
+        throw new Error("Not authenticated. Please login first.")
+      }
+
+      const secretHex = await deriveSecret(this.appSecret, label)
+
+      this.postMessage(event, {
+        type: "deriveAppSecretResponse",
+        requestId,
+        secret: hexToUint8Array(secretHex),
+      })
+    } catch (error) {
+      this.sendErrorToParent(
+        event,
+        requestId,
+        error instanceof Error ? error.message : "deriveAppSecret failed",
       )
     }
   }

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -725,6 +725,14 @@ export const DownloadDataMessageSchema = z.object({
   requestOptions: RequestOptionsSchema,
 })
 
+// Derive a stable, app-scoped secret HMAC(appSecret, label) inside the iframe.
+// The raw appSecret never crosses to the parent; only the derived bytes do (#520).
+export const DeriveAppSecretMessageSchema = z.object({
+  type: z.literal("deriveAppSecret"),
+  requestId: z.string(),
+  label: z.string(),
+})
+
 export const UploadFileMessageSchema = z.object({
   type: z.literal("uploadFile"),
   requestId: z.string(),
@@ -1037,6 +1045,7 @@ export const ParentToIframeMessageSchema = z.discriminatedUnion("type", [
   DisconnectMessageSchema,
   UploadDataMessageSchema,
   DownloadDataMessageSchema,
+  DeriveAppSecretMessageSchema,
   UploadFileMessageSchema,
   DownloadFileMessageSchema,
   UploadChunkMessageSchema,
@@ -1075,6 +1084,9 @@ export type CheckAuthMessage = z.infer<typeof CheckAuthMessageSchema>
 export type DisconnectMessage = z.infer<typeof DisconnectMessageSchema>
 export type UploadDataMessage = z.infer<typeof UploadDataMessageSchema>
 export type DownloadDataMessage = z.infer<typeof DownloadDataMessageSchema>
+export type DeriveAppSecretMessage = z.infer<
+  typeof DeriveAppSecretMessageSchema
+>
 export type UploadFileMessage = z.infer<typeof UploadFileMessageSchema>
 export type DownloadFileMessage = z.infer<typeof DownloadFileMessageSchema>
 export type UploadChunkMessage = z.infer<typeof UploadChunkMessageSchema>
@@ -1179,6 +1191,12 @@ export const DownloadDataResponseMessageSchema = z.object({
   type: z.literal("downloadDataResponse"),
   requestId: z.string(),
   data: z.instanceof(Uint8Array),
+})
+
+export const DeriveAppSecretResponseMessageSchema = z.object({
+  type: z.literal("deriveAppSecretResponse"),
+  requestId: z.string(),
+  secret: z.instanceof(Uint8Array),
 })
 
 export const UploadFileResponseMessageSchema = z.object({
@@ -1465,6 +1483,7 @@ export const IframeToParentMessageSchema = z.discriminatedUnion("type", [
   AuthSuccessMessageSchema,
   UploadDataResponseMessageSchema,
   DownloadDataResponseMessageSchema,
+  DeriveAppSecretResponseMessageSchema,
   UploadFileResponseMessageSchema,
   DownloadFileResponseMessageSchema,
   UploadChunkResponseMessageSchema,
@@ -1515,6 +1534,9 @@ export type UploadDataResponseMessage = z.infer<
 >
 export type DownloadDataResponseMessage = z.infer<
   typeof DownloadDataResponseMessageSchema
+>
+export type DeriveAppSecretResponseMessage = z.infer<
+  typeof DeriveAppSecretResponseMessageSchema
 >
 export type UploadFileResponseMessage = z.infer<
   typeof UploadFileResponseMessageSchema


### PR DESCRIPTION
## Problem

An app's state-feed topic is derived from the app key's **public** key, which is recoverable from any SOC signature the app has ever written. Anyone holding one of the app's chunks can recompute the topic and observe that the feed exists and how often it updates. Content stays ACT-protected; this metadata does not.

The app has no secret of its own to derive from — the only secret material (`appSecret` and the master key) never leaves the iframe.

## Change

Add `client.deriveAppSecret(label: string): Promise<Uint8Array>` = `HMAC(appSecret, label)`.

- Computed **inside the proxy** from `appSecret` (which is genuinely secret and never crosses the postMessage boundary); only the derived bytes are returned.
- Deterministic — same identity + app origin + label yields the same 32 bytes across sessions and devices — yet unguessable without the identity.
- An app can seed an unguessable, stable feed topic instead of using the recoverable public key.

Implemented as a parent→iframe request/response round-trip mirroring `downloadData`, reusing the existing `deriveSecret` (HMAC-SHA256) helper — no new crypto.

## Tests
- Client round-trip + not-authenticated rejection (`swarm-id-client.test.ts`).
- Proxy-level construction (`swarm-id-proxy.test.ts`): asserts `secret === HMAC(appSecret, label)`, stable across calls, label-scoped, and errors instead of leaking when unauthenticated.

`format:check` / `lint` / `typecheck` clean; new tests pass. (An unrelated pre-existing flaky integration test, `roundtrip.test.ts > should write and read 50 sequential updates`, passes in isolation.)

Closes #520

🤖 Generated with [Claude Code](https://claude.com/claude-code)