### PR TITLE
docs: document the on-chain postage engine and the drive payment flow

### DIFF
--- a/docs/Drive-Payment-Flow.md
+++ b/docs/Drive-Payment-Flow.md
@@ -1,0 +1,280 @@
+# Drive payment flow — paying for storage in-app, from any chain
+
+Status: **design of record**; the implementation lands in
+[#533](https://github.com/snaha/swarm-id/pull/533) and
+[#534](https://github.com/snaha/swarm-id/pull/534). This describes how BZZ and xDAI reach the derived
+batch-owner address. What is then done with them on Gnosis is
+[`Postage-On-Chain-Engine.md`](./Postage-On-Chain-Engine.md), consumed here as a library.
+
+## What it is
+
+Buying, extending and resizing a drive are paid for **inside our UI**, with no external
+fund.bzz.limo popup and no Bee node. The user connects a wallet, picks a source chain and token, sees
+a quoted cost, and signs **one** transaction. Everything after that — cross-chain delivery of xDAI to
+the batch-owner address, the Gnosis-side xDAI→BZZ swap, and the postage operations themselves — is
+handled by our code, signed by the owner key.
+
+The screens follow Figma file `1UCqrAPBp5jBG4IXjp4bEg`, page "Current", section STORAGE: the extend
+and resize dialogs, the method chooser, wallet connect, the pay screen with its expandable cost
+breakdown, chain-switch and approval waits, progress, success and failure.
+
+Two properties hold throughout:
+
+- **No temp wallet.** Every intermediate balance parks at an address we control, so an abandoned flow
+  is recoverable by re-running the funds check. (The old widget used a throwaway creator wallet and
+  handed ownership over afterwards.)
+- **The two keys never cross.** The payment wallet signs exactly one source-chain transaction and
+  never sees the owner key; the owner key only ever signs on Gnosis. The payment wallet is unrelated
+  to the account's access method, so passkey and password users connect any wallet just to pay.
+
+## Position in the stack
+
+```
+  drive-extend-dialog.svelte / drive-resize-dialog.svelte     phases: form | pending | error
+        │                                                     (branch on funding.pending first)
+        ▼
+  drive-operation.ts ── FundingNeed ──▶ funding-request.svelte.ts ──▶ payment-dialog.svelte
+        │                                    │  resolvePaymentRail()      (rail-agnostic screens)
+        │                                    ▼
+        │                              payment-rail.ts ◀── gnosis-direct.ts | relay.ts | dev rail
+        │                                                  (leaf module: imports no rail)
+        ├── funding.ts        quoteFunding — sizes the Gnosis side; swapDeliveredXdai
+        └── postage-onchain.ts / chain.ts       ── Postage-On-Chain-Engine.md
+```
+
+## The rail seam
+
+We do not fork or embed the multichain widget's UI. It is React, and its PostageStamp ABI contains
+only `createBatch`, so it has no top-up or dilute capability at all.
+
+Instead the payment leg is a **`PaymentRail`** (`ui/src/lib/payment/payment-rail.ts`): `chains`,
+`tokens(chainId)`, `quote()`, `execute()`, plus `switchWalletChain`. A rail's quote reduces to an
+opaque `handle` that only the rail which produced it consumes, which is what lets more than one
+implementation exist. The module is deliberately a **leaf** — it imports no rail, so rails can import
+values from it with no initialisation cycle.
+
+`resolve-rail.ts` picks and composes, dispatching **per token, not per chain** (a chain-level claim
+silently removed Gnosis USDC from the picker):
+
+- **Gnosis direct** (`gnosis-direct.ts`) — resolved first for any endpoint answering as chain 100, so
+  it claims native xDAI there. The destination is the source, so the wallet simply sends xDAI to the
+  batch-owner address and the operation continues into the same swap. It is the cheapest route by a
+  wide margin, has the fewest moving parts, and is the only route that is genuinely the same code
+  locally. Routing Gnosis through a cross-chain network would pay that network to move money across
+  zero chains.
+- **Relay** (`relay.ts`) — the bridged rail, a thin wrapper over `@relayprotocol/relay-sdk` (plain TS
+  core, no React, public mainnet API, no API key). It is the same rail the widget uses, proven for
+  Gnosis with xDAI output. SDK progress callbacks map onto our step model; on failure the SDK error
+  surfaces verbatim, and Relay-level refund semantics are the SDK's own.
+- **The dev rail** (`ui/src/lib/dev/local-payment-rail.ts`) — only off mainnet, in a dev build, with
+  a local source chain answering. See [Dev and testing](#dev-and-testing).
+
+Source chains mirror the widget's: Ethereum, Polygon, Optimism, Arbitrum, Base, Gnosis. Token lists
+are a static table per chain (native plus the obvious stablecoin); Relay's chain/currency metadata
+call buys nothing for a six-chain, two-token picker.
+
+**When no rail resolves, that is an error.** There is no mode in which the app funds an operation
+itself — money must never arrive with no screen, no signature and no record of who paid.
+
+## Quoting — `funding.ts`
+
+`quoteFunding` sizes the Gnosis side, which is the rail-independent half; the rail quotes the source
+side. `swapDeliveredXdai` lives here too, turning delivered xDAI into the BZZ the operation needs.
+
+1. From the operation: `plurNeeded` (per-chunk amount `<< depth`) → `bzzNeeded` (1 BZZ = 1e16 PLUR).
+2. `quoteXdaiInForBzzOut(bzzNeeded)` from `@swarm-id/multichain` (Sushi V3 `quoteExactOutputSingle`),
+   × 1.2 (`SWAP_BUFFER_NUMERATOR` / `_DENOMINATOR`), mirroring the widget's 20% buffer. The swap
+   executes exact-**input**, so the buffer is spent buying BZZ rather than left over: the surplus
+   lands as BZZ at the owner address and the next operation's funds check consumes it.
+3. Add `GAS_BUDGET_XDAI = 0.005` (approve + topUp + increaseDepth at 1 gwei, with headroom) minus the
+   owner address's existing xDAI, floored at 0 — **plus `SWAP_GAS_XDAI = 0.002` whenever a swap will
+   run**. The swap is signed by the owner key and pays for itself out of the same balance, before any
+   of the operations the gas budget covers; without that term the swap spends the budget back down and
+   the funds re-check immediately afterwards rejects a payment that in fact succeeded.
+4. The rail's own quote for the selected source chain and token. Relay is asked for an
+   `EXACT_OUTPUT` trade from the payment wallet to `recipient: ownerAddress` on `toChainId: 100` in
+   native xDAI, for `amount: totalXdai`; the direct and dev rails price it themselves, having no
+   route to shop for.
+5. Surfaced as the source-token cost, the USD total, and the breakdown rows — an xDAI gas line and an
+   xBZZ value line, each also priced in the source token.
+
+**Owner residuals are consumed first.** The funds check subtracts existing owner BZZ and xDAI from
+`bzzNeeded`/`totalXdai`; when they already cover the operation, payment is skipped entirely and
+execution starts straight away. This matters most on the recovery path — a delivery whose swap never
+ran would otherwise be paid for twice.
+
+The swap leg itself is `swapXdaiToBzz({ originPrivateKey, amountXdai, recipient })` from
+`@swarm-id/multichain`: exact-input, 0.5% slippage bound, 10-minute deadline. Quoting exact-output to
+size the xDAI and then executing exact-input is deliberate — the top-up uses the PLUR that actually
+arrived, so slight over-delivery becomes slightly longer lifespan rather than stranded BZZ, leaving
+at most `< 2^depth` PLUR of dust.
+
+## The flow
+
+`drive-operation.ts` raises a `FundingNeed` mid-operation and calls the `RequestFunding` seam.
+`createFundingRequester` answers it one way only: surface the payment screens for the resolved rail
+and wait, or fail when there is none. `payment-dialog.svelte` owns the screens and is handed a
+`PaymentRail` — it never knows which one.
+
+```
+                 ┌ no rail → throw: there is no route, and no free settlement
+FundingNeed ─────┤
+                 └ rail → method → connecting → configure (chain/token/quote) →
+                          switching → approving → relaying → resolve()
+                          → back into the engine: swap → approve → topUp [→ increaseDepth]
+```
+
+The pending request carries the need, its rail **and** the Gnosis-side quote as one `PendingPayment`,
+so the dialog receives values it can rely on rather than optionals it must re-check. The quote
+travels with it for a second reason: the amount the rail is asked to deliver has to be the one
+`swapDeliveredXdai` later spends, and two independent quotes of the same need drift as the pool moves.
+
+- Connect and chain-switch waits follow the attempt-guard rule (`.claude/rules/attempt-guard.md`):
+  cancellable, with `attempt.guard` on every await before a side effect.
+- Everything from the moment the user signs the source-chain transaction runs **outside** the attempt
+  guard (spend-must-record, with the standard comment), so the flow finishes even if the dialog
+  unmounts; the drive record lands via the engine's reconcile.
+- Steps map to progress labels on one card — "Cross-swap xDAI on Relay" → "Swapping xDAI to BZZ" →
+  "Extending lifespan" / "Increasing size".
+- Chain switching requests `wallet_switchEthereumChain` when the selected chain differs from the
+  wallet's; while pending, the balance shows "–" and the button spins.
+
+In the drive dialogs, "payment" is not a phase. A pending funding request is already distinct state
+(`funding.pending`) and the dialogs branch on it before their own `form | pending | error`. Proceed
+runs the engine preflight and funds check; a shortfall raises the payment screens as dialog-sized
+cards, not a popup; once funds land the engine continues to `pending`, then success or error. On
+open, the engine's chain-truth reconciliation runs first.
+
+## Slippage and liquidity
+
+On-chain BZZ liquidity on Gnosis is shallow — roughly $10k in total, with the deepest pool about $9k
+in SushiSwap V3 BZZ/USDC. So:
+
+- Always quote before enabling Pay, and refuse in words when the Sushi quote's price impact exceeds
+  `MAX_PRICE_IMPACT_PERCENT` (5%). Since the pool exposes no spot oracle, `quoteFunding` prices a
+  small reference trade (`IMPACT_REFERENCE_BZZ_PLUR`) alongside the real one and compares the fills.
+- The pay screen's USD total uses the rail's own pricing data (`currencyIn.amountUsd` for Relay; the
+  dev rail derives it from the xDAI figure, xDAI being a dollar stablecoin). No third-party feed.
+- The **dialogs'** cost estimates come from `bzz-price.ts`, which asks the same Sushi pool what BZZ
+  costs in xDAI and takes xDAI as the dollar — so the forms agree with the screen they lead to. It
+  caches a rate rather than a quote, per minute, because the extend dialog re-derives its estimate on
+  every keystroke and `quoteExactOutputSingle` is an RPC round-trip. A near-spot reference trade
+  carries none of a large trade's price impact, so the estimate reads slightly low for big resizes;
+  the 5% refusal bounds how far off it can be, and every screen prefixes it with "~".
+
+## Failure handling
+
+| Failure point                            | State after                                          | Recovery                                |
+| ---------------------------------------- | ---------------------------------------------------- | --------------------------------------- |
+| Quote fails / no route                   | nothing spent                                        | retry, other token or chain             |
+| User rejects source tx                   | nothing spent                                        | back to the pay screen                  |
+| Relay leg fails                          | per Relay SDK semantics (refunded or held)           | retry re-quotes; "View details"         |
+| xDAI delivered, swap fails               | xDAI parked at owner                                 | funds check consumes residual on retry  |
+| Swap done, approve or topUp fails        | BZZ parked at owner                                  | same                                    |
+| topUp done, increaseDepth fails (resize) | unbundled path only: lifespan extended, size pending | see below                               |
+| Anything after payment, dialog closed    | funds and state on chain                             | next dialog open reconciles and resumes |
+
+Value is never parked deliberately. The quote requests exactly what the operation needs plus the swap
+buffer, which the exact-input swap turns into a little surplus BZZ rather than xDAI. Both kinds of
+residual are consumed before the next request: BZZ by `fundingShortfall`, and xDAI above the gas
+budget by `quoteFunding`, which subtracts it from what the rail is asked to deliver.
+
+### Resize partial failure
+
+On any chain with the EIP-7702 delegate — which includes Gnosis mainnet — the resize is one atomic
+transaction, so the top-up and the depth increase land together or not at all. What follows applies
+only to the unbundled fallback.
+
+The designed "Lifespan decreased" modal (Figma `481:14324` / `481:14846`, from
+[#392](https://github.com/snaha/swarm-id/issues/392)) assumes the old dilute-first ordering. Because
+the engine inverts that order, a drive can never come out of a resize smaller-lived than it went in.
+The reachable partial state is the benign inverse: **payment succeeded, the lifespan got longer, and
+only the depth increase is pending**. `runResize` throws a typed `SizeIncreasePendingError` for it,
+and `DriveDialogStatus` renders it with a neutral `tone` rather than a red warning — a warning icon
+sends the user looking for damage that did not happen. Nothing shrank, so the drive row needs no
+warning state either.
+
+Retrying it is **not yet free**, and the copy must not promise that it is. `runResize` re-derives
+`resizePlan` from the live remaining balance, which the top-up has just increased, so a keep-lifespan
+retry asks for a second top-up sized against the grown figure — for a depth step of one, exactly
+twice the first. Chain state alone cannot fix this: a batch topped up for a pending resize is
+indistinguishable from one that always held that balance. Resuming needs the target depth persisted
+on the record.
+
+## Dev and testing
+
+Relay cannot be reproduced locally. It is an intent/solver network, so quotes come from a hosted API
+and deliveries from off-chain solvers paying out on real Gnosis. Two rails stand in:
+
+- **Gnosis direct**, against any endpoint answering as chain 100 — no bridge, no solver, no invented
+  price, and the same code as production. `resolvePaymentRail()` offers it first, so it is what a
+  local payment normally takes.
+- **The local rail**, under `pnpm dev:local`, which adds a bare anvil on chain 31337 and a solver
+  that fills from it. The wallet signs a real deposit there, the faucet then plays solver and delivers
+  the xDAI, and the real Sushi swap runs on top. This is what makes the
+  method → connect → configure → wallet-approval half of the flow exercisable at all. The chain is
+  offered to the wallet through the `wallet_addEthereumChain` path already in the flow, but the
+  **money is not**: no rail funds the payer, so the connected wallet must already hold what it pays
+  with (/dev → Chain → Faucet, or anvil's first key).
+
+A green local run must never be read as "the payment path works". The local rail rehearses the UX
+only — Relay's pricing, routing, real step model (an ERC-20 source needs an approve before the
+deposit) and refund semantics stay untested.
+
+Tests that do not need a payment fund the postage signer **out of band** first (`fundPostageSigner` in
+`ui/tests/helpers.ts`, the same chain faucet a developer uses by hand). The operation then finds the
+funds already at the owner address, `ensureFunded` short-circuits, and no payment screen opens —
+because nothing needs paying for, not because a rail was suppressed.
+`ui/tests/payment-rail.test.ts` is the suite that deliberately does not prefund, so the screens open
+and the rail runs end to end: method → connect → configure → pay, then a real deposit on the source
+chain, the solver's delivery, the real Sushi swap and the real `createBatch`. Isolated component
+tests would re-cover those same screens with nothing behind them, so that tier is not planned.
+
+`relay.live.test.ts` contract-tests Relay's **quote** against the live API (`pnpm test:live` in CI).
+Everything downstream of the quote is proven only against the dev rail, whose prices are invented and
+whose step list is shorter than Relay's.
+
+## Out of scope
+
+- Fiat payment. The method dropdown reserves the slot.
+- Contributing `mode=topup` upstream to `ethersphere/multichain-widget` — a worthwhile parallel track,
+  tracked outside this document.
+
+## Known gaps
+
+- **Relay's delivery has never been exercised** — no production canary yet, and there is a specific
+  thing for one to prove. A native transfer to an address that has authorised an EIP-7702 delegate
+  executes that delegate's fallback, so the 21 000 gas a transfer to a plain EOA costs is not enough
+  and the transfer reverts. Every postage signer authorises the delegate permanently on its first
+  bundled operation, so from a drive's second paid operation onward Relay's solver is delivering to a
+  delegated address. We hit this locally and fixed it by estimating rather than assuming
+  (`estimateTransferGas`, `multichain/src/rpc.ts`); whether Relay's solver estimates is not ours to
+  fix, and not something the dev rail can tell us.
+- Retrying an unbundled resize charges twice; the dialog copy should stop promising otherwise until
+  the target depth is persisted on the record.
+- No e2e for the partial-failure copy and its retry, and the Figma nodes still show the unreachable
+  "Lifespan decreased" design — to coordinate with design on
+  [#392](https://github.com/snaha/swarm-id/issues/392).
+- The size dropdown offers every larger size, with no soft cap on the jump. The 5% price-impact
+  refusal catches the bad case after the fact rather than the dropdown preventing it; whether that is
+  enough is a design call, not a correctness one.
+
+## Files and tests
+
+| Path                                           | Role                                         |
+| ---------------------------------------------- | -------------------------------------------- |
+| `ui/src/lib/payment/payment-rail.ts`           | the `PaymentRail` contract (leaf module)     |
+| `ui/src/lib/payment/relay.ts`                  | bridged rail over `@relayprotocol/relay-sdk` |
+| `ui/src/lib/payment/gnosis-direct.ts`          | same-chain rail, native xDAI on Gnosis       |
+| `ui/src/lib/payment/resolve-rail.ts`           | per-token composition and selection          |
+| `ui/src/lib/payment/funding.ts`                | `quoteFunding`, `swapDeliveredXdai`          |
+| `ui/src/lib/payment/bzz-price.ts`              | BZZ→USD rate for the dialogs' cost estimates |
+| `ui/src/lib/payment/funding-request.svelte.ts` | `createFundingRequester`, `PendingPayment`   |
+| `ui/src/lib/components/payment-dialog.svelte`  | the payment screens, rail-agnostic           |
+| `ui/src/lib/dev/local-payment-rail.ts`         | local stand-in rail                          |
+
+- Units: `funding.test.ts`, `resolve-rail.test.ts`, `gnosis-direct.test.ts`,
+  `local-payment-rail.test.ts`.
+- Live contract test: `relay.live.test.ts` (`pnpm test:live`).
+- E2E: `ui/tests/payment-rail.test.ts` (payment screens end to end),
+  `ui/tests/drive-onchain.test.ts` (the engine's flows).

--- a/docs/Postage-On-Chain-Engine.md
+++ b/docs/Postage-On-Chain-Engine.md
@@ -1,0 +1,274 @@
+# Postage on-chain engine — extending and resizing a drive without a Bee node
+
+Status: **design of record**; the implementation lands in
+[#533](https://github.com/snaha/swarm-id/pull/533). How the BZZ and xDAI this engine spends reach the
+owner address is a separate document, [`Drive-Payment-Flow.md`](./Drive-Payment-Flow.md).
+
+## What it is
+
+Drive **extend** (lifespan top-up) and **resize** (depth increase plus a compensating top-up) are
+executed as Gnosis Chain transactions built, signed and submitted from `ui/`, using the derived
+batch-owner key the UI already holds. No Bee node is involved.
+
+The alternative does not work in production. A Bee node's `topUpBatch`/`diluteBatch` only act on
+batches the _node_ owns, and product batches are owned by the account's derived postage signer
+(`derivePostageSigner`, `ui/src/lib/payment/purchase.ts`).
+
+## Position in the stack
+
+```
+  ui/src/lib/payment/drive-operation.ts    runPurchase / runExtend / runResize
+        │                                  (raises FundingNeed → Drive-Payment-Flow.md)
+        ├── purchase.ts        resizePlan — how much to top up, at which depth
+        ├── chain.ts           chain identity, MultichainClient construction, owner balances
+        ├── postage-onchain.ts preflights, allowance, topUp / increaseDepth, bundles, reconcile
+        │        │
+        │        └──▶ @swarm-id/multichain   ABI, signing, waiters, EIP-7702 bundling, SushiSwap
+        │                                    (multichain/, vendored from @upcoming/multichain-library)
+        └── account.updateStamp              the recorded drive state (LWW, see Account-State.md)
+```
+
+`lib/` is untouched: its raw `eth_call` reads remain the UI's display path.
+
+The owner key crosses from bee-js into the multichain package as raw hex —
+`prefix0x(signerKey.toHex())` into `originPrivateKey`. bee-js's `PrivateKey.sign()` is hardcoded to
+EIP-191 and cannot sign transactions, but `toHex()` exports the 32 bytes.
+
+## On-chain ground truth
+
+Verified 2026-07-31 against PostageStamp `0x45a1502382541Cd610CC9068e88727426b696293` on Gnosis
+(Sourcify-verified, byte-identical to `ethersphere/storage-incentives` master `src/PostageStamp.sol`).
+
+| Fact                                                                                                                            | Consequence                                                         |
+| ------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `topUp(bytes32,uint256)` — `0xb67644b9` — is permissionless; pulls `amountPerChunk << depth` BZZ via `transferFrom(msg.sender)` | Caller needs BZZ, a prior `approve`, and xDAI gas                   |
+| `increaseDepth(bytes32,uint8)` — `0x47aab79b` — is owner-only, transfers no tokens, has no meta-tx support                      | The derived owner key MUST be `msg.sender`; nothing else can dilute |
+| `remainingBalance = batch.normalisedBalance − currentTotalOutPayment()`, ages every block                                       | Planning math uses the live chain figure, never `stamp.amount`      |
+| `topUp` on an expired batch reverts `BatchExpired`; expired batches are deleted by `expireLimited`                              | Preflight expiry before requesting payment                          |
+| `immutableFlag` is not enforced by the contract on either op                                                                    | Chain imposes nothing; the UI blocks resize on immutable batches    |
+| Both ops are `whenNotPaused`; `paused()` is `0x5c975abb`                                                                        | Preflight `paused()` and report it in words                         |
+| Batch IDs are `keccak256(creator, nonce)` — the creator, not the owner                                                          | Never derive a batchId; carry `stamp.batchID`                       |
+| BZZ is `0xdBF3Ea6F5beE45c02255B2c26a16F300502F68da`, **16 decimals** (1 BZZ = 1e16 PLUR)                                        | Standard ERC-20 fragments; watch the decimals                       |
+
+Gas is negligible: at Gnosis's 0.07–1.25 gwei each operation costs well under $0.001, and a full
+bundled resize is ~420k.
+
+The same addresses are used locally. `@snaha/bee-compose` ships a hybrid snapshot — mainnet's BZZ
+token and SushiSwap pools with the Swarm contracts deployed on top at their mainnet addresses,
+answering as chain `100` on `http://localhost:9545`. See
+[HYBRID-CHAIN.md](https://github.com/snaha/bee-compose/blob/main/blockchain/HYBRID-CHAIN.md).
+
+### The ordering rule
+
+`increaseDepth` requires `remainingBalance(batchId) / 2^Δdepth >= minimumInitialBalancePerChunk()`
+and checks it **before** any compensation, where
+`minimumInitialBalancePerChunk = minimumValidityBlocks() × lastPrice()` — about 24h of storage
+(mainnet 2026-07-31: `17280 × 68891 = 1,190,436,480` PLUR; read live, never hardcode).
+
+**So the compensating top-up runs first, then `increaseDepth`.** Diluting first reverts on-chain in
+the common keep-lifespan case. This holds for the bundled path too — atomicity does not relax the
+contract's check, so a bundle that dilutes first reverts exactly as the sequential version does.
+
+## `resizePlan` — `ui/src/lib/payment/purchase.ts`
+
+```ts
+export function resizePlan(
+  liveRemainingPerChunk: bigint, // from chain, NOT stamp.amount
+  currentDepth: number,
+  newDepth: number,
+  keepLifespan: boolean,
+  minimumInitialBalancePerChunk: bigint,
+  lastPrice: bigint,
+): ResizePlan // { topUpAmount, afterTopUp, afterDilute }
+```
+
+With `Δ = newDepth − currentDepth`, `factor = 2^Δ` and `R = liveRemainingPerChunk`:
+
+- **keepLifespan**: `topUpAmount = R × (factor − 1)`, so the post-dilution per-chunk balance returns
+  to `R` and the TTL is preserved. Total BZZ = `topUpAmount << currentDepth`, which is
+  `R × (2^newDepth − 2^currentDepth)` PLUR — the same total as the old dilute-first ordering, so
+  existing cost estimates carry over unchanged.
+- **not keepLifespan**: `topUpAmount = 0`; the TTL divides by `factor`.
+- **Floor clamp**: if `(R + topUpAmount) / factor` still misses the minimum, `topUpAmount` is raised
+  to the shortfall and the plan is marked, so the dialog can say that resizing requires topping up
+  to at least ~1 day of lifespan. A user who declines the clamped amount cannot resize; the engine
+  says so rather than sending a known revert.
+
+## Chain access — `chain.ts` and `postage-onchain.ts`
+
+`chain.ts` resolves the chain and constructs the client:
+
+```ts
+export function probeChainId(rpcUrl): Promise<number> // one call, before any client exists
+export function chainIdentity(rpcUrl?): Promise<ChainIdentity> // { chainId, isMainnet }
+export function postageChain(rpcUrl?): Promise<MultichainClient>
+export function ownerFunds(address, client?): Promise<OwnerFunds> // { xdai, bzz }
+```
+
+`postage-onchain.ts` orchestrates over `@swarm-id/multichain`:
+
+```ts
+export function fundingShortfall(address, bzzPlur, client?): Promise<OwnerFunds>
+export function ensureBzzAllowance(signerKey, totalPlur, client?): Promise<void>
+export function topUpOnChain(signerKey, stamp, amountPerChunk, client?): Promise<void>
+export function increaseDepthOnChain(signerKey, stamp, newDepth, client?): Promise<void>
+export function createOnChain(signerKey, amountPerChunk, depth, client?): Promise<string>
+export function bundledCreate(signerKey, amountPerChunk, depth, totalPlur, client?)
+export function bundledExtend(signerKey, stamp, amountPerChunk, totalPlur, client?)
+export function bundledResize(signerKey, stamp, amountPerChunk, totalPlur, newDepth, client?)
+export function preflightExtend(stamp, client?): Promise<PostagePreflight>
+export function preflightResize(stamp, signerKey, newDepth, client?)
+export function reconcileStampFromChain(account, stamp, client?): Promise<boolean>
+```
+
+`ensureBzzAllowance` skips when the existing allowance suffices and otherwise approves **exactly**
+the amount needed. The `bundled*` functions return false (or undefined) when the chain has no
+EIP-7702 delegate, which is the caller's signal to send the calls separately.
+`reconcileStampFromChain` patches `{depth, amount, batchTTL}` through `account.updateStamp` and
+returns false — leaving the record untouched — when the chain cannot answer.
+
+Rules that hold across all of it:
+
+- **Assert chain 100 before any signature** (`settingsFor` throws otherwise). Chain id alone cannot
+  tell the local chain from mainnet — it reports `100` deliberately, so that an app resolving
+  addresses by chain id finds what it expects. `chainIdentity()` separates them by **genesis hash**,
+  and an endpoint that is not mainnet never falls back to the public RPCs, so a failed local call
+  cannot silently read or write real mainnet.
+- Every wait wraps in `withTimeout` (`lib/src/utils/promise.ts`), never `Promise.race`. A timeout
+  surfaces as "still pending" and is resolved by reconciliation on the next dialog open.
+- Preflights assemble from `getPostageBatch` + `getPostageWriteConstraints` and map every reachable
+  revert to a typed error before spending gas: batch missing, expired, paused, not owner, floor not
+  cleared, insufficient funds at the owner address.
+- Transactions run sequentially from the owner key; the package resolves pending-block nonces.
+
+## Flows
+
+Both flows begin with a funds check and end with a recorded stamp. Where the chain has the EIP-7702
+delegate — which includes Gnosis mainnet — the steps run as a single atomic transaction; elsewhere
+they run one at a time. The steps, their order and their preconditions are identical either way.
+
+**Extend** — `approve → topUp`:
+
+1. `topUpAmount = stampAmountForSeconds(price, addedSeconds)`, with the price read from the
+   contract's `lastPrice` via `fetchPostageWriteConstraints` (`chain-price.ts`, 60s cache) rather
+   than the Bee `/chainstate`.
+2. `preflightExtend`: batch exists, not expired, not paused. Ownership is irrelevant here — `topUp`
+   is permissionless — but the owner key signs anyway.
+3. Funds check: `topUpAmount << depth` PLUR of BZZ plus gas at the owner address. A shortfall hands
+   off to the payment flow, then re-checks.
+4. `ensureBzzAllowance` → `topUpOnChain` → `reconcileStampFromChain`, falling back to the projected
+   `extendedStamp` patch if the read fails.
+
+**Resize** — `approve → topUp → increaseDepth`:
+
+1. `preflightResize`: `batch.owner === ownerAddress` (a hard requirement — imported foreign batches
+   get a clear "owned by a different key" error), not expired, not paused, `newDepth > depth`, floor
+   cleared by the plan, `stamp.immutableFlag === false`.
+2. Funds check as above; BZZ is only needed when `topUpAmount > 0`.
+3. `ensureBzzAllowance` → `topUpOnChain(topUpAmount)` → `account.updateStamp(batchID, afterTopUp)`,
+   then `increaseDepthOnChain(newDepth)` → `reconcileStampFromChain` (falling back to `afterDilute`).
+   The record must reflect the top-up even if the depth increase then fails.
+4. **Resume is chain truth, not component state.** On dialog open and before every retry the chain is
+   read; if on-chain `depth` already equals the target, the increase landed in a lost session, so the
+   record is patched and the operation finishes. This is `alreadyResized` off `preflightResize`, and
+   it closes the stuck-state class in [#392](https://github.com/snaha/swarm-id/issues/392).
+
+Steps 3–4 run deliberately **outside** the attempt guard: an on-chain spend's record must land even
+if the dialog closes.
+
+### Atomic execution (EIP-7702)
+
+The owner EOA authorises **`Simple7702Account`** — eth-infinitism's audited minimal 7702 account,
+verified on Gnosis at `0x4Cd241E8d1510e30b2076397afc7508Ae59C66c9` — and sends the transaction from
+the EOA to itself, so `msg.sender` stays the owner throughout. Both `topUp` (which pulls from the
+sender) and `increaseDepth` (owner-only) require that. `supportsBundling()` gates it on the delegate
+having code, so an endpoint without one degrades to the sequential path. EIP-7702 has been live on
+Gnosis since the Pectra fork, 30 April 2025.
+
+A replacement delegate must preserve two properties: **execution restricted to the account itself**,
+so only a self-call from the EOA can drive it, and an `executeBatch` that reverts the whole batch on
+any inner failure. `Simple7702Account` was chosen over MetaMask's `EIP7702StatelessDeleGator` (also
+deployed on Gnosis, but a far larger surface than a three-call batch needs) and over writing our own,
+which would add Solidity and an audit burden to a TypeScript repo.
+
+Bundling makes the resize partial-failure state unreachable and removes the window in which an
+allowance sits unspent. `SizeIncreasePendingError` and its dialog copy remain for the unbundled path;
+see [`Drive-Payment-Flow.md`](./Drive-Payment-Flow.md) §5.
+
+## Errors and wording
+
+| Condition                     | Wording direction                                                  |
+| ----------------------------- | ------------------------------------------------------------------ |
+| `BatchExpired` / not found    | "This drive has expired and can no longer be extended."            |
+| Floor (`InsufficientBalance`) | Explain the ~1-day minimum; show the clamped amount.               |
+| `NotBatchOwner`               | "This drive is owned by a different key" (imported foreign batch). |
+| `paused()`                    | "Swarm's payment contract is temporarily paused. Try again later." |
+| Confirmation timeout          | "Still pending" — resolved by reconciliation on next open.         |
+| Insufficient owner funds      | Hand off to the payment flow.                                      |
+
+## Recording and sync
+
+Every record patch flows through `account.updateStamp` (LWW `updatedAt` clock, which re-anchors the
+TTL measurement instant). Chain truth via `reconcileStampFromChain` is preferred after each
+confirmation; the projected plan patches are the fallback, so an RPC blip after a confirmed
+transaction still lands a record.
+
+The runtime `Stamper` needs no explicit rebuild: `postage-stamps.svelte.ts`'s `getStamper()`
+constructs one per call from the stored `stamp.depth`, so there is no cached instance to go stale.
+
+## Security
+
+- No new key-exposure class. The owner key already lives client-side and signs stamps; the hex key is
+  passed function-scoped into `@swarm-id/multichain` calls, is never persisted anywhere new, and
+  never leaves the origin.
+- Exact-amount approvals to the fixed PostageStamp address only. No unlimited allowances.
+- Because the addresses are the mainnet ones on both chains, the safety property is not _which
+  addresses_ but _which endpoint_ — see the genesis-hash rule above.
+- A hostile user-configured `gnosisRpcUrl` can lie about state and censor transactions, but cannot
+  alter calldata, redirect approvals or extract the key. Same trust level as today's TTL reads.
+- **The EIP-7702 delegation is permanent.** The authorization writes `0xef0100 || delegate` into the
+  owner EOA's code field, where it stays until overwritten or cleared by authorising the zero
+  address; it is not scoped to one transaction. So every account's derived postage signer reads as a
+  contract (`EXTCODESIZE > 0`) after its first bundled operation. Nothing on the postage path checks
+  that, but a future counterparty requiring `sender.code.length == 0` would reject it, and the
+  delegate holds standing authority over that EOA — which is why the choice is a minimal account and
+  not a general-purpose executor. No flow clears the delegation.
+
+## Out of scope
+
+- Fund delivery, quoting and the payment UI — [`Drive-Payment-Flow.md`](./Drive-Payment-Flow.md).
+- Partition and utilization reaction to depth changes (capacity accounting, the depth-31→32 counter
+  codec crossing, IndexedDB invalidation, multi-device skew) —
+  [#463](https://github.com/snaha/swarm-id/issues/463). This engine only rebuilds the stamper.
+- Relayed and gasless variants (EIP-2612 permit, ERC-4337) — unnecessary at <$0.001 per operation.
+
+## Known gaps
+
+- No regression test pins that the runtime `Stamper` follows a depth change.
+- The unbundled path cannot resume a resize whose top-up landed but whose depth increase did not; see
+  [`Drive-Payment-Flow.md`](./Drive-Payment-Flow.md) §5.
+
+## Files and tests
+
+| Path                                    | Role                                                      |
+| --------------------------------------- | --------------------------------------------------------- |
+| `ui/src/lib/payment/chain.ts`           | chain identity, client construction, owner balances       |
+| `ui/src/lib/payment/postage-onchain.ts` | preflights, allowance, writes, bundles, reconcile         |
+| `ui/src/lib/payment/purchase.ts`        | `derivePostageSigner`, `resizePlan`, TTL and cost maths   |
+| `ui/src/lib/payment/drive-operation.ts` | `runPurchase` / `runExtend` / `runResize`                 |
+| `ui/src/lib/payment/chain-price.ts`     | `lastPrice` from the contract, 60s cache                  |
+| `multichain/`                           | ABI, signing, waiters, bundling, SushiSwap leg, dev tools |
+
+- `purchase.test.ts` covers `resizePlan` (cost parity with the old ordering, floor clamps,
+  keepLifespan on and off, integer dust); `funding.test.ts` covers the funding maths.
+- `@swarm-id/multichain` pins the `b67644b9` / `47aab79b` selectors in `abi.test.ts` and runs a fork
+  suite (`pnpm test:fork`): fund → swap → create → topUp → increaseDepth → non-owner revert.
+- `ui/tests/drive-onchain.test.ts` runs four Playwright tests against the local chain, skipped when
+  no chain answers: extend grows the on-chain balance and the recorded TTL; extend again with the
+  delegate cleared, covering the sequential fallback; resize keeps the lifespan by topping up before
+  increasing depth; an interrupted resize resumes from chain truth without paying twice.
+- Chain-level dev helpers live in `@swarm-id/multichain`'s `src/dev.ts` (`fundLocalAccount`,
+  `simulateWidgetPurchase`), wrapped by `ui/src/lib/dev/chain-funding.ts` and driven from the /dev
+  **Chain** tab. Creating a batch there also calls `ensureBundlingDelegate`: a baked snapshot cannot
+  carry the delegate, so its mainnet runtime bytecode is committed (`src/delegate-bytecode.ts`) and
+  spliced in.


### PR DESCRIPTION
**Stack 3/7** — base `stack/2-multichain` ([#532](https://github.com/snaha/swarm-id/pull/532)). Part of #309.

The two documents for the change that follows, split out of it so the implementation can be read *against* them rather than carrying them. 554 lines of Markdown, no code.

- **`docs/Postage-On-Chain-Engine.md`** — read this one first. The contract-facts table is what the ordering rule rests on: `increaseDepth` checks the post-dilution per-chunk balance against the ~24h floor **before** any compensation, so the compensating top-up must run first.
- **`docs/Drive-Payment-Flow.md`** — consumes the engine's API: how BZZ and xDAI reach the owner address without the external widget.

Both follow the house style of the existing `docs/` set (`Account-State.md`, `BatchWriteCoordinator.md`): present tense, "What it is" / "Position in the stack" / "Files and tests", with a `Known gaps` section instead of inline status markers. Acceptance criteria and per-section done/open bookkeeping live in the implementation PRs, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)