### PR TITLE
chore: run the local cluster on bee-compose 0.2.0

### DIFF
--- a/.claude/rules/bee-cluster.md
+++ b/.claude/rules/bee-cluster.md
@@ -7,41 +7,25 @@ paths:
 
 # Local Bee Development Cluster (bee-compose)
 
-Docker-based local Bee cluster for development with postage stamps, from
-[@snaha/bee-compose](https://www.npmjs.com/package/@snaha/bee-compose) **>= 0.2.0**, which carries
-the hybrid chain the whole repo runs on — swap disabled, no chequebook factory, Gnosis mainnet
-contract addresses.
-
-**The version floor matters.** 0.1.x expected the old DEX-less chain (`BEE_SWAP_ENABLE=true`, a
-chequebook factory at `0x5FC8d326…`, its own PostageStamp); against the hybrid chain its queen
-crashloops with `factory fail: abi: attempting to unmarshal an empty string`, which reads as a
-broken cluster rather than a stale dependency.
+Docker-based local Bee cluster for development with postage stamps. Uses [@snaha/bee-compose](https://www.npmjs.com/package/@snaha/bee-compose) **≥ 0.2.0** — the release carrying the hybrid Gnosis chain. Against it, 0.1.x's queen crashloops with `factory fail: abi: attempting to unmarshal an empty string`, which reads as a broken cluster rather than a stale dependency.
 
 ```bash
-pnpm dev:cluster:start          # start the cluster (what CI runs)
-pnpm dev:cluster:start --fresh  # the same, from a clean chain and empty node state
-pnpm dev:cluster stop
-pnpm dev:cluster status
-pnpm dev:cluster:logs                    # tail the queen
-
-pnpm dev:chain:detach   # the cluster's chain alone, on :9545 (start --without-bees)
-pnpm dev:chain:stop
+pnpm dev:cluster:start          # Start in background
+pnpm dev:cluster:start --fresh  # Fresh start (purge data)
+pnpm dev:cluster stop           # Stop cluster
+pnpm dev:cluster:logs           # Tail the queen
 ```
 
-`--full 4` is a 4-node full network (queen + 3 full workers).
+The scripts start a 4-node full network (`--full 4` = queen + 3 full workers). `pnpm dev:cluster`
+passes anything else through to the CLI (`status`, `--without-bees`, …).
 
 **Bumping bee-compose needs `--pull`, not just `--fresh`.** The chain snapshot is baked into the
 `bee-compose:blockchain-*` image at build time, and `--fresh` only tears down volumes — it reuses
-the image it already has. So after a version bump the cluster keeps serving the OLD chain, and the
-only symptom is that nodes never ingest a batch you can see on-chain (`/chainstate` looks healthy).
-Use `pnpm dev:cluster:start --fresh --pull`, or delete the image. CI is immune: its image
-cache is keyed on the lockfile.
+the image it already has, so the cluster keeps serving the OLD chain. The only symptom is that
+nodes never ingest a batch you can plainly see on-chain (`/chainstate` looks healthy). Use
+`pnpm dev:cluster:start --fresh --pull`. CI is immune: its image cache is keyed on the lockfile.
 
-`dev:cluster` is the package's own CLI off `node_modules/.bin`. `dev:chain` is the same CLI with
-`--without-bees`: the identical chain container on `:9545`, no Bee nodes, for anything that needs a
-chain but not a network — the fork suite and the drive e2e both do.
-
-## Pushsync needs `reachabilityOverridePublic=true` — built into the cluster image
+## Pushsync needs `reachabilityOverridePublic=true` — now built into bee-compose ≥ 0.1.4
 
 `deferred: false` writes (every epoch-feed, partition-lock/intent SOC, and any direct
 `/bytes`/`/chunks`/`/soc` upload — note `uploadData`/`uploadChunk` are non-deferred) require Bee
@@ -55,12 +39,12 @@ SOC/non-deferred upload takes exactly ~30 s** (reads still work — the chunk is
 origin — but replication/receipts don't), and multi-device lock/intent SOCs never become
 network-readable by peers.
 
-**Fixed, and no longer something to check** ([#11](https://github.com/snaha/bee-compose/issues/11)):
+**Fixed in bee-compose ≥ 0.1.4** ([#11](https://github.com/snaha/bee-compose/issues/11)):
 `bee/Dockerfile` recompiles Bee from source at `v${BEE_VERSION}` with
 `make binary REACHABILITY_OVERRIDE_PUBLIC=true`, so non-deferred uploads replicate out of the box — no
-manual override-image build needed. 0.2.0 is well past the release that added it. Cost: the **first**
-`dev:cluster start` compiles Bee from source (a few minutes; cached and shared across node images
-afterward). (On a real public gateway the override is irrelevant — reachability is genuine there.)
+manual override-image build needed. Cost: the **first** `bee-compose start` compiles Bee from source (a
+few minutes; cached and shared across node images afterward). (On a real public gateway the override
+is irrelevant — reachability is genuine there.)
 
 Verify after start (read-only): every node `bee_kademlia_reachability_status{...="Public"}` (NOT
 `Unknown`); queen `/topology` `connected ≥ 3`; a non-deferred upload returns in <1 s and queen

--- a/.claude/rules/bee-cluster.md
+++ b/.claude/rules/bee-cluster.md
@@ -7,18 +7,41 @@ paths:
 
 # Local Bee Development Cluster (bee-compose)
 
-Docker-based local Bee cluster for development with postage stamps. Uses [@snaha/bee-compose](https://www.npmjs.com/package/@snaha/bee-compose).
+Docker-based local Bee cluster for development with postage stamps, from
+[@snaha/bee-compose](https://www.npmjs.com/package/@snaha/bee-compose) **>= 0.2.0**, which carries
+the hybrid chain the whole repo runs on — swap disabled, no chequebook factory, Gnosis mainnet
+contract addresses.
+
+**The version floor matters.** 0.1.x expected the old DEX-less chain (`BEE_SWAP_ENABLE=true`, a
+chequebook factory at `0x5FC8d326…`, its own PostageStamp); against the hybrid chain its queen
+crashloops with `factory fail: abi: attempting to unmarshal an empty string`, which reads as a
+broken cluster rather than a stale dependency.
 
 ```bash
-pnpm dev:bee          # Start cluster (queen + 3 full workers = 4-node net), foreground
-pnpm dev:bee:detach   # Start in background
-pnpm dev:bee:stop     # Stop cluster
-pnpm dev:bee:fresh    # Fresh start (purge data)
+pnpm dev:cluster:start          # start the cluster (what CI runs)
+pnpm dev:cluster:start --fresh  # the same, from a clean chain and empty node state
+pnpm dev:cluster stop
+pnpm dev:cluster status
+pnpm dev:cluster:logs                    # tail the queen
+
+pnpm dev:chain:detach   # the cluster's chain alone, on :9545 (start --without-bees)
+pnpm dev:chain:stop
 ```
 
-The scripts start a 4-node full network (`--full 4` = queen + 3 full workers).
+`--full 4` is a 4-node full network (queen + 3 full workers).
 
-## Pushsync needs `reachabilityOverridePublic=true` — now built into bee-compose ≥ 0.1.4
+**Bumping bee-compose needs `--pull`, not just `--fresh`.** The chain snapshot is baked into the
+`bee-compose:blockchain-*` image at build time, and `--fresh` only tears down volumes — it reuses
+the image it already has. So after a version bump the cluster keeps serving the OLD chain, and the
+only symptom is that nodes never ingest a batch you can see on-chain (`/chainstate` looks healthy).
+Use `pnpm dev:cluster:start --fresh --pull`, or delete the image. CI is immune: its image
+cache is keyed on the lockfile.
+
+`dev:cluster` is the package's own CLI off `node_modules/.bin`. `dev:chain` is the same CLI with
+`--without-bees`: the identical chain container on `:9545`, no Bee nodes, for anything that needs a
+chain but not a network — the fork suite and the drive e2e both do.
+
+## Pushsync needs `reachabilityOverridePublic=true` — built into the cluster image
 
 `deferred: false` writes (every epoch-feed, partition-lock/intent SOC, and any direct
 `/bytes`/`/chunks`/`/soc` upload — note `uploadData`/`uploadChunk` are non-deferred) require Bee
@@ -32,16 +55,12 @@ SOC/non-deferred upload takes exactly ~30 s** (reads still work — the chunk is
 origin — but replication/receipts don't), and multi-device lock/intent SOCs never become
 network-readable by peers.
 
-**Fixed in bee-compose ≥ 0.1.4** ([#11](https://github.com/snaha/bee-compose/issues/11)):
+**Fixed, and no longer something to check** ([#11](https://github.com/snaha/bee-compose/issues/11)):
 `bee/Dockerfile` recompiles Bee from source at `v${BEE_VERSION}` with
 `make binary REACHABILITY_OVERRIDE_PUBLIC=true`, so non-deferred uploads replicate out of the box — no
-manual override-image build needed. Cost: the **first** `bee-compose start` compiles Bee from source (a
-few minutes; cached and shared across node images afterward).
-
-> ⚠️ swarm-id pins `@snaha/bee-compose@^0.1.3` and the lockfile may still resolve to **0.1.3 (no
-> override → the ~30 s hang)**. If non-deferred uploads stall locally, update to ≥ 0.1.4
-> (`pnpm update @snaha/bee-compose`) and rebuild (`pnpm dev:bee:fresh`; the first start recompiles Bee).
-> (On a real public gateway the override is irrelevant — reachability is genuine there.)
+manual override-image build needed. 0.2.0 is well past the release that added it. Cost: the **first**
+`dev:cluster start` compiles Bee from source (a few minutes; cached and shared across node images
+afterward). (On a real public gateway the override is irrelevant — reachability is genuine there.)
 
 Verify after start (read-only): every node `bee_kademlia_reachability_status{...="Public"}` (NOT
 `Unknown`); queen `/topology` `connected ≥ 3`; a non-deferred upload returns in <1 s and queen

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,7 +41,7 @@ jobs:
       # Cache the locally-built cluster images (queen, worker, blockchain) so we
       # skip rebuilding them and re-pulling the upstream bases each run. This
       # caches IMAGES ONLY via docker save/load — never volumes, so the chain
-      # state (baked into the image as state.anvil.json) is always fresh.
+      # state (baked into the image as state.gnosis.json) is always fresh.
       # Keyed on the lockfile so a bee-compose bump invalidates it.
       - name: Cache Bee cluster images
         id: bee-images
@@ -57,7 +57,7 @@ jobs:
           docker images --filter 'reference=bee-compose:*'
 
       - name: Start Bee cluster
-        run: pnpm dev:bee:detach
+        run: pnpm dev:cluster:start
 
       - name: Save cluster images to cache
         if: steps.bee-images.outputs.cache-hit != 'true'
@@ -97,12 +97,12 @@ jobs:
         run: |
           docker ps -a || true
           echo "::group::blockchain logs"
-          pnpm exec bee-compose logs blockchain --tail 200 || true
+          pnpm dev:cluster logs blockchain --tail 200 || true
           echo "::endgroup::"
           echo "::group::queen logs"
-          pnpm exec bee-compose logs queen --tail 300 || true
+          pnpm dev:cluster logs queen --tail 300 || true
           echo "::endgroup::"
 
       - name: Stop Bee cluster
         if: always()
-        run: pnpm dev:bee:stop || true
+        run: pnpm dev:cluster stop || true

--- a/README.md
+++ b/README.md
@@ -110,21 +110,22 @@ pnpm dev:lib         # Library watch mode (rebuilds on changes)
 
 ### Local Bee Cluster (bee-compose)
 
-For local development with postage stamps and uploads, use [@snaha/bee-compose](https://www.npmjs.com/package/@snaha/bee-compose) to run a local Bee cluster with blockchain. Requires Docker.
+For local development with postage stamps and uploads you need a Bee cluster and its chain. Both
+come from [@snaha/bee-compose](https://www.npmjs.com/package/@snaha/bee-compose), which ships the
+chain snapshot the cluster boots. Requires Docker.
 
 ```bash
-# Start cluster (queen + 1 light worker)
-pnpm dev:bee:detach
+pnpm dev:cluster:start           # start the cluster (queen + 3 full workers)
+pnpm dev:cluster:start --fresh   # the same, from a clean chain and empty node state
+pnpm dev:cluster stop
+pnpm dev:cluster:logs                     # tail the queen
 
-# View logs
-pnpm dev:bee:logs
-
-# Stop cluster
-pnpm dev:bee:stop
-
-# Fresh start (pull latest images, purge data)
-pnpm dev:bee:fresh
+pnpm dev:chain:detach                     # the cluster's chain alone, on :8545
+pnpm dev:chain:stop
 ```
+
+> `pnpm install` is all the setup there is — the chain snapshot ships inside the package. The first
+> start compiles Bee from source (a few minutes, cached afterwards); later runs are seconds.
 
 **Endpoints:**
 

--- a/README.md
+++ b/README.md
@@ -110,22 +110,21 @@ pnpm dev:lib         # Library watch mode (rebuilds on changes)
 
 ### Local Bee Cluster (bee-compose)
 
-For local development with postage stamps and uploads you need a Bee cluster and its chain. Both
-come from [@snaha/bee-compose](https://www.npmjs.com/package/@snaha/bee-compose), which ships the
-chain snapshot the cluster boots. Requires Docker.
+For local development with postage stamps and uploads, use [@snaha/bee-compose](https://www.npmjs.com/package/@snaha/bee-compose) to run a local Bee cluster with blockchain. Requires Docker.
 
 ```bash
-pnpm dev:cluster:start           # start the cluster (queen + 3 full workers)
-pnpm dev:cluster:start --fresh   # the same, from a clean chain and empty node state
+# Start cluster (queen + 3 full workers)
+pnpm dev:cluster:start
+
+# View logs
+pnpm dev:cluster:logs
+
+# Stop cluster
 pnpm dev:cluster stop
-pnpm dev:cluster:logs                     # tail the queen
 
-pnpm dev:chain:detach                     # the cluster's chain alone, on :8545
-pnpm dev:chain:stop
+# Fresh start (purge data; add --pull after a bee-compose bump)
+pnpm dev:cluster:start --fresh
 ```
-
-> `pnpm install` is all the setup there is — the chain snapshot ships inside the package. The first
-> start compiles Bee from source (a few minutes, cached afterwards); later runs are seconds.
 
 **Endpoints:**
 

--- a/docs-site/src/content/docs/local-development.mdx
+++ b/docs-site/src/content/docs/local-development.mdx
@@ -13,7 +13,7 @@ The project uses [@snaha/bee-compose](https://www.npmjs.com/package/@snaha/bee-c
 
 ```bash
 # Start Bee cluster in background
-pnpm dev:bee:detach
+pnpm dev:cluster:start
 
 # Start the development servers
 pnpm dev
@@ -21,13 +21,18 @@ pnpm dev
 
 ### All Cluster Commands
 
-| Command               | Description                              |
-| --------------------- | ---------------------------------------- |
-| `pnpm dev:bee`        | Start cluster interactively (shows logs) |
-| `pnpm dev:bee:detach` | Start cluster in background              |
-| `pnpm dev:bee:stop`   | Stop the cluster                         |
-| `pnpm dev:bee:logs`   | View queen node logs                     |
-| `pnpm dev:bee:fresh`  | Clean start with latest images           |
+| Command                          | Description                             |
+| -------------------------------- | --------------------------------------- |
+| `pnpm dev:cluster:start`         | Start cluster in background (queen + 3) |
+| `pnpm dev:cluster:start --fresh` | Clean start (destroys node state)       |
+| `pnpm dev:cluster stop`          | Stop the cluster                        |
+| `pnpm dev:cluster status`        | Show what is running                    |
+| `pnpm dev:cluster:logs`          | Follow queen node logs                  |
+
+`pnpm dev:cluster` passes anything through to the `bee-compose` CLI, so
+`pnpm dev:cluster start --help` lists the rest.
+
+The first start compiles Bee from source (a few minutes); later starts are seconds.
 
 ### Local Endpoints
 
@@ -140,7 +145,8 @@ On Chrome/Firefox localhost, storage should work immediately. If issues occur, t
 
 - Ensure Docker is running
 - Check if ports 1633, 16331, or 9545 are already in use
-- Try `pnpm dev:bee:fresh` for a clean start
+- Try `pnpm dev:cluster:start --fresh` for a clean start
+- After a `@snaha/bee-compose` upgrade, add `--pull` so the chain image is rebuilt rather than reused
 
 ### Library Changes Not Reflected
 

--- a/docs-site/src/content/docs/local-development.mdx
+++ b/docs-site/src/content/docs/local-development.mdx
@@ -29,10 +29,8 @@ pnpm dev
 | `pnpm dev:cluster status`        | Show what is running                    |
 | `pnpm dev:cluster:logs`          | Follow queen node logs                  |
 
-`pnpm dev:cluster` passes anything through to the `bee-compose` CLI, so
-`pnpm dev:cluster start --help` lists the rest.
-
-The first start compiles Bee from source (a few minutes); later starts are seconds.
+`pnpm dev:cluster` passes anything through to the `bee-compose` CLI, so `pnpm dev:cluster --help`
+lists the rest.
 
 ### Local Endpoints
 

--- a/lib/test/integration/README.md
+++ b/lib/test/integration/README.md
@@ -22,7 +22,7 @@ replacing manual testing with automated round-trips against a real node.
 From the repo root, start the cluster, then run the suite:
 
 ```bash
-pnpm dev:cluster:start                            # start queen + 1 worker (Docker)
+pnpm dev:cluster:start   # start queen + 3 full workers (Docker)
 pnpm --filter @snaha/swarm-id test:integration
 ```
 

--- a/lib/test/integration/README.md
+++ b/lib/test/integration/README.md
@@ -22,7 +22,7 @@ replacing manual testing with automated round-trips against a real node.
 From the repo root, start the cluster, then run the suite:
 
 ```bash
-pnpm dev:bee:detach                            # start queen + 1 worker (Docker)
+pnpm dev:cluster:start                            # start queen + 1 worker (Docker)
 pnpm --filter @snaha/swarm-id test:integration
 ```
 

--- a/lib/test/integration/cluster.ts
+++ b/lib/test/integration/cluster.ts
@@ -3,7 +3,7 @@
 
 /**
  * Helpers for integration tests that run against a live local Bee cluster
- * started with `@snaha/bee-compose` (see `pnpm dev:bee`).
+ * started with `@snaha/bee-compose` (see `pnpm dev:cluster:start`).
  *
  * These helpers intentionally avoid the browser-only machinery used by the
  * proxy (IndexedDB-backed `UtilizationAwareStamper`, postMessage, etc.) and

--- a/lib/test/integration/global-setup.ts
+++ b/lib/test/integration/global-setup.ts
@@ -19,7 +19,7 @@ import { isClusterReachable, buyUsableStamp } from "./cluster"
 export default async function setup({ provide }: GlobalSetupContext) {
   if (!(await isClusterReachable())) {
     console.warn(
-      "[cluster] No local Bee cluster reachable at http://localhost:1633 — cluster integration tests will be skipped. Run `pnpm dev:bee:detach` to enable them.",
+      "[cluster] No local Bee cluster reachable at http://localhost:1633 — cluster integration tests will be skipped. Run `pnpm dev:cluster:start` to enable them.",
     )
     return
   }

--- a/lib/test/integration/round-trip.test.ts
+++ b/lib/test/integration/round-trip.test.ts
@@ -6,7 +6,7 @@
  * against a live local Bee node started with `@snaha/bee-compose`.
  *
  * Run with:
- *   pnpm dev:bee:detach   # from the repo root, starts the cluster
+ *   pnpm dev:cluster:start   # from the repo root, starts the cluster
  *   pnpm --filter @snaha/swarm-id test:integration
  *
  * The whole suite is skipped automatically when no cluster is reachable, so it

--- a/package.json
+++ b/package.json
@@ -6,15 +6,13 @@
   "type": "module",
   "scripts": {
     "dev": "concurrently -n ui,demo -c blue,green \"pnpm dev:ui\" \"pnpm dev:demo\"",
-    "dev:bee": "bee-compose start --full 4 --no-detach",
-    "dev:bee:detach": "bee-compose start --full 4",
-    "dev:bee:stop": "bee-compose stop",
-    "dev:bee:logs": "bee-compose logs queen --follow",
-    "dev:bee:fresh": "bee-compose start --full 4 --fresh",
     "dev:demo": "PUBLIC_ID_DOMAIN=http://localhost:5500 pnpm --filter @swarm-id/demo exec vite dev --port 3500",
     "dev:lib": "pnpm --filter @snaha/swarm-id build:watch",
     "dev:ui": "pnpm --filter @swarm-id/ui dev",
     "dev:docs": "pnpm --filter @swarm-id/docs dev",
+    "dev:cluster": "bee-compose",
+    "dev:cluster:start": "bee-compose start --full 4",
+    "dev:cluster:logs": "bee-compose logs queen --follow",
     "build": "pnpm -r --workspace-concurrency=1 build",
     "build:lib": "pnpm --filter @snaha/swarm-id build",
     "build:demo": "pnpm --filter @swarm-id/demo build",
@@ -30,7 +28,7 @@
     "format:lib": "pnpm --filter @snaha/swarm-id format"
   },
   "devDependencies": {
-    "@snaha/bee-compose": "^0.1.5",
+    "@snaha/bee-compose": "^0.2.0",
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "concurrently": "^9.1.2",
     "prettier": "^3.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@snaha/bee-compose':
-        specifier: ^0.1.5
-        version: 0.1.5
+        specifier: ^0.2.0
+        version: 0.2.0
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^6.0.2
         version: 6.0.2(prettier-plugin-svelte@3.4.0(prettier@3.8.1)(svelte@5.48.2))(prettier@3.8.1)(svelte@5.48.2)
@@ -1771,8 +1771,8 @@ packages:
   '@sideway/pinpoint@2.0.0':
     resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
 
-  '@snaha/bee-compose@0.1.5':
-    resolution: {integrity: sha512-m5A+eqD5rRDaF2RaRWJ0eHOcOsYhXLRbZN25/ydhyGEDB2wy0tNYeMVq5cBXlvWRbuHy1IsDa9MfGMCO6whrFQ==}
+  '@snaha/bee-compose@0.2.0':
+    resolution: {integrity: sha512-6svciJ8QVmiy6ncJWXtfDTFQVc2MRGTJJu+rhguaZVkO1iIyNvisMCDJFwgPNF2quPE2Xi62V/dcKNINvDNtGw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6096,7 +6096,7 @@ snapshots:
 
   '@sideway/pinpoint@2.0.0': {}
 
-  '@snaha/bee-compose@0.1.5':
+  '@snaha/bee-compose@0.2.0':
     dependencies:
       commander: 12.1.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,3 +14,11 @@ allowBuilds:
   sharp: true
   # es5-ext has a noisy postinstall (sponsorship message); not required to build.
   es5-ext: false
+
+# pnpm holds new releases back for a cooling-off period as a supply-chain
+# guard. 0.2.0 is the release that carries the hybrid chain and was published
+# the same day this landed, so it needs an explicit exemption to install at
+# all. It is OURS (snaha/bee-compose), a devDependency, and never ships.
+# Delete this once the release has aged past the window.
+minimumReleaseAgeExclude:
+  - '@snaha/bee-compose@0.2.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,10 +15,8 @@ allowBuilds:
   # es5-ext has a noisy postinstall (sponsorship message); not required to build.
   es5-ext: false
 
-# pnpm holds new releases back for a cooling-off period as a supply-chain
-# guard. 0.2.0 is the release that carries the hybrid chain and was published
-# the same day this landed, so it needs an explicit exemption to install at
-# all. It is OURS (snaha/bee-compose), a devDependency, and never ships.
-# Delete this once the release has aged past the window.
+# pnpm holds new releases back for a cooling-off period as a supply-chain guard,
+# and 0.2.0 was published the same day this landed. It is ours (snaha/bee-compose)
+# and a devDependency that never ships. Delete once the release has aged out.
 minimumReleaseAgeExclude:
   - '@snaha/bee-compose@0.2.0'

--- a/ui/src/lib/payment/contract.ts
+++ b/ui/src/lib/payment/contract.ts
@@ -11,11 +11,6 @@ import { strip0x } from '$lib/crypto/hex'
 import type { NewStamp } from '$lib/payment/purchase'
 import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
 
-// bee-compose anvil deploy of the PostageStamp contract; only used when the RPC
-// URL is local (resolvePostageStampContractAddress gates it — a remote RPC
-// resolves to Gnosis mainnet). Inert in production.
-export const LOCAL_POSTAGE_STAMP_CONTRACT_ADDRESS = '0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512'
-
 /**
  * Read a batch's parameters straight from the PostageStamp contract ON-CHAIN
  * (not from a Bee node), so any batch id works even when the configured node
@@ -34,9 +29,9 @@ export async function fetchExistingBatchFromChain(
   opts?: { rpcUrl?: string; contractAddress?: string },
 ): Promise<NewStamp | undefined> {
   const rpcUrl = opts?.rpcUrl ?? networkSettingsStore.gnosisRpcUrl
-  const contractAddress =
-    opts?.contractAddress ??
-    resolvePostageStampContractAddress(rpcUrl, LOCAL_POSTAGE_STAMP_CONTRACT_ADDRESS)
+  // No local-only deployment any more: the cluster's chain carries the Swarm
+  // contracts at their MAINNET addresses, so local and remote resolve alike.
+  const contractAddress = opts?.contractAddress ?? resolvePostageStampContractAddress(rpcUrl)
 
   const state = await fetchOnChainBatchState(rpcUrl, strip0x(batchId), contractAddress)
   if (!state) {

--- a/ui/src/routes/dev/+page.svelte
+++ b/ui/src/routes/dev/+page.svelte
@@ -597,10 +597,9 @@ Check console logs for details:
   let importMessage = $state('')
   let importError = $state('')
 
-  // Contract address the read will use: the override if set, else auto-detected
-  // from the RPC. There is no local-only deployment any more: the cluster's
-  // chain carries the Swarm contracts at their MAINNET addresses, so local and
-  // remote resolve to the same one.
+  // Contract address the read will use: the override if set, else the mainnet
+  // deployment — the cluster's chain carries the Swarm contracts at their
+  // mainnet addresses, so local and remote resolve to the same one.
   const resolvedContract = $derived(resolvePostageStampContractAddress(importRpcUrl.trim()))
   const effectiveContract = $derived(importContractOverride.trim() || resolvedContract)
 

--- a/ui/src/routes/dev/+page.svelte
+++ b/ui/src/routes/dev/+page.svelte
@@ -29,10 +29,7 @@
   import { Tabs } from '$lib/components/ui/tabs'
   import { postageStampsStore } from '$lib/dev/postage-stamps.svelte'
   import { syncStore } from '$lib/dev/sync.svelte'
-  import {
-    LOCAL_POSTAGE_STAMP_CONTRACT_ADDRESS,
-    fetchExistingBatchFromChain,
-  } from '$lib/payment/contract'
+  import { fetchExistingBatchFromChain } from '$lib/payment/contract'
   import routes from '$lib/routes'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { devSettingsStore } from '$lib/stores/dev-settings.svelte'
@@ -601,11 +598,10 @@ Check console logs for details:
   let importError = $state('')
 
   // Contract address the read will use: the override if set, else auto-detected
-  // from the RPC — local RPC → local anvil deployment, any remote RPC → Gnosis
-  // mainnet (resolvePostageStampContractAddress encodes that rule).
-  const resolvedContract = $derived(
-    resolvePostageStampContractAddress(importRpcUrl.trim(), LOCAL_POSTAGE_STAMP_CONTRACT_ADDRESS),
-  )
+  // from the RPC. There is no local-only deployment any more: the cluster's
+  // chain carries the Swarm contracts at their MAINNET addresses, so local and
+  // remote resolve to the same one.
+  const resolvedContract = $derived(resolvePostageStampContractAddress(importRpcUrl.trim()))
   const effectiveContract = $derived(importContractOverride.trim() || resolvedContract)
 
   async function importBatchById() {


### PR DESCRIPTION
**Stack 1/6** — base `main`. The rest of the series builds on this.

The cluster and the chain it boots come from `@snaha/bee-compose@^0.2.0`, the release that carries the hybrid chain: swap disabled, no chequebook factory, Gnosis mainnet contract addresses, and the baked snapshot shipped inside the package.

**0.1.x is not merely older, it is wrong for this chain.** It expected the DEX-less one (`BEE_SWAP_ENABLE=true`, a chequebook factory, its own PostageStamp); against the hybrid chain its queen crashloops with `factory fail: abi: attempting to unmarshal an empty string`, which reads as a broken cluster rather than a stale dependency. Hence the version floor.

## Scripts

`dev:bee*` → `dev:cluster*`, in two pieces so the long form stops leaking into every document:

- **`dev:cluster:start`** — the fixed four-node network (`start --full 4`) that every call site actually wants. CI, the READMEs and the integration suite all use this.
- **`dev:cluster`** — a passthrough to the CLI, which is what makes `--fresh`, `--pull`, `--without-bees`, `status` and `logs` reachable without a script per flag.

## The local PostageStamp address goes with the old chain

`LOCAL_POSTAGE_STAMP_CONTRACT_ADDRESS = 0xe7f1725E…` was 0.1.x's anvil deployment. On the hybrid chain the contract sits at its **mainnet** address, so a local RPC resolving to the old constant reads an address with no code and every on-chain batch read fails silently — the [#344](https://github.com/snaha/swarm-id/issues/344) failure mode from the other side, reintroduced by the chain swap.

Local and mainnet are now the same address, so the constant and its `localContractAddress` argument are **deleted rather than corrected**. (`ProxyConfig.postageStampContractAddress` in `lib/` is the same dead weight; left for a follow-up so this PR stays about the cluster.)

## Docs

`docs-site/.../local-development.mdx` documented all five `dev:bee*` commands and is the one page strangers read, so it moves too — including a note that a version bump needs `--pull`.

## Two things reviewers should know

**A version bump needs `--pull`, not just `--fresh`.** The snapshot is baked into the `bee-compose:blockchain-*` image at build time, and the tag does not change between releases — so `--fresh` tears down volumes and then reuses the stale image. The cluster keeps serving the *old* chain and the only symptom is that nodes never ingest a batch you can plainly see on-chain. This cost me a debugging round; it is now in `.claude/rules/bee-cluster.md`. CI is immune (image cache keyed on the lockfile).

**`minimumReleaseAgeExclude`.** pnpm 11 holds new releases back for a cooling-off period by default, and 0.2.0 was published the same day, so installing it needs an explicit exemption. Our own package, a devDependency, never shipped — but it is a security control switched off for one entry, and it pins `0.2.0` exactly, so a 0.2.1 would need a new entry. Worth an issue so it gets deleted rather than rotting.

## Verification

`pnpm check:all` green. Against a cluster and chain rebuilt from 0.2.0: fork suite **11/11**, drive e2e **33 passed**, Bee-ingestion e2e **2 passed**. (Those suites live later in the stack; run at the tip.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

