### PR TITLE
feat(dev): rebuild /dev around the chain, with a faucet and a real test drive

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -229,6 +229,9 @@ importers:
       '@snaha/swarm-id':
         specifier: workspace:*
         version: link:../lib
+      '@swarm-id/multichain':
+        specifier: workspace:*
+        version: link:../multichain
       '@web3-onboard/core':
         specifier: ^2.24.1
         version: 2.24.1(typescript@5.8.3)
@@ -238,6 +241,9 @@ importers:
       ethers:
         specifier: 6.15.0
         version: 6.15.0
+      viem:
+        specifier: ^2.55.10
+        version: 2.55.13(typescript@5.8.3)(zod@4.4.3)
     devDependencies:
       '@eslint/js':
         specifier: 9.39.1

--- a/ui/knip.ts
+++ b/ui/knip.ts
@@ -11,7 +11,7 @@ const config: KnipConfig = {
   },
   // Knip cannot resolve the workspace package through its exports map, so it
   // would misreport the dependency as unused.
-  ignoreDependencies: ['@snaha/swarm-id'],
+  ignoreDependencies: ['@snaha/swarm-id', '@swarm-id/multichain'],
   ignoreExportsUsedInFile: true,
 }
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -53,8 +53,10 @@
   "dependencies": {
     "@ethersphere/bee-js": "^11.1.1",
     "@snaha/swarm-id": "workspace:*",
+    "@swarm-id/multichain": "workspace:*",
     "@web3-onboard/core": "^2.24.1",
     "@web3-onboard/injected-wallets": "^2.11.3",
-    "ethers": "6.15.0"
+    "ethers": "6.15.0",
+    "viem": "^2.55.10"
   }
 }

--- a/ui/src/lib/components/drive-add-dialog.svelte
+++ b/ui/src/lib/components/drive-add-dialog.svelte
@@ -181,6 +181,8 @@
         mocked: devSettingsStore.data.mockStampEnabled,
         mockPopup: devSettingsStore.data.mockStampPopup,
         mockError: devSettingsStore.data.mockStampResult === 'error',
+        // Only the mock can honour this — the real widget picks the size itself.
+        mockDepth: depthValue === '' ? undefined : Number(depthValue),
         onSuccess: (batch) => {
           if (!attempt.current) {
             return

--- a/ui/src/lib/components/network-settings-dialog.svelte
+++ b/ui/src/lib/components/network-settings-dialog.svelte
@@ -9,22 +9,12 @@
   import { Button } from '$lib/components/ui/button'
   import { Dialog } from '$lib/components/ui/dialog'
   import { Input } from '$lib/components/ui/input'
-  import { chainIdentity, probeChainId } from '$lib/payment/chain'
+  import { chainIdentity } from '$lib/payment/chain'
   import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
 
   interface Props {
     onclose: () => void
   }
-
-  /**
-   * The local endpoints "Use local" fills in. Two chains can be serving Gnosis
-   * locally — bee-compose's cluster and the standalone snapshot — so the button
-   * asks which is actually answering rather than making the user remember. The
-   * cluster comes first: it also serves the Bee node, so if it is up that is
-   * the environment you want.
-   */
-  const LOCAL_BEE_NODE_URL = 'http://localhost:1633/'
-  const LOCAL_GNOSIS_RPC_URLS = ['http://localhost:9545', 'http://localhost:8545']
 
   let { onclose }: Props = $props()
 
@@ -70,24 +60,6 @@
     beeNodeUrl = DEFAULT_BEE_NODE_URL
     gnosisRpcUrl = DEFAULT_GNOSIS_RPC_URL
   }
-
-  /**
-   * Point at whichever local chain is running. Dev builds only — the button is
-   * not rendered otherwise, and typing two localhost URLs by hand is the step
-   * that most often goes wrong when setting the environment up.
-   */
-  async function useLocal() {
-    beeNodeUrl = LOCAL_BEE_NODE_URL
-    const reachable = await Promise.all(
-      LOCAL_GNOSIS_RPC_URLS.map((url) =>
-        probeChainId(url).then(
-          () => url,
-          () => undefined,
-        ),
-      ),
-    )
-    gnosisRpcUrl = reachable.find((url) => url !== undefined) ?? LOCAL_GNOSIS_RPC_URLS[0]
-  }
 </script>
 
 <Dialog title="Network settings" {onclose}>
@@ -126,11 +98,6 @@
   <div class="flex w-full items-center gap-2">
     <Button disabled={!canSave} onclick={save}>Save</Button>
     <Button variant="outline" onclick={onclose}>Cancel</Button>
-    {#if import.meta.env.DEV}
-      <Button variant="ghost" class="ml-auto" onclick={useLocal}>Use local</Button>
-      <Button variant="ghost" onclick={resetToDefaults}>Reset</Button>
-    {:else}
-      <Button variant="ghost" class="ml-auto" onclick={resetToDefaults}>Reset</Button>
-    {/if}
+    <Button variant="ghost" class="ml-auto" onclick={resetToDefaults}>Reset</Button>
   </div>
 </Dialog>

--- a/ui/src/lib/components/network-settings-dialog.svelte
+++ b/ui/src/lib/components/network-settings-dialog.svelte
@@ -9,11 +9,22 @@
   import { Button } from '$lib/components/ui/button'
   import { Dialog } from '$lib/components/ui/dialog'
   import { Input } from '$lib/components/ui/input'
+  import { chainIdentity, probeChainId } from '$lib/payment/chain'
   import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
 
   interface Props {
     onclose: () => void
   }
+
+  /**
+   * The local endpoints "Use local" fills in. Two chains can be serving Gnosis
+   * locally — bee-compose's cluster and the standalone snapshot — so the button
+   * asks which is actually answering rather than making the user remember. The
+   * cluster comes first: it also serves the Bee node, so if it is up that is
+   * the environment you want.
+   */
+  const LOCAL_BEE_NODE_URL = 'http://localhost:1633/'
+  const LOCAL_GNOSIS_RPC_URLS = ['http://localhost:9545', 'http://localhost:8545']
 
   let { onclose }: Props = $props()
 
@@ -27,6 +38,21 @@
   const canSave = $derived(beeNodeUrlValid && gnosisRpcUrlValid)
   const beeNodeUrlError = $derived(beeNodeUrl.trim().length > 0 && !beeNodeUrlValid)
   const gnosisRpcUrlError = $derived(gnosisRpcUrl.trim().length > 0 && !gnosisRpcUrlValid)
+
+  /**
+   * What is actually answering at the SAVED endpoint. Worth showing, because a
+   * dev chain reports the same chain id as mainnet on purpose — so the URL is
+   * otherwise the only clue, and a stale `localhost` looks exactly like the
+   * real thing. Probed for the saved value rather than the field being edited,
+   * so typing a URL does not fire a request per keystroke.
+   */
+  const connected = chainIdentity(networkSettingsStore.gnosisRpcUrl).then(
+    (identity) =>
+      identity.isMainnet
+        ? { label: 'Gnosis Chain', tone: 'text-muted-foreground' }
+        : { label: 'Gnosis Chain (fake) — funds here are not real', tone: 'font-medium' },
+    () => ({ label: 'Not reachable', tone: 'text-destructive' }),
+  )
 
   function save() {
     if (!canSave) {
@@ -43,6 +69,24 @@
   function resetToDefaults() {
     beeNodeUrl = DEFAULT_BEE_NODE_URL
     gnosisRpcUrl = DEFAULT_GNOSIS_RPC_URL
+  }
+
+  /**
+   * Point at whichever local chain is running. Dev builds only — the button is
+   * not rendered otherwise, and typing two localhost URLs by hand is the step
+   * that most often goes wrong when setting the environment up.
+   */
+  async function useLocal() {
+    beeNodeUrl = LOCAL_BEE_NODE_URL
+    const reachable = await Promise.all(
+      LOCAL_GNOSIS_RPC_URLS.map((url) =>
+        probeChainId(url).then(
+          () => url,
+          () => undefined,
+        ),
+      ),
+    )
+    gnosisRpcUrl = reachable.find((url) => url !== undefined) ?? LOCAL_GNOSIS_RPC_URLS[0]
   }
 </script>
 
@@ -72,12 +116,21 @@
     />
     {#if gnosisRpcUrlError}
       <p class="text-destructive text-xs">Please enter a valid URL</p>
+    {:else}
+      {#await connected then chain}
+        <p class="text-xs {chain.tone}">Connected to: {chain.label}</p>
+      {/await}
     {/if}
   </div>
 
   <div class="flex w-full items-center gap-2">
     <Button disabled={!canSave} onclick={save}>Save</Button>
     <Button variant="outline" onclick={onclose}>Cancel</Button>
-    <Button variant="ghost" class="ml-auto" onclick={resetToDefaults}>Reset</Button>
+    {#if import.meta.env.DEV}
+      <Button variant="ghost" class="ml-auto" onclick={useLocal}>Use local</Button>
+      <Button variant="ghost" onclick={resetToDefaults}>Reset</Button>
+    {:else}
+      <Button variant="ghost" class="ml-auto" onclick={resetToDefaults}>Reset</Button>
+    {/if}
   </div>
 </Dialog>

--- a/ui/src/lib/dev/chain-funding.ts
+++ b/ui/src/lib/dev/chain-funding.ts
@@ -27,6 +27,7 @@ import { generatePrivateKey } from 'viem/accounts'
 import { ownerFunds, postageChain } from '$lib/payment/chain'
 import { fetchExistingBatchFromChain } from '$lib/payment/contract'
 import { derivePostageSigner } from '$lib/payment/purchase'
+import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
 import type { Account } from '$lib/types'
 
 /**
@@ -48,8 +49,18 @@ export const ANVIL_ACCOUNT = {
 
 /** Default drive size for the dev batch actions. */
 const DEV_BATCH_DEPTH = 20
-/** Funds a dev batch well above the contract's ~24h floor. */
-const DEV_BATCH_FLOOR_MULTIPLE = 3n
+/**
+ * How long a dev batch is funded for, as a multiple of the contract's ~24h
+ * minimum — so the number reads as days.
+ *
+ * The default clears the product's 7-day "Expires soon" threshold with room to
+ * spare: a test drive that lands already flagged, under a "1 drive needs
+ * attention" banner, trains everyone to read that warning as noise. The short
+ * one is for deliberately producing that state.
+ */
+const DEV_BATCH_DAYS = 15n
+/** A batch that is flagged the moment it exists, for testing the warning. */
+const DEV_BATCH_EXPIRING_DAYS = 1n
 /** Bankrolls the simulated purchase's throwaway payer: swap, batch and gas. */
 const PURCHASE_PAYER_XDAI = 2n * 10n ** 18n // 2 xDAI
 /**
@@ -81,10 +92,13 @@ export interface FaucetAmounts {
  */
 export async function sendFromFaucet(address: string, amounts: FaucetAmounts): Promise<void> {
   const to = new EthAddress(address).toChecksum() as `0x${string}`
-  if (amounts.xdai > 0n || amounts.bzzPlur > 0n) {
-    const chain = await postageChain()
-    await fundLocalAccount({ to, xdai: amounts.xdai, bzzPlur: amounts.bzzPlur }, chain.settings)
+  // Nothing to send is a mistyped amount, not a send: reporting "✅ Sent 0" for
+  // it reads as a transfer that happened.
+  if (amounts.xdai <= 0n && amounts.bzzPlur <= 0n) {
+    throw new Error('Enter an amount above zero.')
   }
+  const chain = await postageChain()
+  await fundLocalAccount({ to, xdai: amounts.xdai, bzzPlur: amounts.bzzPlur }, chain.settings)
 }
 
 /** An address and what it holds on the Gnosis-side chain, for the faucet panel. */
@@ -120,6 +134,13 @@ export interface LocalBatch {
   blockNumber: string
 }
 
+/** How long a created batch should last, and how big it should be. */
+export interface BatchShape {
+  depth?: number
+  /** Days of lifespan to fund, as a multiple of the contract's ~24h floor. */
+  days?: bigint
+}
+
 /**
  * Create a batch the account's postage signer OWNS, paid for by someone else —
  * the production role split, where the payment machinery creates the batch and
@@ -130,7 +151,7 @@ export interface LocalBatch {
  */
 export async function createOwnedBatchOnChain(
   derivationKey: string,
-  requestedDepth?: number,
+  { depth: requestedDepth, days = DEV_BATCH_DAYS }: BatchShape = {},
 ): Promise<LocalBatch> {
   const { destination } = await derivePostageSigner(derivationKey)
   const chain = await postageChain()
@@ -141,7 +162,7 @@ export async function createOwnedBatchOnChain(
   const owner = destination as `0x${string}`
   const depth = requestedDepth ?? DEV_BATCH_DEPTH
   const { minimumInitialBalancePerChunk } = await chain.getPostageWriteConstraints()
-  const amountPerChunk = minimumInitialBalancePerChunk * DEV_BATCH_FLOOR_MULTIPLE
+  const amountPerChunk = minimumInitialBalancePerChunk * days
 
   const created = await simulateWidgetPurchase(
     {
@@ -164,6 +185,49 @@ export async function createOwnedBatchOnChain(
   }
 }
 
+/** How long to wait for the Bee node to catch up to the batch's block. */
+const BATCH_VISIBLE_TIMEOUT_MS = 30_000
+const BATCH_VISIBLE_POLL_MS = 500
+
+/**
+ * Wait until the Bee node has synced past the block the batch landed in.
+ *
+ * A batch bought straight from the contract exists on chain before the node
+ * knows it: until Bee's chain sync reaches that block, stamping with it is
+ * rejected with `400 invalid batch id`, so attaching the drive immediately
+ * makes the very next account sync fail for no reason a reader can see.
+ *
+ * Best effort — a node that does not serve `/status` (a gateway) or one that
+ * never catches up leaves the drive attached anyway, since the batch is real
+ * either way and the next sync will retry.
+ */
+async function waitForNodeToSeeBatch(beeNodeUrl: string, blockNumber: string): Promise<void> {
+  const target = Number(BigInt(blockNumber))
+  if (!Number.isFinite(target) || target === 0) {
+    return
+  }
+  const deadline = Date.now() + BATCH_VISIBLE_TIMEOUT_MS
+  const statusUrl = new URL('status', beeNodeUrl.endsWith('/') ? beeNodeUrl : `${beeNodeUrl}/`)
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(statusUrl)
+      if (!response.ok) {
+        return
+      }
+      const { lastSyncedBlock } = (await response.json()) as { lastSyncedBlock?: number }
+      if (lastSyncedBlock === undefined) {
+        return
+      }
+      if (lastSyncedBlock >= target) {
+        return
+      }
+    } catch {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, BATCH_VISIBLE_POLL_MS))
+  }
+}
+
 /**
  * Create a batch AND attach it to the account as a drive, in one go.
  *
@@ -172,15 +236,23 @@ export async function createOwnedBatchOnChain(
  * which is a chance to paste the wrong field. The drive it leaves behind is an
  * ordinary one: a real batch the account's own signer owns.
  *
+ * @param shape — defaults to a drive that outlives the "Expires soon"
+ *   threshold; pass `days: DEV_BATCH_EXPIRING_DAYS` to make one that does not.
  * @returns the attached drive's batch id.
  */
-export async function createTestDrive(account: Account): Promise<string> {
-  const { batchId } = await createOwnedBatchOnChain(account.derivationKey)
+export async function createTestDrive(account: Account, shape?: BatchShape): Promise<string> {
+  const { batchId, blockNumber } = await createOwnedBatchOnChain(account.derivationKey, shape)
   const { signerKey } = await derivePostageSigner(account.derivationKey)
   const stamp = await fetchExistingBatchFromChain(batchId, signerKey, '')
   if (!stamp) {
     throw new Error('The batch was created but could not be read back from the chain.')
   }
+  await waitForNodeToSeeBatch(networkSettingsStore.beeNodeUrl, blockNumber)
   account.addStamp(stamp)
   return batchId
+}
+
+/** A drive that is already inside the "Expires soon" window, for testing it. */
+export async function createExpiringTestDrive(account: Account): Promise<string> {
+  return createTestDrive(account, { days: DEV_BATCH_EXPIRING_DAYS })
 }

--- a/ui/src/lib/dev/chain-funding.ts
+++ b/ui/src/lib/dev/chain-funding.ts
@@ -1,0 +1,186 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * DEV ONLY — stands in for the production payment flow on the local chain.
+ *
+ * That chain — the cluster's (`pnpm dev:local`) or the same snapshot
+ * standalone (`pnpm dev:chain`) — carries a real BZZ market and the
+ * PostageStamp the nodes follow, so the only faked leg is the bridge: xDAI is
+ * minted with anvil's setBalance and everything after it (swap, approve,
+ * createBatch) is the production path.
+ *
+ * It also prefunds a faucet, so handing an address what it needs is a transfer
+ * rather than a trade — the BZZ pool is real and thin, and only the purchase
+ * itself is worth spending it on.
+ *
+ * Production code must never import this module.
+ */
+import { EthAddress } from '@ethersphere/bee-js'
+import {
+  DEV_FAUCET_ADDRESS,
+  ensureBundlingDelegate,
+  fundLocalAccount,
+  simulateWidgetPurchase,
+} from '@swarm-id/multichain/dev'
+import { generatePrivateKey } from 'viem/accounts'
+
+import { ownerFunds, postageChain } from '$lib/payment/chain'
+import { fetchExistingBatchFromChain } from '$lib/payment/contract'
+import { derivePostageSigner } from '$lib/payment/purchase'
+import type { Account } from '$lib/types'
+
+/**
+ * Anvil's first default account — the key every anvil prints on startup, so
+ * publicly known and worth nothing off a dev chain.
+ *
+ * The dev chain is anvil, and anvil funds its ten default accounts at genesis
+ * even when loading a state dump, so this address starts with 10 000 xDAI. It
+ * holds no BZZ — that float is the bake's, and sits with `DEV_FAUCET_ADDRESS`.
+ *
+ * Importing it is never required; it is only the shortcut to a wallet showing
+ * a balance from the start, instead of one that looks empty until the faucet
+ * fills it.
+ */
+export const ANVIL_ACCOUNT = {
+  address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+  privateKey: '0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+}
+
+/** Default drive size for the dev batch actions. */
+const DEV_BATCH_DEPTH = 20
+/** Funds a dev batch well above the contract's ~24h floor. */
+const DEV_BATCH_FLOOR_MULTIPLE = 3n
+/** Bankrolls the simulated purchase's throwaway payer: swap, batch and gas. */
+const PURCHASE_PAYER_XDAI = 2n * 10n ** 18n // 2 xDAI
+/**
+ * Of that, what goes into BZZ. Two orders of magnitude more than a dev batch
+ * costs, so price drift on a long-lived chain cannot starve a purchase, and
+ * still small against a ~$10k pool. The leftovers go to the batch owner, as
+ * they do in production.
+ */
+const PURCHASE_SWAP_XDAI = 10n ** 18n / 4n // 0.25 xDAI
+
+/** What one faucet send delivers. A zero leg is skipped entirely. */
+export interface FaucetAmounts {
+  /** Gnosis-side native xDAI, in wei. */
+  xdai: bigint
+  /** Gnosis-side BZZ, in PLUR. */
+  bzzPlur: bigint
+}
+
+/**
+ * Hand any address money on the dev chain.
+ *
+ * A transfer from the baked faucet rather than a trade: every swap moves a real
+ * and thin BZZ pool, and topping an address up is not the thing worth
+ * simulating faithfully. The purchase path still trades — see
+ * `createOwnedBatchOnChain`.
+ *
+ * Any address, not just a derived signer: reproducing a bug usually means
+ * funding the one address that is stuck.
+ */
+export async function sendFromFaucet(address: string, amounts: FaucetAmounts): Promise<void> {
+  const to = new EthAddress(address).toChecksum() as `0x${string}`
+  if (amounts.xdai > 0n || amounts.bzzPlur > 0n) {
+    const chain = await postageChain()
+    await fundLocalAccount({ to, xdai: amounts.xdai, bzzPlur: amounts.bzzPlur }, chain.settings)
+  }
+}
+
+/** An address and what it holds on the Gnosis-side chain, for the faucet panel. */
+export interface FundsRow {
+  address: `0x${string}`
+  xdai: bigint
+  bzz: bigint
+}
+
+/** What the faucet has left to give, and what `address` holds. */
+export async function devChainFunds(
+  address: string,
+): Promise<{ faucet: FundsRow; recipient: FundsRow }> {
+  const chain = await postageChain()
+  const recipient = new EthAddress(address).toChecksum() as `0x${string}`
+  const [faucetFunds, recipientFunds] = await Promise.all([
+    ownerFunds(DEV_FAUCET_ADDRESS, chain),
+    ownerFunds(recipient, chain),
+  ])
+  return {
+    faucet: { address: DEV_FAUCET_ADDRESS, ...faucetFunds },
+    recipient: { address: recipient, ...recipientFunds },
+  }
+}
+
+/** A batch created on a local chain, in the terms a purchase reports. */
+export interface LocalBatch {
+  batchId: string
+  depth: number
+  /** Initial balance per chunk, in PLUR. */
+  amountPerChunk: bigint
+  /** Block the creation landed in, as the widget reports it (hex). */
+  blockNumber: string
+}
+
+/**
+ * Create a batch the account's postage signer OWNS, paid for by someone else —
+ * the production role split, where the payment machinery creates the batch and
+ * the derived signer owns it.
+ *
+ * Runs the widget's actual step list: swap → approve → createBatch → hand the
+ * leftovers to the owner.
+ */
+export async function createOwnedBatchOnChain(
+  derivationKey: string,
+  requestedDepth?: number,
+): Promise<LocalBatch> {
+  const { destination } = await derivePostageSigner(derivationKey)
+  const chain = await postageChain()
+  // Any dev flow that makes a batch will go on to extend or resize it, so this
+  // is the one place that guarantees the delegate is there for the bundled
+  // path — including in e2e runs, which never start the solver.
+  await ensureBundlingDelegate(chain.settings)
+  const owner = destination as `0x${string}`
+  const depth = requestedDepth ?? DEV_BATCH_DEPTH
+  const { minimumInitialBalancePerChunk } = await chain.getPostageWriteConstraints()
+  const amountPerChunk = minimumInitialBalancePerChunk * DEV_BATCH_FLOOR_MULTIPLE
+
+  const created = await simulateWidgetPurchase(
+    {
+      owner,
+      depth,
+      amountPerChunk,
+      payerPrivateKey: generatePrivateKey(),
+      payerXdai: PURCHASE_PAYER_XDAI,
+      swapXdai: PURCHASE_SWAP_XDAI,
+    },
+    chain.settings,
+  )
+
+  const receipt = await chain.getTransactionReceipt(created.transactionHash)
+  return {
+    batchId: created.batchId,
+    depth,
+    amountPerChunk,
+    blockNumber: receipt?.blockNumber ?? '0x0',
+  }
+}
+
+/**
+ * Create a batch AND attach it to the account as a drive, in one go.
+ *
+ * Hand-testing extend or resize otherwise starts with six UI steps — create the
+ * batch, copy its id, copy the signer key, paste both, import — every one of
+ * which is a chance to paste the wrong field. The drive it leaves behind is an
+ * ordinary one: a real batch the account's own signer owns.
+ *
+ * @returns the attached drive's batch id.
+ */
+export async function createTestDrive(account: Account): Promise<string> {
+  const { batchId } = await createOwnedBatchOnChain(account.derivationKey)
+  const { signerKey } = await derivePostageSigner(account.derivationKey)
+  const stamp = await fetchExistingBatchFromChain(batchId, signerKey, '')
+  if (!stamp) {
+    throw new Error('The batch was created but could not be read back from the chain.')
+  }
+  account.addStamp(stamp)
+  return batchId
+}

--- a/ui/src/lib/payment/chain.ts
+++ b/ui/src/lib/payment/chain.ts
@@ -60,36 +60,63 @@ export interface ChainIdentity {
   isMainnet: boolean
 }
 
-/** One JSON-RPC call without a client — none can be built until we know the chain. */
-export async function probeChainId(rpcUrl: string): Promise<number> {
-  const response = await fetch(rpcUrl, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'eth_chainId', params: [] }),
-    signal: AbortSignal.timeout(CHAIN_ID_PROBE_TIMEOUT_MS),
-  })
-  const data = (await response.json()) as { result?: string }
-  if (typeof data.result !== 'string') {
-    throw new Error('The configured Gnosis RPC did not report a chain id.')
-  }
-  return Number(BigInt(data.result))
+interface JsonRpcResponse<T> {
+  result?: T
+  error?: { code?: number; message?: string }
 }
 
-/** The hash of block 0, or undefined when the endpoint keeps no genesis. */
-async function probeGenesisHash(rpcUrl: string): Promise<string | undefined> {
+/**
+ * One JSON-RPC call, checked. An endpoint that answers 429, or 200 carrying a
+ * JSON-RPC error, must not be read as an answer: every caller of this module
+ * decides from it whether money is real.
+ */
+async function jsonRpc<T>(rpcUrl: string, method: string, params: unknown[]): Promise<T> {
   const response = await fetch(rpcUrl, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'eth_getBlockByNumber',
-      params: ['0x0', false],
-    }),
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
     signal: AbortSignal.timeout(CHAIN_ID_PROBE_TIMEOUT_MS),
   })
-  const data = (await response.json()) as { result?: { hash?: string } }
-  return data.result?.hash
+  if (!response.ok) {
+    throw new Error(`The configured Gnosis RPC answered ${response.status} to ${method}.`)
+  }
+  const data = (await response.json()) as JsonRpcResponse<T>
+  if (data.error) {
+    throw new Error(
+      `The configured Gnosis RPC refused ${method}: ${data.error.message ?? 'unknown error'}`,
+    )
+  }
+  if (data.result === undefined) {
+    throw new Error(`The configured Gnosis RPC returned no result for ${method}.`)
+  }
+  return data.result
+}
+
+/** One JSON-RPC call without a client — none can be built until we know the chain. */
+export async function probeChainId(rpcUrl: string): Promise<number> {
+  const result = await jsonRpc<string>(rpcUrl, 'eth_chainId', [])
+  if (typeof result !== 'string') {
+    throw new Error('The configured Gnosis RPC did not report a chain id.')
+  }
+  return Number(BigInt(result))
+}
+
+/**
+ * The hash of block 0.
+ *
+ * @throws when the endpoint will not serve it. Deliberately: an unproven
+ *   genesis must never resolve to "not mainnet", because that is the answer
+ *   that tells the page spending is free. A rate-limited or pruned Gnosis node
+ *   would otherwise be dressed up as a dev chain, under a banner saying nothing
+ *   here is real, while the faucet spent actual funds. Unreachable is loud; a
+ *   false all-clear is not.
+ */
+async function probeGenesisHash(rpcUrl: string): Promise<string> {
+  const block = await jsonRpc<{ hash?: string }>(rpcUrl, 'eth_getBlockByNumber', ['0x0', false])
+  if (typeof block.hash !== 'string') {
+    throw new Error('The configured Gnosis RPC did not report a genesis block.')
+  }
+  return block.hash
 }
 
 // One identity per RPC URL: the chain a URL serves does not change under us,
@@ -112,13 +139,20 @@ export function chainIdentity(
   if (existing) {
     return existing
   }
-  const identity = Promise.all([probeChainId(rpcUrl), probeGenesisHash(rpcUrl)])
+  const identity: Promise<ChainIdentity> = Promise.all([
+    probeChainId(rpcUrl),
+    probeGenesisHash(rpcUrl),
+  ])
     .then(([chainId, genesisHash]) => ({
       chainId,
       isMainnet: chainId === GNOSIS_CHAIN_ID && genesisHash === GNOSIS_GENESIS_HASH,
     }))
     .catch((error: unknown) => {
-      identities.delete(rpcUrl)
+      // Only evict OUR entry: a retry may already have stored a healthy probe
+      // under this url, and dropping that one would re-probe for nothing.
+      if (identities.get(rpcUrl) === identity) {
+        identities.delete(rpcUrl)
+      }
       throw error
     })
   identities.set(rpcUrl, identity)

--- a/ui/src/lib/payment/chain.ts
+++ b/ui/src/lib/payment/chain.ts
@@ -1,0 +1,162 @@
+// Copyright 2026 The Swarm Authors. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+/**
+ * Which chain is on the other end of the configured Gnosis RPC, and a client
+ * for it.
+ *
+ * Separate from the operations built on top because the question is asked well
+ * before any of them: the dev tools, the network settings dialog and the
+ * postage engine all need to know whether they are talking to Gnosis mainnet
+ * or to a local chain wearing its chain id, and the answer decides which
+ * contract addresses and which RPC fallbacks apply.
+ */
+import {
+  GNOSIS_CHAIN_ID,
+  MultichainClient,
+  type MultichainSettings,
+  gnosisMainnetSettings,
+} from '@swarm-id/multichain'
+
+import { prefix0x } from '$lib/crypto/hex'
+import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
+
+/**
+ * Settings for the endpoint. There is one preset: the baked local chain carries
+ * a real BZZ market and the contracts at their mainnet addresses, so it is
+ * driven with the production ones — which is what makes it worth testing on.
+ */
+function settingsFor(identity: ChainIdentity, rpcUrl: string): MultichainSettings {
+  if (identity.chainId !== GNOSIS_CHAIN_ID) {
+    throw new Error(
+      `The configured Gnosis RPC reports chain id ${identity.chainId}, not Gnosis (${GNOSIS_CHAIN_ID}). Check the network settings.`,
+    )
+  }
+  // A dev chain answering as Gnosis must never fall back to the public RPCs:
+  // a failed call would silently read REAL mainnet state.
+  const mainnet = gnosisMainnetSettings()
+  return gnosisMainnetSettings({
+    rpcUrls: identity.isMainnet
+      ? [rpcUrl, ...mainnet.rpcUrls.filter((url) => url !== rpcUrl)]
+      : [rpcUrl],
+  })
+}
+
+const CHAIN_ID_PROBE_TIMEOUT_MS = 5000
+
+/**
+ * Gnosis mainnet's genesis block hash. A chain's genesis is its identity and
+ * cannot change, which is what makes this the honest way to ask "is this the
+ * real thing" — the local chain answers chain id 100 too, deliberately, so an
+ * app resolving contract addresses by chain id finds what it expects there.
+ */
+const GNOSIS_GENESIS_HASH = '0x4f1dd23188aab3a76b463e4af801b52b1248ef073c648cbdc4c9333d3da79756'
+
+export interface ChainIdentity {
+  chainId: number
+  /**
+   * True only for Gnosis mainnet itself. Anything else answering as chain 100
+   * is a dev chain, and spending on it is free.
+   */
+  isMainnet: boolean
+}
+
+/** One JSON-RPC call without a client — none can be built until we know the chain. */
+export async function probeChainId(rpcUrl: string): Promise<number> {
+  const response = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'eth_chainId', params: [] }),
+    signal: AbortSignal.timeout(CHAIN_ID_PROBE_TIMEOUT_MS),
+  })
+  const data = (await response.json()) as { result?: string }
+  if (typeof data.result !== 'string') {
+    throw new Error('The configured Gnosis RPC did not report a chain id.')
+  }
+  return Number(BigInt(data.result))
+}
+
+/** The hash of block 0, or undefined when the endpoint keeps no genesis. */
+async function probeGenesisHash(rpcUrl: string): Promise<string | undefined> {
+  const response = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'eth_getBlockByNumber',
+      params: ['0x0', false],
+    }),
+    signal: AbortSignal.timeout(CHAIN_ID_PROBE_TIMEOUT_MS),
+  })
+  const data = (await response.json()) as { result?: { hash?: string } }
+  return data.result?.hash
+}
+
+// One identity per RPC URL: the chain a URL serves does not change under us,
+// so the probe is paid once. A failure is never cached — the node may just
+// have been starting up.
+const identities = new Map<string, Promise<ChainIdentity>>()
+const clients = new Map<string, Promise<MultichainClient>>()
+
+/**
+ * What chain is actually on the other end of `rpcUrl`.
+ *
+ * The chain id alone cannot answer this: the local chain deliberately reports
+ * 100 so that an app resolving contract addresses by chain id finds the Gnosis
+ * deployments there. Genesis can — it is the one thing a chain cannot borrow.
+ */
+export function chainIdentity(
+  rpcUrl: string = networkSettingsStore.gnosisRpcUrl,
+): Promise<ChainIdentity> {
+  const existing = identities.get(rpcUrl)
+  if (existing) {
+    return existing
+  }
+  const identity = Promise.all([probeChainId(rpcUrl), probeGenesisHash(rpcUrl)])
+    .then(([chainId, genesisHash]) => ({
+      chainId,
+      isMainnet: chainId === GNOSIS_CHAIN_ID && genesisHash === GNOSIS_GENESIS_HASH,
+    }))
+    .catch((error: unknown) => {
+      identities.delete(rpcUrl)
+      throw error
+    })
+  identities.set(rpcUrl, identity)
+  return identity
+}
+
+/**
+ * The chain client for the configured Gnosis RPC, built from whichever preset
+ * the endpoint's chain id calls for.
+ * @throws when the endpoint is unreachable or serves an unsupported chain —
+ *   deliberately, since every caller goes on to sign or spend.
+ */
+export function postageChain(
+  rpcUrl: string = networkSettingsStore.gnosisRpcUrl,
+): Promise<MultichainClient> {
+  const existing = clients.get(rpcUrl)
+  if (existing) {
+    return existing
+  }
+  const client = chainIdentity(rpcUrl)
+    .then((identity) => new MultichainClient(settingsFor(identity, rpcUrl)))
+    .catch((error: unknown) => {
+      clients.delete(rpcUrl)
+      throw error
+    })
+  clients.set(rpcUrl, client)
+  return client
+}
+
+export interface OwnerFunds {
+  xdai: bigint
+  bzz: bigint
+}
+
+/** Current balances at the batch-owner address. */
+export async function ownerFunds(address: string, client?: MultichainClient): Promise<OwnerFunds> {
+  const chain = client ?? (await postageChain())
+  const owner = prefix0x(address) as `0x${string}`
+  const [xdai, bzz] = await Promise.all([chain.getNativeBalance(owner), chain.getBzzBalance(owner)])
+  return { xdai, bzz }
+}

--- a/ui/src/lib/payment/contract.ts
+++ b/ui/src/lib/payment/contract.ts
@@ -1,13 +1,10 @@
 // Copyright 2026 The Swarm Authors. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 import { BatchId, PrivateKey } from '@ethersphere/bee-js'
-import {
-  calculateContractTTLSeconds,
-  fetchOnChainBatchState,
-  resolvePostageStampContractAddress,
-} from '@snaha/swarm-id'
+import { calculateContractTTLSeconds, fetchOnChainBatchState } from '@snaha/swarm-id'
 
 import { strip0x } from '$lib/crypto/hex'
+import { postageChain } from '$lib/payment/chain'
 import type { NewStamp } from '$lib/payment/purchase'
 import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
 
@@ -29,9 +26,10 @@ export async function fetchExistingBatchFromChain(
   opts?: { rpcUrl?: string; contractAddress?: string },
 ): Promise<NewStamp | undefined> {
   const rpcUrl = opts?.rpcUrl ?? networkSettingsStore.gnosisRpcUrl
-  // No local-only deployment any more: the cluster's chain carries the Swarm
-  // contracts at their MAINNET addresses, so local and remote resolve alike.
-  const contractAddress = opts?.contractAddress ?? resolvePostageStampContractAddress(rpcUrl)
+  // The contract address follows the chain the endpoint actually serves, not
+  // its hostname — a localhost fork of Gnosis carries the MAINNET deployment.
+  const contractAddress =
+    opts?.contractAddress ?? (await postageChain(rpcUrl)).settings.addresses.postageStamp
 
   const state = await fetchOnChainBatchState(rpcUrl, strip0x(batchId), contractAddress)
   if (!state) {

--- a/ui/src/lib/payment/multichain-widget.ts
+++ b/ui/src/lib/payment/multichain-widget.ts
@@ -40,6 +40,11 @@ export interface PurchaseStampOptions {
   mocked?: boolean // For testing - simulate the settlement instead of paying
   mockPopup?: boolean // For testing - also open the widget's `?mocked=true` popup
   mockError?: boolean // For testing - simulate error instead of success
+  // For testing - the depth to fabricate. The real widget picks the depth
+  // itself, which is why there is no plain `depth` option; the mock takes the
+  // size the user asked for so the drive it leaves behind is the one they
+  // chose, rather than always a 600 MB one.
+  mockDepth?: number
 }
 
 /** How long to keep listening for a trailing `batch` message after the popup
@@ -214,6 +219,7 @@ export function openStampPurchaseWidget(options: PurchaseStampOptions): StampPur
     mocked,
     mockPopup,
     mockError,
+    mockDepth,
   } = options
 
   // Mocked mode (the /dev toggle): settle locally without a real cross-chain
@@ -239,7 +245,7 @@ export function openStampPurchaseWidget(options: PurchaseStampOptions): StampPur
       settle(onSuccess, onError, {
         event: 'batch',
         batchId,
-        depth: MOCK_BATCH_DEPTH,
+        depth: mockDepth ?? MOCK_BATCH_DEPTH,
         amount: MOCK_BATCH_AMOUNT,
         blockNumber: '0x' + Math.floor(Date.now() / MS_PER_SECOND).toString(HEX_RADIX),
       })

--- a/ui/src/routes/dev/+page.svelte
+++ b/ui/src/routes/dev/+page.svelte
@@ -5,8 +5,12 @@
 
 <script lang="ts">
   import { BatchId, Bee, EthAddress, Identifier, PrivateKey } from '@ethersphere/bee-js'
+  import ChevronDown from '@lucide/svelte/icons/chevron-down'
   import Info from '@lucide/svelte/icons/info'
+  import Settings from '@lucide/svelte/icons/settings'
   import {
+    DEFAULT_BEE_NODE_URL,
+    DEFAULT_GNOSIS_RPC_URL,
     derivePostageSignerKey,
     downloadEncryptedSOC,
     rejectAfter,
@@ -19,7 +23,13 @@
   import { resolve } from '$app/paths'
 
   import CopyButton from '$lib/components/copy-button.svelte'
+  import NetworkSettingsDialog from '$lib/components/network-settings-dialog.svelte'
   import { Button } from '$lib/components/ui/button'
+  import {
+    DropdownMenu,
+    DropdownMenuItem,
+    DropdownMenuSeparator,
+  } from '$lib/components/ui/dropdown-menu'
   import { Input } from '$lib/components/ui/input'
   import { Select } from '$lib/components/ui/select'
   import { Switch } from '$lib/components/ui/switch'
@@ -27,6 +37,7 @@
   import {
     ANVIL_ACCOUNT,
     type FundsRow,
+    createExpiringTestDrive,
     createOwnedBatchOnChain,
     createTestDrive,
     devChainFunds,
@@ -34,7 +45,7 @@
   } from '$lib/dev/chain-funding'
   import { postageStampsStore } from '$lib/dev/postage-stamps.svelte'
   import { syncStore } from '$lib/dev/sync.svelte'
-  import { chainIdentity, postageChain } from '$lib/payment/chain'
+  import { chainIdentity, postageChain, probeChainId } from '$lib/payment/chain'
   import { fetchExistingBatchFromChain } from '$lib/payment/contract'
   import routes from '$lib/routes'
   import { accountsStore } from '$lib/stores/accounts.svelte'
@@ -86,6 +97,60 @@
 
   // Demo app URL for connect flow testing (the new UI's demo runs on :3500).
   const demoAppOrigin = 'http://localhost:3500'
+
+  /**
+   * The local endpoints "Use local" points the app at. Two chains can be
+   * serving Gnosis locally — bee-compose's cluster and the standalone snapshot
+   * — so it asks which is actually answering rather than making the user
+   * remember. The cluster comes first: it also serves the Bee node, so if it
+   * is up that is the environment you want. This lives here rather than in
+   * Network settings, which ships to production.
+   */
+  const LOCAL_BEE_NODE_URL = 'http://localhost:1633/'
+  const LOCAL_GNOSIS_RPC_URLS = ['http://localhost:9545', 'http://localhost:8545']
+  /** Worker 1 of the same cluster; only meaningful while the queen is in use. */
+  const LOCAL_CLUSTER_WORKER_URL = 'http://localhost:16331'
+
+  /**
+   * Which environment the saved endpoints amount to — the one word the menu
+   * needs. Anything else, a gateway or a colleague's node, is `Custom`: the
+   * pair is what makes an environment, so one preset URL beside a hand-typed
+   * one is not that preset.
+   */
+  const endpointMode = $derived.by(() => {
+    const { beeNodeUrl, gnosisRpcUrl } = networkSettingsStore
+    if (beeNodeUrl === LOCAL_BEE_NODE_URL && LOCAL_GNOSIS_RPC_URLS.includes(gnosisRpcUrl)) {
+      return 'Local'
+    }
+    if (beeNodeUrl === DEFAULT_BEE_NODE_URL && gnosisRpcUrl === DEFAULT_GNOSIS_RPC_URL) {
+      return 'Production'
+    }
+    return 'Custom'
+  })
+
+  let networkDialogOpen = $state(false)
+
+  // Both presets apply straight away; anything else goes through the product's
+  // own Network settings dialog rather than a second copy of its fields.
+  async function useLocalEndpoints() {
+    const reachable = await Promise.all(
+      LOCAL_GNOSIS_RPC_URLS.map((url) =>
+        probeChainId(url).then(
+          () => url,
+          () => undefined,
+        ),
+      ),
+    )
+    const gnosisRpcUrl = reachable.find((url) => url !== undefined) ?? LOCAL_GNOSIS_RPC_URLS[0]
+    networkSettingsStore.updateSettings({ beeNodeUrl: LOCAL_BEE_NODE_URL, gnosisRpcUrl })
+  }
+
+  function useProductionEndpoints() {
+    networkSettingsStore.updateSettings({
+      beeNodeUrl: DEFAULT_BEE_NODE_URL,
+      gnosisRpcUrl: DEFAULT_GNOSIS_RPC_URL,
+    })
+  }
 
   // Sync state
   let syncMessage = $state('')
@@ -742,33 +807,75 @@ Check console logs for details:
 {/snippet}
 
 <div class="mx-auto flex w-full max-w-3xl flex-col gap-8 p-8">
-  <h2 class="text-xl font-bold">Developer Tools</h2>
+  <div class="flex items-center justify-between gap-2">
+    <h2 class="text-xl font-bold">Developer Tools</h2>
+
+    <!--
+      Switching environments is a rare act, so it sits in a menu rather than
+      occupying the page: the trigger carries the one word worth seeing at a
+      glance, and anything that is neither preset is edited through the
+      product's own Network settings dialog.
+    -->
+    <DropdownMenu class="top-full right-0 mt-2 min-w-44 p-1">
+      {#snippet trigger(props)}
+        <Button variant="outline" {...props}>
+          Connected to: {endpointMode}
+          <ChevronDown class="size-4 shrink-0" />
+        </Button>
+      {/snippet}
+
+      <DropdownMenuItem onclick={useLocalEndpoints}>
+        <span class="flex-1 whitespace-nowrap">Use local</span>
+      </DropdownMenuItem>
+      <DropdownMenuItem onclick={useProductionEndpoints}>
+        <span class="flex-1 whitespace-nowrap">Use production</span>
+      </DropdownMenuItem>
+
+      <DropdownMenuSeparator />
+
+      <DropdownMenuItem onclick={() => (networkDialogOpen = true)}>
+        <Settings class="size-4 shrink-0" />
+        <span class="flex-1 whitespace-nowrap">Network settings</span>
+      </DropdownMenuItem>
+    </DropdownMenu>
+  </div>
 
   <!--
     Which chain these tools are pointed at. Every action on this page spends,
     and a dev chain reports the same chain id as mainnet on purpose — so the
     only honest answer comes from the genesis hash. Red is for MAINNET: on this
     page that is the state nobody intends to be in.
+
+    Keyed on the endpoint: without it a switch away from an unreachable RPC
+    keeps rendering the failed branch — with the NEW url interpolated into it,
+    since the message reads that from the store — so a healthy endpoint is
+    reported dead the instant it is selected.
   -->
-  {#await chainIdentity(networkSettingsStore.gnosisRpcUrl)}
-    {@render chainBanner('Checking the chain at ', networkSettingsStore.gnosisRpcUrl, false)}
-  {:then identity}
-    {#if identity.isMainnet}
-      {@render chainBanner(
-        'GNOSIS MAINNET — these tools spend real funds. ',
-        networkSettingsStore.gnosisRpcUrl,
-        true,
-      )}
-    {:else}
-      {@render chainBanner(
-        'Local dev chain, nothing here is real. ',
-        networkSettingsStore.gnosisRpcUrl,
-        false,
-      )}
-    {/if}
-  {:catch}
-    {@render chainBanner('No chain reachable at ', networkSettingsStore.gnosisRpcUrl, true)}
-  {/await}
+  {#key networkSettingsStore.gnosisRpcUrl}
+    {#await chainIdentity(networkSettingsStore.gnosisRpcUrl)}
+      {@render chainBanner('Checking the chain at ', networkSettingsStore.gnosisRpcUrl, false)}
+    {:then identity}
+      {#if identity.isMainnet}
+        {@render chainBanner(
+          'GNOSIS MAINNET — these tools spend real funds. ',
+          networkSettingsStore.gnosisRpcUrl,
+          true,
+        )}
+      {:else}
+        {@render chainBanner(
+          'Local dev chain, nothing here is real. ',
+          networkSettingsStore.gnosisRpcUrl,
+          false,
+        )}
+      {/if}
+    {:catch}
+      {@render chainBanner('No chain reachable at ', networkSettingsStore.gnosisRpcUrl, true)}
+    {/await}
+  {/key}
+
+  {#if networkDialogOpen}
+    <NetworkSettingsDialog onclose={() => (networkDialogOpen = false)} />
+  {/if}
 
   <Tabs {tabs} bind:value={activeTab} />
 
@@ -797,7 +904,7 @@ Check console logs for details:
     {@const connectUrl = `${resolve(routes.CONNECT)}?origin=${encodeURIComponent(demoAppOrigin)}`}
     <div class="flex flex-col gap-4">
       <div class="flex flex-col gap-2">
-        <h4 class="text-sm font-semibold">Local Bee Endpoints</h4>
+        <h4 class="text-sm font-semibold">Endpoints these tools use</h4>
         <!--
           These hrefs are absolute http(s) endpoints read from network settings —
           never app routes — which a dynamic href cannot prove to the rule.
@@ -814,17 +921,25 @@ Check console logs for details:
           >
           <CopyButton text={networkSettingsStore.beeNodeUrl} />
         </div>
-        <div class="flex items-center gap-2">
-          <StatusDot endpoint="http://localhost:16331" />
-          <span class="font-mono text-sm">Cluster worker:</span>
-          <a
-            href="http://localhost:16331"
-            target="_blank"
-            rel="noopener"
-            class="text-primary font-mono text-sm">http://localhost:16331</a
-          >
-          <CopyButton text="http://localhost:16331" />
-        </div>
+        <!--
+          A second node of the bee-compose cluster, useful for checking that a
+          chunk replicated off the node that took it. It only exists while the
+          Bee node IS that cluster — against a gateway there is no such peer to
+          link to, and a dead localhost row reads as something being broken.
+        -->
+        {#if networkSettingsStore.beeNodeUrl === LOCAL_BEE_NODE_URL}
+          <div class="flex items-center gap-2">
+            <StatusDot endpoint={LOCAL_CLUSTER_WORKER_URL} />
+            <span class="font-mono text-sm">Cluster worker:</span>
+            <a
+              href={LOCAL_CLUSTER_WORKER_URL}
+              target="_blank"
+              rel="noopener"
+              class="text-primary font-mono text-sm">{LOCAL_CLUSTER_WORKER_URL}</a
+            >
+            <CopyButton text={LOCAL_CLUSTER_WORKER_URL} />
+          </div>
+        {/if}
         <div class="flex items-center gap-2">
           <StatusDot endpoint={networkSettingsStore.gnosisRpcUrl} method="json-rpc" />
           <!--
@@ -845,7 +960,7 @@ Check console logs for details:
       </div>
 
       <div class="flex flex-col gap-2">
-        <h4 class="text-sm font-semibold">Test Connect Flow</h4>
+        <h4 class="text-sm font-semibold">Test connect flow</h4>
         <p class="text-sm">Test the connect flow with the demo app:</p>
         <div class="flex items-center gap-2">
           <StatusDot endpoint={demoAppOrigin} />
@@ -856,7 +971,7 @@ Check console logs for details:
       </div>
 
       <div class="flex flex-col items-start gap-2">
-        <h4 class="text-sm font-semibold">Local Data</h4>
+        <h4 class="text-sm font-semibold">Local data</h4>
         <p class="text-sm">
           {accountCount} accounts, {connectionCount} connections, {stampCount} stamps
         </p>
@@ -876,7 +991,7 @@ Check console logs for details:
   <!-- Node Tab: everything that talks to the Bee node -->
   {#if activeTab === 'node'}
     <div class="flex flex-col gap-4">
-      <h3 class="text-lg font-semibold">Stored Stamps (local)</h3>
+      <h3 class="text-lg font-semibold">Stored stamps (local)</h3>
       <p class="text-muted-foreground text-sm">
         The postage batches saved in this browser. Copy these fields before clearing storage — paste
         them into the "Use existing one" screen to re-adopt the same batch on a fresh account (the
@@ -968,7 +1083,7 @@ Check console logs for details:
 
       <div class="bg-border my-4 h-px"></div>
 
-      <h3 class="text-lg font-semibold">Manual Sync Testing</h3>
+      <h3 class="text-lg font-semibold">Manual sync testing</h3>
       <p class="text-sm">
         Trigger a manual sync for ALL accounts to test postage stamp utilization tracking.
       </p>
@@ -1193,6 +1308,16 @@ Check console logs for details:
         >
           Create drive to test with
         </Button>
+        <Button
+          variant="secondary"
+          disabled={chainToolBusy || !selectedAccountId}
+          onclick={() =>
+            runChainTool('Created expiring drive', (_key, account) =>
+              createExpiringTestDrive(account),
+            )}
+        >
+          Create expiring drive
+        </Button>
       </div>
       <p class="text-muted-foreground text-sm">
         Acts on the account selected at the top of the page. For the normal path just use
@@ -1275,7 +1400,7 @@ Check console logs for details:
   <!-- Devices Tab -->
   {#if activeTab === 'devices'}
     <div class="flex flex-col gap-4">
-      <h3 class="text-lg font-semibold">Account Devices</h3>
+      <h3 class="text-lg font-semibold">Account devices</h3>
       <p class="text-sm">
         Inspect the devices registered to an account and which partitions they currently hold.
       </p>

--- a/ui/src/routes/dev/+page.svelte
+++ b/ui/src/routes/dev/+page.svelte
@@ -4,20 +4,17 @@
 -->
 
 <script lang="ts">
-  import { SvelteMap } from 'svelte/reactivity'
-
-  import { BatchId, Bee, EthAddress, Identifier, PrivateKey, Utils } from '@ethersphere/bee-js'
+  import { BatchId, Bee, EthAddress, Identifier, PrivateKey } from '@ethersphere/bee-js'
+  import Info from '@lucide/svelte/icons/info'
   import {
-    calculateStampAmountForDays,
     derivePostageSignerKey,
     downloadEncryptedSOC,
-    fetchChainState,
-    formatTTL,
     rejectAfter,
-    resolvePostageStampContractAddress,
     uint8ArrayToHex,
     uploadSOC,
   } from '@snaha/swarm-id'
+  import { gnosisMainnetSettings } from '@swarm-id/multichain'
+  import { formatUnits, parseUnits } from 'viem'
 
   import { resolve } from '$app/paths'
 
@@ -27,14 +24,24 @@
   import { Select } from '$lib/components/ui/select'
   import { Switch } from '$lib/components/ui/switch'
   import { Tabs } from '$lib/components/ui/tabs'
+  import {
+    ANVIL_ACCOUNT,
+    type FundsRow,
+    createOwnedBatchOnChain,
+    createTestDrive,
+    devChainFunds,
+    sendFromFaucet,
+  } from '$lib/dev/chain-funding'
   import { postageStampsStore } from '$lib/dev/postage-stamps.svelte'
   import { syncStore } from '$lib/dev/sync.svelte'
+  import { chainIdentity, postageChain } from '$lib/payment/chain'
   import { fetchExistingBatchFromChain } from '$lib/payment/contract'
   import routes from '$lib/routes'
   import { accountsStore } from '$lib/stores/accounts.svelte'
   import { devSettingsStore } from '$lib/stores/dev-settings.svelte'
   import { networkSettingsStore } from '$lib/stores/network-settings.svelte'
   import { sessionStore } from '$lib/stores/session.svelte'
+  import type { Account } from '$lib/types'
 
   import DeviceList from './device-list.svelte'
   import StatusDot from './status-dot.svelte'
@@ -43,26 +50,6 @@
   // (`+layout.svelte`), so /dev no longer manages it — a local install +
   // unmount cleanup here would toggle publishing off for the whole app on
   // navigating away.
-
-  // Milliseconds per second — for converting TTL/Unix seconds to JS `Date` ms.
-  const MS_PER_SECOND = 1000
-
-  // How many days of validity to fund by default when auto-filling the
-  // stamp amount from current chain price. Bee enforces a 24h minimum on
-  // POST /stamps; 7 days gives comfortable headroom for dev testing without
-  // re-buying constantly.
-  const DEFAULT_STAMP_DAYS = 7
-
-  // Renders a listed stamp's remaining lifetime as "<ttl> (<date>)". batchTTL
-  // comes straight from the Bee node's /stamps response — authoritative for the
-  // batches it tracks, which is exactly what this list shows (no contract read
-  // needed here, and the default chain is local where the mainnet PostageStamp
-  // contract isn't deployed).
-  function formatStampExpiry(batchTTL: number): string {
-    if (!batchTTL || batchTTL <= 0) return 'Expired'
-    const date = new Date(Date.now() + batchTTL * MS_PER_SECOND).toLocaleDateString()
-    return `${formatTTL(batchTTL)} (${date})`
-  }
 
   // Every live (non-tombstoned) stamp across all accounts — the account owns its
   // stamps now, and a removed stamp lingers as a `deletedAt` tombstone so its
@@ -92,8 +79,8 @@
 
   const tabs = [
     { value: 'overview', label: 'Overview' },
-    { value: 'stamps', label: 'Stamps' },
-    { value: 'sync', label: 'Sync' },
+    { value: 'chain', label: 'Chain' },
+    { value: 'node', label: 'Node' },
     { value: 'devices', label: 'Devices' },
   ]
 
@@ -103,25 +90,6 @@
   // Sync state
   let syncMessage = $state('')
 
-  // Stamp buying state. The Bee node URL is NOT page-local: every dev
-  // subsystem (stamp buying/listing here, sync, account refresh, the
-  // retrievability checks) reads the one persisted network setting, so a URL
-  // change applies everywhere at once — buying a stamp against one node while
-  // sync silently targets another was a debugging trap.
-  // Amount starts empty — autofilled from chain price on first chainstate
-  // load (see loadChainState). Hardcoding a default is fragile across chain
-  // configs: bee-compose's PriceOracle floor (24_000 PLUR/chunk/block) needs
-  // ≥ 414_720_000 PLUR/chunk for 24h, and other chains have different floors.
-  let stampAmount = $state('')
-  let stampDepth = $state('20')
-  let buying = $state(false)
-  let stampResult = $state<{ batchID: string; txHash: string } | undefined>(undefined)
-  let stampError = $state('')
-  let currentPrice = $state<bigint | undefined>(undefined)
-  let chainStateError = $state('')
-  let assignMessage = $state('')
-  let assignError = $state('')
-  let selectedStampId = $state('')
   let selectedAccountId = $state('')
 
   // Derived postage signer key + owner address for the selected account.
@@ -147,24 +115,184 @@
       accountSigner = { privateKey: k, owner: new PrivateKey(k).publicKey().address().toHex() }
     })()
   })
-  let beeStamps = $state<
-    Array<{
-      batchID: string
-      utilization: number
-      usable: boolean
-      label: string
-      depth: number
-      amount: string
-      bucketDepth: number
-      blockNumber: number
-      immutableFlag: boolean
-      exists: boolean
-      batchTTL: number
-    }>
-  >([])
-  let beeStampsLoading = $state(false)
-  let beeStampsError = $state('')
-  let lastBeeUrl = $state('')
+  // On-chain drive tooling: fund the account's postage signer and create a
+  // batch it OWNS, so extend/resize can run for real against the local chain.
+  let chainToolBusy = $state(false)
+  let chainToolMessage = $state('')
+  let chainToolError = $state('')
+
+  // Faucet panel. Amounts are what you type — no hidden multiplier, since the
+  // point of the panel is to hand over an exact amount and watch it land.
+  const XDAI_DECIMALS = 18
+  const BZZ_DECIMALS = 16
+  const AMOUNT_PRECISION = 4
+  /** Stands in where the chain has no figure to give, rather than a lying zero. */
+  const NO_FIGURE = '—'
+  /** The assets the faucet can hand over, and how to read an amount for each. */
+  const FAUCET_TOKENS = [
+    { value: 'xdai', label: 'xDAI', decimals: XDAI_DECIMALS, placeholder: '0.05' },
+    { value: 'bzz', label: 'BZZ', decimals: BZZ_DECIMALS, placeholder: '1' },
+  ]
+  let faucetTo = $state('')
+  let faucetToken = $state(FAUCET_TOKENS[0].value)
+  let faucetTyped = $state('0.05')
+  let faucetHelpOpen = $state(false)
+  let faucetBusy = $state(false)
+  let faucetMessage = $state('')
+  let faucetError = $state('')
+  let funds = $state<{ faucet: FundsRow; recipient: FundsRow } | undefined>(undefined)
+  let fundsError = $state('')
+
+  // The typed recipient, normalized. Undefined while it is not an address,
+  // which is also what disables Send.
+  const faucetRecipient = $derived.by(() => {
+    try {
+      return new EthAddress(faucetTo.trim()).toChecksum()
+    } catch {
+      return undefined
+    }
+  })
+
+  /**
+   * Read the amount box. Anything that is not a positive number reads as zero
+   * rather than an error — a half-typed figure disables Send, it does not take
+   * the panel down with it.
+   */
+  function faucetAmount(typed: string, decimals: number): bigint {
+    const value = typed.trim()
+    if (!(Number(value) > 0)) return 0n
+    try {
+      return parseUnits(value, decimals)
+    } catch {
+      return 0n
+    }
+  }
+
+  const faucetAsset = $derived(
+    FAUCET_TOKENS.find((token) => token.value === faucetToken) ?? FAUCET_TOKENS[0],
+  )
+  /** What Send would deliver; zero disables it. */
+  const faucetValue = $derived(faucetAmount(faucetTyped, faucetAsset.decimals))
+  const faucetTokenOptions = $derived(FAUCET_TOKENS.map(({ value, label }) => ({ value, label })))
+
+  // Amounts differ by orders of magnitude between assets, so carrying the
+  // previous box over is a wrong default every time; each token brings its own.
+  function pickFaucetToken(value: string) {
+    faucetTyped = FAUCET_TOKENS.find((token) => token.value === value)?.placeholder ?? faucetTyped
+  }
+
+  // Point the faucet at the selected account's signer, and re-point it when the
+  // account changes — reaching for Send with the previous account's address
+  // still in the box is the trap this panel would otherwise set. Only the value
+  // we filled in is ever replaced; anything typed or pasted is left alone.
+  let prefilledSigner = ''
+  $effect(() => {
+    if (!accountSigner) return
+    const owner = new EthAddress(accountSigner.owner).toChecksum()
+    if (owner === prefilledSigner) return
+    if (faucetTo === '' || faucetTo === prefilledSigner) faucetTo = owner
+    prefilledSigner = owner
+  })
+
+  function formatAmount(value: bigint, decimals: number): string {
+    return Number(formatUnits(value, decimals)).toLocaleString(undefined, {
+      maximumFractionDigits: AMOUNT_PRECISION,
+    })
+  }
+
+  async function refreshFunds() {
+    const requested = faucetRecipient
+    if (!requested) {
+      funds = undefined
+      fundsError = ''
+      return
+    }
+    try {
+      const read = await devChainFunds(requested)
+      // Typing an address fires this per keystroke and two reads can land out
+      // of order — never show one address's balances under another.
+      if (faucetRecipient !== requested) return
+      funds = read
+      fundsError = ''
+    } catch (e) {
+      if (faucetRecipient !== requested) return
+      funds = undefined
+      fundsError = e instanceof Error ? e.message : String(e)
+    }
+  }
+
+  // Re-read whenever the recipient changes; the Chain tab is the only consumer,
+  // so this costs nothing on a tab most sessions never open.
+  $effect(() => {
+    if (activeTab === 'chain' && faucetRecipient) {
+      void refreshFunds()
+    }
+  })
+
+  /** The rows of the balances table, formatted. */
+  const balanceRows = $derived.by(() => {
+    const rows: { label: string; address: string; xdai: string; bzz: string }[] = []
+    if (faucetRecipient) {
+      rows.push({
+        label: 'Recipient',
+        address: faucetRecipient,
+        xdai: funds ? formatAmount(funds.recipient.xdai, XDAI_DECIMALS) : NO_FIGURE,
+        bzz: funds ? formatAmount(funds.recipient.bzz, BZZ_DECIMALS) : NO_FIGURE,
+      })
+    }
+    if (funds) {
+      rows.push({
+        label: 'Faucet',
+        address: funds.faucet.address,
+        xdai: formatAmount(funds.faucet.xdai, XDAI_DECIMALS),
+        bzz: formatAmount(funds.faucet.bzz, BZZ_DECIMALS),
+      })
+    }
+    return rows
+  })
+
+  async function sendFaucetFunds() {
+    const to = faucetRecipient
+    if (!to || faucetValue === 0n) return
+    faucetBusy = true
+    faucetMessage = ''
+    faucetError = ''
+    try {
+      await sendFromFaucet(to, {
+        xdai: faucetToken === 'xdai' ? faucetValue : 0n,
+        bzzPlur: faucetToken === 'bzz' ? faucetValue : 0n,
+      })
+      faucetMessage = `✅ Sent ${faucetTyped.trim()} ${faucetAsset.label} to ${to}`
+    } catch (error) {
+      faucetError = error instanceof Error ? error.message : String(error)
+    } finally {
+      faucetBusy = false
+    }
+    await refreshFunds()
+  }
+
+  async function runChainTool(
+    label: string,
+    action: (derivationKey: string, account: Account) => Promise<string>,
+  ) {
+    const account = selectedAccountId
+      ? accountsStore.getAccount(new EthAddress(selectedAccountId))
+      : undefined
+    if (!account) {
+      chainToolError = 'Select an account first.'
+      return
+    }
+    chainToolBusy = true
+    chainToolMessage = ''
+    chainToolError = ''
+    try {
+      chainToolMessage = `${label}: ${await action(account.derivationKey, account)}`
+    } catch (e) {
+      chainToolError = e instanceof Error ? e.message : String(e)
+    } finally {
+      chainToolBusy = false
+    }
+  }
 
   // Retrievability self-check: does the configured Bee node serve back a SOC we
   // just wrote? (If not, no cross-device coordination — lock/intent/presence
@@ -374,62 +502,6 @@
     }
   }
 
-  // Known dev signers (pre-funded with ETH + BZZ in the local Bee cluster)
-  const KNOWN_SIGNERS = [
-    {
-      value: '566058308ad5fa3888173c741a1fb902c9f1f19559b11fc2738dfc53637ce4e9',
-      label: 'Queen (node owner)',
-    },
-    {
-      value: '4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d',
-      label: 'Wallet 0 (pre-funded)',
-    },
-    {
-      value: '6cbed15c793ce57650b9877cf6fa156fbef513c4e6134f022a85b1ffdd59b2a1',
-      label: 'Wallet 1 (pre-funded)',
-    },
-  ]
-  let selectedSigner = $state(KNOWN_SIGNERS[0].value)
-
-  // Custom signer key settings
-  let useCustomSigner = $state(false)
-  let customSignerKey = $state('')
-  // Unchecked = stack the batch onto the account WITHOUT stealing the default
-  // pointer, so an account can hold multiple drives.
-  let assignSetDefault = $state(true)
-  let customSignerError = $state<string | undefined>(undefined)
-
-  // Mock stamp widget settings — `devSettingsStore` is the single source of
-  // truth (durable + cross-tab); the controls bind straight to its setters via
-  // function bindings, so there is no local mirror to drift.
-  const MOCK_RESULT_OPTIONS = [
-    { value: 'success', label: 'Success (creates a drive)' },
-    { value: 'error', label: 'Error (purchase failed)' },
-  ]
-
-  // Validate custom signer key when enabled
-  $effect(() => {
-    if (useCustomSigner) {
-      if (customSignerKey.length === 0) {
-        customSignerError = 'Custom signer key is required'
-      } else if (!/^[0-9a-fA-F]+$/.test(customSignerKey)) {
-        customSignerError = 'Signer key must be a valid hex string'
-      } else if (customSignerKey.length !== 64) {
-        customSignerError = 'Signer key must be exactly 64 characters (hex)'
-      } else {
-        customSignerError = undefined
-      }
-    } else {
-      customSignerError = undefined
-    }
-  })
-
-  const stampOptions = $derived(
-    beeStamps.map((stamp) => ({
-      value: stamp.batchID,
-      label: `${stamp.batchID.slice(0, 10)}… (depth ${stamp.depth})`,
-    })),
-  )
   // Stored stamps (with signerKey) usable to pay for the retrievability check.
   const storedStampOptions = $derived(
     allStamps.map((stamp) => ({
@@ -451,30 +523,6 @@
   const selectedAccount = $derived(
     selectedAccountId ? accountsStore.getAccount(new EthAddress(selectedAccountId)) : undefined,
   )
-  const accountHasDefaultStamp = $derived(!!selectedAccount?.defaultPostageStampBatchID)
-  const stampAssignments = $derived(
-    (() => {
-      const map = new SvelteMap<string, { account?: string }>()
-      for (const account of accountsStore.accounts) {
-        const batch = account.defaultPostageStampBatchID?.toHex()
-        if (batch) {
-          map.set(batch, { ...(map.get(batch) ?? {}), account: account.name })
-        }
-      }
-      return map
-    })(),
-  )
-
-  $effect(() => {
-    if (stampOptions.length && !selectedStampId) {
-      selectedStampId = stampOptions[0].value
-    } else if (
-      selectedStampId &&
-      !stampOptions.some((option) => option.value === selectedStampId)
-    ) {
-      selectedStampId = stampOptions[0]?.value ?? ''
-    }
-  })
 
   $effect(() => {
     if (accountOptions.length && !selectedAccountId) {
@@ -553,34 +601,6 @@ Check console logs for details:
 - [PostageStamps] Updated utilization`
   }
 
-  async function buyStamp() {
-    buying = true
-    stampError = ''
-    stampResult = undefined
-
-    try {
-      // Buy a MUTABLE batch. Bee's POST /stamps defaults to immutable, but the
-      // multi-device partition scheme rewrites the partition-lock SOC on every
-      // lease refresh, which an immutable batch forbids. Request mutable
-      // explicitly so /dev-bought stamps work with partitioning.
-      // Tolerate a trailing slash (the default gateway URL has one).
-      const base = networkSettingsStore.beeNodeUrl.replace(/\/$/, '')
-      const response = await fetch(`${base}/stamps/${stampAmount}/${stampDepth}`, {
-        method: 'POST',
-        headers: { immutable: 'false' },
-      })
-      if (!response.ok) {
-        const errorText = await response.text()
-        throw new Error(errorText || `HTTP ${response.status}`)
-      }
-      stampResult = await response.json()
-    } catch (e) {
-      stampError = e instanceof Error ? e.message : String(e)
-    } finally {
-      buying = false
-    }
-  }
-
   // Import a batch by ID, reading its parameters from the PostageStamp contract
   // ON-CHAIN (not from a Bee node) — works for any batch id even when the
   // configured node never saw it. The signer key is NOT on-chain, so the user
@@ -589,19 +609,27 @@ Check console logs for details:
 
   let importBatchId = $state('')
   let importSignerKey = $state('')
-  let importRpcUrl = $state('http://localhost:9545')
-  // Blank → auto-detect from the RPC (local vs Gnosis mainnet); a value overrides.
+  // Defaults to the shared network setting, like every other dev tool here —
+  // reading a batch from one chain while the app talks to another is a trap.
+  let importRpcUrl = $state(networkSettingsStore.gnosisRpcUrl)
+  // Blank → resolve from the chain the RPC serves; a value overrides.
   let importContractOverride = $state('')
   let importSetDefault = $state(true)
   let importing = $state(false)
   let importMessage = $state('')
   let importError = $state('')
 
-  // Contract address the read will use: the override if set, else the mainnet
-  // deployment — the cluster's chain carries the Swarm contracts at their
-  // mainnet addresses, so local and remote resolve to the same one.
-  const resolvedContract = $derived(resolvePostageStampContractAddress(importRpcUrl.trim()))
-  const effectiveContract = $derived(importContractOverride.trim() || resolvedContract)
+  // Contract address the read will use: the override if set, else whatever the
+  // endpoint's chain reports. Every chain the app supports carries PostageStamp
+  // at the Gnosis address, so that is also the fallback when the probe fails.
+  const DEFAULT_POSTAGE_STAMP = gnosisMainnetSettings().addresses.postageStamp
+  let resolvedContract = $state<string>(DEFAULT_POSTAGE_STAMP)
+  $effect(() => {
+    const url = importRpcUrl.trim()
+    void postageChain(url)
+      .then((chain) => (resolvedContract = chain.settings.addresses.postageStamp))
+      .catch(() => (resolvedContract = DEFAULT_POSTAGE_STAMP))
+  })
 
   async function importBatchById() {
     importError = ''
@@ -622,7 +650,9 @@ Check console logs for details:
 
       const stamp = await fetchExistingBatchFromChain(batchId.toHex(), signerKey, '', {
         rpcUrl: importRpcUrl.trim(),
-        contractAddress: effectiveContract,
+        // Only force an address when the user typed one; otherwise let the
+        // read resolve it from the chain the RPC actually serves.
+        contractAddress: importContractOverride.trim() || undefined,
       })
       if (!stamp) {
         importError =
@@ -644,7 +674,8 @@ Check console logs for details:
   }
 
   // Clear this browser's accounts (which own their apps + stamps) + session.
-  function clearAccount() {
+  /** Every account on the device, not just a selected one. */
+  function clearAccounts() {
     accountsStore.clear()
     sessionStore.clearCurrentAccount()
   }
@@ -664,164 +695,33 @@ Check console logs for details:
     location.reload()
   }
 
-  async function loadBeeStamps() {
-    const url = networkSettingsStore.beeNodeUrl
-    // Record the attempt BEFORE fetching — success or failure. The auto-load
-    // effect is guarded by `url !== lastBeeUrl`; recording only on success made
-    // every failure re-arm the effect, hammering an unreachable node in a loop.
-    lastBeeUrl = url
-    beeStampsLoading = true
-    beeStampsError = ''
-    try {
-      // Tolerate a trailing slash (the default gateway URL has one);
-      // `lastBeeUrl` keeps the raw value so the effect's guard compares equal.
-      const response = await fetch(`${url.replace(/\/$/, '')}/stamps`)
-      if (!response.ok) {
-        const errorText = await response.text()
-        throw new Error(errorText || `HTTP ${response.status}`)
-      }
-      const data = await response.json()
-      beeStamps = data.stamps ?? []
-    } catch (error) {
-      beeStampsError = error instanceof Error ? error.message : String(error)
-      beeStamps = []
-    } finally {
-      beeStampsLoading = false
-    }
-  }
-
-  async function loadChainState() {
-    chainStateError = ''
-    try {
-      const state = await fetchChainState(networkSettingsStore.beeNodeUrl)
-      currentPrice = state.currentPrice
-      // Only autofill if the user hasn't typed (or pre-typed) a value yet.
-      // After the first fill, the user owns this field — switching bee URLs
-      // updates the displayed price but does not clobber their input.
-      if (stampAmount === '') {
-        stampAmount = calculateStampAmountForDays(state.currentPrice, DEFAULT_STAMP_DAYS).toString()
-      }
-    } catch (error) {
-      chainStateError = error instanceof Error ? error.message : String(error)
-      currentPrice = undefined
-    }
-  }
-
-  $effect(() => {
-    const url = networkSettingsStore.beeNodeUrl
-    if (activeTab === 'stamps' && url && url !== lastBeeUrl && !beeStampsLoading) {
-      loadBeeStamps()
-      loadChainState()
-    }
-  })
-
-  function assignAccountStamp() {
-    assignError = ''
-    assignMessage = ''
-    if (!selectedStampId || !selectedAccountId) {
-      assignError = 'Select a stamp and an account first.'
-      return
-    }
-
-    // Validate custom signer if enabled
-    if (useCustomSigner && customSignerError) {
-      assignError = customSignerError
-      return
-    }
-
-    try {
-      const batchId = new BatchId(selectedStampId)
-      const accountId = new EthAddress(selectedAccountId)
-      const account = accountsStore.getAccount(accountId)
-      if (!account) {
-        assignError = 'Account not found.'
-        return
-      }
-
-      // Determine which signer key to use
-      const signerKeyToUse =
-        useCustomSigner && customSignerKey
-          ? new PrivateKey(customSignerKey)
-          : new PrivateKey(selectedSigner)
-
-      // Existence is per-ACCOUNT (`hasLiveStamp`), not the cross-account
-      // runtime view: a batch already owned by another account must still be
-      // added to THIS one, else only the default pointer would move and dangle
-      // at a batch the account doesn't own.
-      if (!account.hasLiveStamp(batchId)) {
-        // Stamp data source: another account's live copy, or the node list.
-        const stored = postageStampsStore.getStamp(batchId)
-        const beeStamp = beeStamps.find((s) => s.batchID === selectedStampId)
-        if (stored) {
-          account.addStamp({ ...stored, signerKey: signerKeyToUse })
-        } else if (beeStamp) {
-          account.addStamp({
-            batchID: batchId,
-            signerKey: signerKeyToUse,
-            utilization: Utils.getStampUsage(
-              beeStamp.utilization,
-              beeStamp.depth,
-              beeStamp.bucketDepth,
-            ),
-            usable: beeStamp.usable,
-            depth: beeStamp.depth,
-            amount: BigInt(beeStamp.amount),
-            bucketDepth: beeStamp.bucketDepth,
-            blockNumber: beeStamp.blockNumber,
-            immutableFlag: beeStamp.immutableFlag,
-            exists: beeStamp.exists,
-            // Without this the drive card's Lifespan section has nothing to
-            // show — the node listing knows the remaining TTL.
-            batchTTL: beeStamp.batchTTL,
-          })
-        } else {
-          assignError = 'Stamp data not found. Reload stamps first.'
-          return
-        }
-      } else if (useCustomSigner) {
-        const owned = account.stamps.find((s) => s.batchID.equals(batchId))
-        if (!owned) {
-          assignError = 'Stamp not found on the account.'
-          return
-        }
-        // Compare by value — `signerKey` is a bee-js PrivateKey, so `!==` would
-        // always be true (distinct instances) and re-add the stamp needlessly.
-        if (!owned.signerKey.equals(signerKeyToUse)) {
-          account.removeStamp(batchId)
-          account.addStamp({ ...owned, signerKey: signerKeyToUse })
-        }
-      }
-
-      if (assignSetDefault) {
-        account.setDefaultStamp(batchId)
-        assignMessage = `✅ Set account stamp for ${accountId.toHex().slice(0, 8)}…`
-      } else {
-        assignMessage = `✅ Added stamp to ${accountId.toHex().slice(0, 8)}…`
-      }
-    } catch (error) {
-      assignError = error instanceof Error ? error.message : String(error)
-    }
-  }
-
   // Clears the account's DEFAULT-stamp pointer only; the stamp stays in the
   // account's stamps (delete it outright in "Stored Stamps" above). Assign is
   // the symmetric op — it sets the default.
-  function clearDefaultStamp() {
-    assignError = ''
-    assignMessage = ''
-    if (!selectedAccountId) {
-      assignError = 'Select an account first.'
-      return
-    }
-    const accountId = new EthAddress(selectedAccountId)
-    accountsStore.getAccount(accountId)?.setDefaultStamp(undefined)
-    assignMessage = `✅ Cleared default stamp for ${selectedAccountId.slice(0, 8)}…`
-  }
 
   const LABEL_CLASS = 'flex flex-col gap-1.5 text-sm'
   const LABEL_TEXT_CLASS = 'text-muted-foreground'
   const CARD_CLASS = 'flex flex-col gap-2 rounded-lg border bg-card p-4'
+
+  // Mock stamp widget settings — `devSettingsStore` is the single source of
+  // truth (durable + cross-tab); the controls bind straight to its setters via
+  // function bindings, so there is no local mirror to drift.
+  const MOCK_RESULT_OPTIONS = [
+    { value: 'success', label: 'Success (creates a drive)' },
+    { value: 'error', label: 'Error (purchase failed)' },
+  ]
 </script>
+
+{#snippet chainBanner(label: string, detail: string, alarming: boolean)}
+  <div
+    class="rounded-md border px-4 py-3 text-sm {alarming
+      ? 'border-destructive bg-destructive/10 text-destructive font-medium'
+      : 'border-border text-muted-foreground'}"
+  >
+    <span>{label}</span>
+    <span class="font-mono">{detail}</span>
+  </div>
+{/snippet}
 
 {#snippet copyRow(label: string, value: string, mono = true)}
   <div class="flex flex-col gap-1.5">
@@ -844,7 +744,47 @@ Check console logs for details:
 <div class="mx-auto flex w-full max-w-3xl flex-col gap-8 p-8">
   <h2 class="text-xl font-bold">Developer Tools</h2>
 
+  <!--
+    Which chain these tools are pointed at. Every action on this page spends,
+    and a dev chain reports the same chain id as mainnet on purpose — so the
+    only honest answer comes from the genesis hash. Red is for MAINNET: on this
+    page that is the state nobody intends to be in.
+  -->
+  {#await chainIdentity(networkSettingsStore.gnosisRpcUrl)}
+    {@render chainBanner('Checking the chain at ', networkSettingsStore.gnosisRpcUrl, false)}
+  {:then identity}
+    {#if identity.isMainnet}
+      {@render chainBanner(
+        'GNOSIS MAINNET — these tools spend real funds. ',
+        networkSettingsStore.gnosisRpcUrl,
+        true,
+      )}
+    {:else}
+      {@render chainBanner(
+        'Local dev chain, nothing here is real. ',
+        networkSettingsStore.gnosisRpcUrl,
+        false,
+      )}
+    {/if}
+  {:catch}
+    {@render chainBanner('No chain reachable at ', networkSettingsStore.gnosisRpcUrl, true)}
+  {/await}
+
   <Tabs {tabs} bind:value={activeTab} />
+
+  <!--
+    Under the tabs, and only for the tabs that act on ONE account: Chain signs
+    with its derived postage signer, Devices lists its devices. Overview and
+    Node read across every account, so a selector there would imply a scoping
+    they do not have — and placing it above would shift the tabs each time it
+    appeared.
+  -->
+  {#if activeTab === 'chain' || activeTab === 'devices'}
+    <label class={LABEL_CLASS}>
+      <span class={LABEL_TEXT_CLASS}>Account these tools act on</span>
+      <Select options={accountOptions} bind:value={selectedAccountId} />
+    </label>
+  {/if}
 
   <!-- Overview Tab -->
   {#if activeTab === 'overview'}
@@ -858,20 +798,25 @@ Check console logs for details:
     <div class="flex flex-col gap-4">
       <div class="flex flex-col gap-2">
         <h4 class="text-sm font-semibold">Local Bee Endpoints</h4>
+        <!--
+          These hrefs are absolute http(s) endpoints read from network settings —
+          never app routes — which a dynamic href cannot prove to the rule.
+        -->
+        <!-- eslint-disable svelte/no-navigation-without-resolve -->
         <div class="flex items-center gap-2">
-          <StatusDot endpoint="http://localhost:1633" />
-          <span class="font-mono text-sm">Queen API:</span>
+          <StatusDot endpoint={networkSettingsStore.beeNodeUrl} />
+          <span class="font-mono text-sm">Bee node:</span>
           <a
-            href="http://localhost:1633"
+            href={networkSettingsStore.beeNodeUrl}
             target="_blank"
             rel="noopener"
-            class="text-primary font-mono text-sm">http://localhost:1633</a
+            class="text-primary font-mono text-sm">{networkSettingsStore.beeNodeUrl}</a
           >
-          <CopyButton text="http://localhost:1633" />
+          <CopyButton text={networkSettingsStore.beeNodeUrl} />
         </div>
         <div class="flex items-center gap-2">
           <StatusDot endpoint="http://localhost:16331" />
-          <span class="font-mono text-sm">Worker API:</span>
+          <span class="font-mono text-sm">Cluster worker:</span>
           <a
             href="http://localhost:16331"
             target="_blank"
@@ -881,16 +826,22 @@ Check console logs for details:
           <CopyButton text="http://localhost:16331" />
         </div>
         <div class="flex items-center gap-2">
-          <StatusDot endpoint="http://localhost:9545" method="json-rpc" />
-          <span class="font-mono text-sm">Blockchain RPC:</span>
+          <StatusDot endpoint={networkSettingsStore.gnosisRpcUrl} method="json-rpc" />
+          <!--
+            Not labelled "(fake)": this endpoint is whatever it is configured to
+            be, and the banner above says which. Asserting it here would
+            contradict that banner the moment someone points at mainnet.
+          -->
+          <span class="font-mono text-sm">Gnosis Chain RPC:</span>
           <a
-            href="http://localhost:9545"
+            href={networkSettingsStore.gnosisRpcUrl}
             target="_blank"
             rel="noopener"
-            class="text-primary font-mono text-sm">http://localhost:9545</a
+            class="text-primary font-mono text-sm">{networkSettingsStore.gnosisRpcUrl}</a
           >
-          <CopyButton text="http://localhost:9545" />
+          <CopyButton text={networkSettingsStore.gnosisRpcUrl} />
         </div>
+        <!-- eslint-enable svelte/no-navigation-without-resolve -->
       </div>
 
       <div class="flex flex-col gap-2">
@@ -915,183 +866,16 @@ Check console logs for details:
           connection required).
         </p>
         <div class="flex gap-2">
-          <Button variant="destructive" onclick={clearAccount}>Clear account</Button>
-          <Button variant="destructive" onclick={clearAll}>Clear all</Button>
+          <Button variant="destructive" onclick={clearAccounts}>Clear accounts</Button>
+          <Button variant="destructive" onclick={clearAll}>Clear everything</Button>
         </div>
       </div>
     </div>
   {/if}
 
-  <!-- Stamps Tab -->
-  {#if activeTab === 'stamps'}
+  <!-- Node Tab: everything that talks to the Bee node -->
+  {#if activeTab === 'node'}
     <div class="flex flex-col gap-4">
-      <h3 class="text-lg font-semibold">Mock stamp purchase</h3>
-      <p class="text-muted-foreground text-sm">
-        Simulate the product <strong>Add drive</strong> flow (Storage tab / Upgrade) without a real cross-chain
-        payment. When enabled, the purchase widget resolves locally after a short delay.
-      </p>
-      <label class="flex items-center gap-2">
-        <Switch
-          bind:checked={
-            () => devSettingsStore.data.mockStampEnabled,
-            (enabled) => devSettingsStore.setMockStampEnabled(enabled)
-          }
-          aria-label="Enable mock stamp purchase"
-        />
-        <span class="text-sm">Enable mock purchases</span>
-      </label>
-      {#if devSettingsStore.data.mockStampEnabled}
-        <label class="flex items-center gap-2">
-          <Switch
-            bind:checked={
-              () => devSettingsStore.data.mockStampPopup,
-              (popup) => devSettingsStore.setMockStampPopup(popup)
-            }
-            aria-label="Open widget popup while mocking"
-          />
-          <span class="text-sm"
-            >Open widget popup (off = local, works where popups are blocked)</span
-          >
-        </label>
-        <label class={`${LABEL_CLASS} w-64`}>
-          <span class={LABEL_TEXT_CLASS}>Outcome</span>
-          <Select
-            options={MOCK_RESULT_OPTIONS}
-            bind:value={
-              () => devSettingsStore.data.mockStampResult,
-              (result) =>
-                devSettingsStore.setMockStampResult(result === 'error' ? 'error' : 'success')
-            }
-          />
-        </label>
-      {/if}
-
-      <div class="bg-border my-4 h-px"></div>
-
-      <h3 class="text-lg font-semibold">Buy Postage Stamp</h3>
-      <p class="text-sm">Buy a postage stamp on the local blockchain for testing uploads.</p>
-
-      <div class="flex flex-col gap-2">
-        <label class={LABEL_CLASS}>
-          <span class={LABEL_TEXT_CLASS}>Bee Node URL (network settings)</span>
-          <div class="flex gap-2">
-            <Input bind:value={networkSettingsStore.beeNodeUrl} />
-            <Button variant="secondary" onclick={networkSettingsStore.reset}>Reset</Button>
-          </div>
-        </label>
-        <p class="text-muted-foreground text-sm">
-          One URL for all dev tooling — stamp buying/listing here, plus sync, account refresh and
-          the retrievability checks below. Persisted across reloads; point it at
-          http://localhost:1633 for the local cluster.
-        </p>
-        <div class="flex gap-4">
-          <label class={`${LABEL_CLASS} flex-1`}>
-            <span class={LABEL_TEXT_CLASS}>Amount</span>
-            <Input bind:value={stampAmount} />
-          </label>
-          <label class={`${LABEL_CLASS} w-32`}>
-            <span class={LABEL_TEXT_CLASS}>Depth (17-40)</span>
-            <Input bind:value={stampDepth} />
-          </label>
-        </div>
-        {#if currentPrice !== undefined}
-          {@const minAmount = calculateStampAmountForDays(currentPrice, 1)}
-          <p class="text-muted-foreground text-sm">
-            Chain price: {currentPrice.toLocaleString()} PLUR/chunk/block · 24h min: {minAmount.toLocaleString()}
-            PLUR · default fills {DEFAULT_STAMP_DAYS}d validity
-          </p>
-        {:else if chainStateError}
-          <p class="text-destructive text-sm">
-            Could not fetch chainstate from Bee: {chainStateError}
-          </p>
-        {/if}
-        <label class={LABEL_CLASS}>
-          <span class={LABEL_TEXT_CLASS}>Signer Key</span>
-          <Select options={KNOWN_SIGNERS} bind:value={selectedSigner} />
-        </label>
-      </div>
-
-      <Button onclick={buyStamp} disabled={buying || !stampAmount}>
-        {buying ? 'Buying...' : 'Buy Stamp'}
-      </Button>
-
-      {#if stampResult}
-        {@const batchId = stampResult.batchID}
-        {@const txHash = stampResult.txHash}
-        <div class={CARD_CLASS}>
-          <p class="font-mono text-sm font-semibold">✅ Stamp purchased!</p>
-          {@render copyRow('Batch ID', batchId)}
-          <div class="flex gap-8">
-            {@render copyRow('Amount', stampAmount)}
-            {@render copyRow('Depth', stampDepth)}
-          </div>
-          {@render copyRow('Signer Key (for Stamper)', selectedSigner)}
-          {@render copyRow('Tx Hash', txHash)}
-          <p class="text-muted-foreground mt-2 text-sm">
-            Note: Wait ~30s for stamp to become usable.
-          </p>
-        </div>
-      {/if}
-
-      {#if stampError}
-        <div class={CARD_CLASS}>
-          <p class="text-destructive font-mono text-sm">❌ {stampError}</p>
-        </div>
-      {/if}
-
-      <div class="bg-border my-4 h-px"></div>
-
-      <h3 class="text-lg font-semibold">Import batch by ID</h3>
-      <p class="text-muted-foreground text-sm">
-        Read a batch's parameters straight from the PostageStamp contract on-chain (not from a Bee
-        node), so any batch id works even if the configured node never saw it. The signer key is not
-        on-chain — paste the one the batch was bought with.
-      </p>
-      <div class="flex flex-col gap-2">
-        <label class={LABEL_CLASS}>
-          <span class={LABEL_TEXT_CLASS}>Batch ID</span>
-          <Input bind:value={importBatchId} placeholder="0x… (64 hex chars)" />
-        </label>
-        <label class={LABEL_CLASS}>
-          <span class={LABEL_TEXT_CLASS}>Signer Key</span>
-          <Input bind:value={importSignerKey} placeholder="64 hex chars" />
-        </label>
-        <label class={LABEL_CLASS}>
-          <span class={LABEL_TEXT_CLASS}>Gnosis RPC URL</span>
-          <Input bind:value={importRpcUrl} />
-        </label>
-        <label class={LABEL_CLASS}>
-          <span class={LABEL_TEXT_CLASS}>PostageStamp contract</span>
-          <Input bind:value={importContractOverride} placeholder={resolvedContract} />
-          <span class="text-muted-foreground text-xs">
-            Auto from RPC: <span class="font-mono">{resolvedContract}</span> — leave blank to use it (local
-            RPC → local deployment, else Gnosis mainnet).
-          </span>
-        </label>
-        <label class={LABEL_CLASS}>
-          <span class={LABEL_TEXT_CLASS}>Account</span>
-          <Select options={accountOptions} bind:value={selectedAccountId} />
-        </label>
-        <label class="flex cursor-pointer items-center gap-2 text-sm">
-          <input type="checkbox" bind:checked={importSetDefault} />
-          Set as account default
-        </label>
-      </div>
-      <Button
-        onclick={importBatchById}
-        disabled={importing || !importBatchId || !importSignerKey || !selectedAccountId}
-      >
-        {importing ? 'Importing…' : 'Import batch'}
-      </Button>
-      {#if importMessage}
-        <p class="text-success text-sm">{importMessage}</p>
-      {/if}
-      {#if importError}
-        <p class="text-destructive text-sm">{importError}</p>
-      {/if}
-
-      <div class="bg-border my-4 h-px"></div>
-
       <h3 class="text-lg font-semibold">Stored Stamps (local)</h3>
       <p class="text-muted-foreground text-sm">
         The postage batches saved in this browser. Copy these fields before clearing storage — paste
@@ -1184,6 +968,32 @@ Check console logs for details:
 
       <div class="bg-border my-4 h-px"></div>
 
+      <h3 class="text-lg font-semibold">Manual Sync Testing</h3>
+      <p class="text-sm">
+        Trigger a manual sync for ALL accounts to test postage stamp utilization tracking.
+      </p>
+      <div class="flex gap-4">
+        <Button onclick={triggerManualSync}>Sync All Accounts</Button>
+      </div>
+
+      {#if syncMessage}
+        <div class="flex flex-col gap-4 rounded-lg border bg-card p-4 whitespace-pre-wrap">
+          <p class="font-mono text-sm">{syncMessage}</p>
+        </div>
+      {/if}
+
+      <div class="flex flex-col gap-2">
+        <p class="text-muted-foreground text-sm">Requirements for sync:</p>
+        <p class="text-muted-foreground font-mono text-sm">
+          • At least one account with a default postage stamp
+        </p>
+        <p class="text-muted-foreground font-mono text-sm">
+          • Open browser console to see detailed logs
+        </p>
+      </div>
+
+      <div class="bg-border my-4 h-px"></div>
+
       <h3 class="text-lg font-semibold">Partition tuning</h3>
       <p class="text-muted-foreground text-sm">
         Tune the multi-device intent-round timing for this gateway's propagation delay. Blank =
@@ -1211,92 +1021,237 @@ Check console logs for details:
           <p class="text-muted-foreground text-sm">{tuningSaved}</p>
         {/if}
       </div>
+    </div>
+  {/if}
+
+  <!-- Chain Tab -->
+  {#if activeTab === 'chain'}
+    <div class="flex flex-col gap-4">
+      <h3 class="text-lg font-semibold">Simulated purchase</h3>
+      <p class="text-muted-foreground text-sm">
+        Simulate the product <strong>Add drive</strong> flow (Storage tab / Upgrade) without a real
+        cross-chain payment — the purchase widget only settles on mainnet, so this is what makes
+        that flow reachable at all here. The batch it leaves behind is fabricated, which is why
+        extend and resize cannot act on it; for a drive backed by a real batch, use
+        <strong>Create drive to test with</strong> below.
+      </p>
+      <label class="flex items-center gap-2">
+        <Switch
+          bind:checked={
+            () => devSettingsStore.data.mockStampEnabled,
+            (enabled) => devSettingsStore.setMockStampEnabled(enabled)
+          }
+          aria-label="Enable mock stamp purchase"
+        />
+        <span class="text-sm">Enable mock purchases</span>
+      </label>
+      {#if devSettingsStore.data.mockStampEnabled}
+        <label class="flex items-center gap-2">
+          <Switch
+            bind:checked={
+              () => devSettingsStore.data.mockStampPopup,
+              (popup) => devSettingsStore.setMockStampPopup(popup)
+            }
+            aria-label="Open widget popup while mocking"
+          />
+          <span class="text-sm"
+            >Open widget popup (off = local, works where popups are blocked)</span
+          >
+        </label>
+        <label class={`${LABEL_CLASS} w-64`}>
+          <span class={LABEL_TEXT_CLASS}>Outcome</span>
+          <Select
+            options={MOCK_RESULT_OPTIONS}
+            bind:value={
+              () => devSettingsStore.data.mockStampResult,
+              (result) =>
+                devSettingsStore.setMockStampResult(result === 'error' ? 'error' : 'success')
+            }
+          />
+        </label>
+      {/if}
 
       <div class="bg-border my-4 h-px"></div>
 
-      <div class="flex items-center justify-between">
-        <h3 class="text-lg font-semibold">Existing Stamps (Bee Node)</h3>
-        <Button variant="secondary" onclick={loadBeeStamps} disabled={beeStampsLoading}>
-          {beeStampsLoading ? 'Refreshing...' : 'Refresh'}
+      <div class="flex items-center gap-1">
+        <h3 class="text-lg font-semibold">Faucet</h3>
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label="About the faucet"
+          aria-expanded={faucetHelpOpen}
+          onclick={() => (faucetHelpOpen = !faucetHelpOpen)}
+        >
+          <Info class="size-4" />
         </Button>
       </div>
-      {#if beeStampsError}
-        <p class="text-destructive text-sm">❌ {beeStampsError}</p>
-      {/if}
-      {#if beeStamps.length === 0}
-        <p class="text-muted-foreground text-sm">No stamps found on the Bee node.</p>
-      {:else}
-        <div class="flex flex-col gap-2">
-          {#each beeStamps as stamp (stamp.batchID)}
-            {@const assignment = stampAssignments.get(stamp.batchID)}
-            <div class="flex flex-col gap-2 rounded-lg border bg-card p-4">
-              <div class="flex items-center justify-between">
-                <p class="font-mono text-sm">{stamp.batchID}</p>
-                <CopyButton text={stamp.batchID} />
-              </div>
-              <div class="text-muted-foreground flex flex-wrap gap-2 text-sm">
-                <span>Depth: {stamp.depth}</span>
-                <span>Utilization: {stamp.utilization}</span>
-                <span>Expires: {formatStampExpiry(stamp.batchTTL)}</span>
-                <span>Account: {assignment?.account ?? '—'}</span>
-              </div>
-            </div>
-          {/each}
+
+      {#if faucetHelpOpen}
+        <div class={CARD_CLASS}>
+          <p class="text-muted-foreground text-sm">
+            Hands <em>any</em> address money on the dev chain — a plain transfer from the faucet the bake
+            stocked, since the BZZ pool here is real and thin and only a purchase is worth spending it
+            on.
+          </p>
+          <p class="text-muted-foreground text-sm">
+            <strong>Anvil account 0</strong> starts with 10 000 xDAI and no BZZ, which is the bake faucet's
+            to give. Importing its key into MetaMask is the shortcut to a wallet that already holds something
+            here.
+          </p>
+          {@render copyRow('Address', ANVIL_ACCOUNT.address)}
+          {@render copyRow('Private key', ANVIL_ACCOUNT.privateKey)}
         </div>
       {/if}
 
-      <div class="bg-border my-4 h-px"></div>
-
-      <h3 class="text-lg font-semibold">Assign stamp to account</h3>
       <div class="flex flex-col gap-2">
         <label class={LABEL_CLASS}>
-          <span class={LABEL_TEXT_CLASS}>Stamp</span>
-          <Select options={stampOptions} bind:value={selectedStampId} />
+          <span class={LABEL_TEXT_CLASS}>Recipient</span>
+          <Input bind:value={faucetTo} placeholder="0x… any address" />
+        </label>
+        {#if faucetTo.trim() && !faucetRecipient}
+          <span class="text-destructive text-sm">Not an address.</span>
+        {/if}
+      </div>
+
+      {#if fundsError}
+        <p class="text-destructive text-sm">{fundsError}</p>
+      {/if}
+      {#if balanceRows.length}
+        <div class="grid grid-cols-[auto_1fr_auto_auto] items-center gap-x-4 gap-y-1 text-sm">
+          <span></span>
+          <span></span>
+          <span class="text-muted-foreground text-right text-xs">xDAI</span>
+          <span class="text-muted-foreground text-right text-xs">BZZ</span>
+          {#each balanceRows as row (row.label)}
+            <span class="text-muted-foreground">{row.label}</span>
+            <span class="font-mono text-xs break-all">{row.address}</span>
+            <span class="text-right font-mono">{row.xdai}</span>
+            <span class="text-right font-mono">{row.bzz}</span>
+          {/each}
+        </div>
+      {:else}
+        <p class="text-muted-foreground text-sm">Enter a recipient to see balances.</p>
+      {/if}
+
+      <div class="flex flex-wrap items-end gap-2">
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Amount</span>
+          <Input bind:value={faucetTyped} class="w-32" />
         </label>
         <label class={LABEL_CLASS}>
-          <span class={LABEL_TEXT_CLASS}>Account</span>
-          <Select options={accountOptions} bind:value={selectedAccountId} />
+          <span class={LABEL_TEXT_CLASS}>Token</span>
+          <Select
+            options={faucetTokenOptions}
+            bind:value={faucetToken}
+            class="w-32"
+            onchange={pickFaucetToken}
+          />
         </label>
+        <Button
+          disabled={faucetBusy || !faucetRecipient || faucetValue === 0n}
+          onclick={sendFaucetFunds}
+        >
+          {faucetBusy ? 'Sending…' : 'Send'}
+        </Button>
+        <Button variant="secondary" disabled={!faucetRecipient} onclick={refreshFunds}>
+          Refresh
+        </Button>
+      </div>
+      {#if faucetMessage}
+        <p class="text-sm break-all">{faucetMessage}</p>
+      {/if}
+      {#if faucetError}
+        <p class="text-destructive text-sm">{faucetError}</p>
+      {/if}
 
-        <label class="flex cursor-pointer items-center gap-2 text-sm">
-          <input type="checkbox" bind:checked={useCustomSigner} />
-          Use custom signer key
+      <div class="bg-border my-4 h-px"></div>
+
+      <h3 class="text-lg font-semibold">On-chain drive tooling</h3>
+      <p class="text-muted-foreground text-sm">
+        Creates a batch the account's own postage signer OWNS on chain, which the purchase widget
+        cannot do off mainnet. That ownership is the point: it is what the paid drive operations
+        will need once they are signed by that signer rather than by a Bee node. The batch is bought
+        rather than granted — <strong>Create owned batch</strong> runs the widget's real step list against
+        the local chain's BZZ pool, swapping rather than drawing on the faucet above, since the purchase
+        is the one leg worth simulating faithfully.
+      </p>
+      <div class="flex flex-wrap gap-2">
+        <Button
+          variant="secondary"
+          disabled={chainToolBusy || !selectedAccountId}
+          onclick={() =>
+            runChainTool(
+              'Created owned batch',
+              async (key) => (await createOwnedBatchOnChain(key)).batchId,
+            )}
+        >
+          Create owned batch (depth 20)
+        </Button>
+        <Button
+          disabled={chainToolBusy || !selectedAccountId}
+          onclick={() => runChainTool('Created drive', (_key, account) => createTestDrive(account))}
+        >
+          Create drive to test with
+        </Button>
+      </div>
+      <p class="text-muted-foreground text-sm">
+        Acts on the account selected at the top of the page. For the normal path just use
+        <em>Add drive</em> — off mainnet it creates the batch the same way. These buttons are for
+        driving the chain directly: topping the signer up, or making a batch to attach by hand via
+        <em>Add drive → Use existing</em>.
+      </p>
+      {#if chainToolMessage}
+        <p class="text-sm break-all">{chainToolMessage}</p>
+      {/if}
+      {#if chainToolError}
+        <p class="text-destructive text-sm">{chainToolError}</p>
+      {/if}
+
+      <div class="bg-border my-4 h-px"></div>
+
+      <h3 class="text-lg font-semibold">Import batch by ID</h3>
+      <p class="text-muted-foreground text-sm">
+        Read a batch's parameters straight from the PostageStamp contract on-chain (not from a Bee
+        node), so any batch id works even if the configured node never saw it. The signer key is not
+        on-chain — paste the one the batch was bought with.
+      </p>
+      <div class="flex flex-col gap-2">
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Batch ID</span>
+          <Input bind:value={importBatchId} placeholder="0x… (64 hex chars)" />
         </label>
-
-        {#if useCustomSigner}
-          <label class={LABEL_CLASS}>
-            <span class={LABEL_TEXT_CLASS}>Custom Signer Key</span>
-            <Input bind:value={customSignerKey} aria-invalid={!!customSignerError} />
-            {#if customSignerError}
-              <span class="text-destructive text-xs">{customSignerError}</span>
-            {/if}
-          </label>
-        {/if}
-
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Signer Key</span>
+          <Input bind:value={importSignerKey} placeholder="64 hex chars" />
+        </label>
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>Gnosis RPC URL</span>
+          <Input bind:value={importRpcUrl} />
+        </label>
+        <label class={LABEL_CLASS}>
+          <span class={LABEL_TEXT_CLASS}>PostageStamp contract</span>
+          <Input bind:value={importContractOverride} placeholder={resolvedContract} />
+          <span class="text-muted-foreground text-xs">
+            Auto from RPC: <span class="font-mono">{resolvedContract}</span> — leave blank to use it (local
+            RPC → local deployment, else Gnosis mainnet).
+          </span>
+        </label>
         <label class="flex cursor-pointer items-center gap-2 text-sm">
-          <input type="checkbox" bind:checked={assignSetDefault} />
+          <input type="checkbox" bind:checked={importSetDefault} />
           Set as account default
         </label>
       </div>
-
-      <div class="flex items-center gap-2">
-        <Button onclick={assignAccountStamp} disabled={!selectedStampId || !selectedAccountId}>
-          {assignSetDefault ? 'Set account stamp' : 'Add stamp to account'}
-        </Button>
-        <Button
-          variant="destructive"
-          onclick={clearDefaultStamp}
-          disabled={!accountHasDefaultStamp}
-        >
-          Clear default stamp
-        </Button>
-      </div>
-
-      {#if assignMessage}
-        <p class="text-success text-sm">{assignMessage}</p>
+      <Button
+        onclick={importBatchById}
+        disabled={importing || !importBatchId || !importSignerKey || !selectedAccountId}
+      >
+        {importing ? 'Importing…' : 'Import batch'}
+      </Button>
+      {#if importMessage}
+        <p class="text-success text-sm">{importMessage}</p>
       {/if}
-      {#if assignError}
-        <p class="text-destructive text-sm">{assignError}</p>
+      {#if importError}
+        <p class="text-destructive text-sm">{importError}</p>
       {/if}
 
       <div class="bg-border my-4 h-px"></div>
@@ -1317,35 +1272,6 @@ Check console logs for details:
     </div>
   {/if}
 
-  <!-- Sync Tab -->
-  {#if activeTab === 'sync'}
-    <div class="flex flex-col gap-4">
-      <h3 class="text-lg font-semibold">Manual Sync Testing</h3>
-      <p class="text-sm">
-        Trigger a manual sync for ALL accounts to test postage stamp utilization tracking.
-      </p>
-      <div class="flex gap-4">
-        <Button onclick={triggerManualSync}>Sync All Accounts</Button>
-      </div>
-
-      {#if syncMessage}
-        <div class="flex flex-col gap-4 rounded-lg border bg-card p-4 whitespace-pre-wrap">
-          <p class="font-mono text-sm">{syncMessage}</p>
-        </div>
-      {/if}
-
-      <div class="flex flex-col gap-2">
-        <p class="text-muted-foreground text-sm">Requirements for sync:</p>
-        <p class="text-muted-foreground font-mono text-sm">
-          • At least one account with a default postage stamp
-        </p>
-        <p class="text-muted-foreground font-mono text-sm">
-          • Open browser console to see detailed logs
-        </p>
-      </div>
-    </div>
-  {/if}
-
   <!-- Devices Tab -->
   {#if activeTab === 'devices'}
     <div class="flex flex-col gap-4">
@@ -1353,10 +1279,6 @@ Check console logs for details:
       <p class="text-sm">
         Inspect the devices registered to an account and which partitions they currently hold.
       </p>
-      <label class={LABEL_CLASS}>
-        <span class={LABEL_TEXT_CLASS}>Account</span>
-        <Select options={accountOptions} bind:value={selectedAccountId} />
-      </label>
       {#if selectedAccount}
         {#key selectedAccountId}
           <DeviceList account={selectedAccount} />


### PR DESCRIPTION
**Stack 3/6** — base `stack/2-multichain` ([#532](https://github.com/snaha/swarm-id/pull/532)). Part of #309. (The specs that used to sit between them, #539, are closed — they land with the code in [#533](https://github.com/snaha/swarm-id/pull/533).)

`/dev` was organised around a Bee node buying stamps for you, which stops being how any of this works once drives are paid for on-chain. It is now organised by what each tab talks to — and it lands **ahead** of that change, so the change itself can be tried by hand.

## Why this comes first

[#533](https://github.com/snaha/swarm-id/pull/533) removes the simulated settlement, so every purchase becomes a real on-chain buy. Without this PR there is no way for a person to fund one locally: no faucet, no dev script, and the widget only settles on mainnet. The e2e suites were fine — they fund out of band — but a reviewer clicking through had nothing.

## The Chain tab

- **Faucet** — any amount of xDAI or BZZ, to any address, from the float the chain snapshot bakes in. Prefilled with the selected account's postage signer.
- **Create drive to test with** — creates a real batch the account's **own postage signer owns on chain**, and attaches it as an ordinary drive. That replaces six copy-paste steps through Import batch, and it is the fixture `drive-onchain.test.ts` uses later in the stack.
- **Create expiring drive** — the same thing funded for a single day, so the product's "Expires soon" warning can be produced on purpose. The ordinary button funds 15 days, clear of the 7-day threshold: a fixture that is born flagged teaches everyone to read that warning as noise.
- A **`Connected to: Local | Production | Custom`** menu in the page's top right, switching both endpoints at once. It lives here rather than in the product's Network settings dialog, which ships; `Custom` names an endpoint that is neither preset, and editing that one opens the product dialog rather than a second copy of its fields.

## Which chain you are pointed at, said wherever it is asked

Three surfaces need the same answer, so all three now give it, from the same `chainIdentity` probe:

- the **`/dev` banner** — `GNOSIS MAINNET — these tools spend real funds` in red, or `Local dev chain, nothing here is real`;
- a **`Connected to: …` line under the RPC field in Network settings** — `Gnosis Chain`, `Gnosis Chain (fake) — funds here are not real`, or `Not reachable`. The URL is otherwise the only clue a user has, and a stale `localhost` looks exactly like the real thing. It probes the *saved* value, not the field being typed into, so editing does not fire a request per keystroke.

The Overview row for that endpoint is labelled plainly, `Gnosis Chain RPC:` — an earlier revision of this PR hardcoded `(fake)` there, which contradicted the MAINNET banner two lines above it the moment anyone pointed at the real chain. The banner asserts the identity; the row just names the endpoint.

## `$lib/payment/chain.ts` is new, and is why any of this can run here

Which chain an endpoint serves — **by genesis hash, not chain id**, since the local chain reports mainnet's 100 on purpose — and a client for it. The question is asked well before any operation exists: the faucet, the banner and the settings dialog all need it. `contract.ts` now resolves the PostageStamp address through it rather than by hostname, which is the same correction [#531](https://github.com/snaha/swarm-id/pull/531) made in the library.

It is extracted from `postage-onchain.ts` in [#533](https://github.com/snaha/swarm-id/pull/533), which keeps the operations and imports the chain resolution.

### An unproven genesis must not read as "fake"

Review caught the first cut failing open. `probeGenesisHash` returned `data.result?.hash`, so an endpoint answering a JSON-RPC `error` — a rate-limited or pruned Gnosis node — yielded `undefined`, which is not the mainnet genesis, which reads as *not mainnet*. A stub answering `eth_chainId: 0x64` and refusing `eth_getBlockByNumber` was duly labelled `Local dev chain, nothing here is real`, under which the faucet and **Create owned batch** spend real money.

Both probes now go through one checked helper that rejects on non-2xx, on a JSON-RPC `error`, and on a missing result. An endpoint that cannot prove its genesis is `No chain reachable` — loud, and in the safe direction. (This also answers Copilot's note about unchecked HTTP/JSON-RPC status on `probeChainId`; its other suggestion, replacing `AbortSignal.timeout()`, I left alone — it is the established pattern in `multichain/src/fetch.ts` and its browser support is a strictly older baseline than the passkeys this app already requires.)

### The banner could report a healthy endpoint dead

`{#await chainIdentity(...)}` was unkeyed, so switching away from an unreachable RPC kept rendering the failed branch — with the *new* url interpolated into it, since the message reads the url from the store rather than the promise. Selecting a working endpoint showed `No chain reachable at <it>` instantly, no probe involved. The block is now keyed on the endpoint.

## The mock stamp purchase stays, for now

Moved onto the Chain tab, not deleted. It is still the only way the product Add-drive flow completes off mainnet, and `mockStampEnabled` defaults to `import.meta.env.DEV` — **on** — so removing the toggles here would strand anyone who has it enabled with no way to turn it off. It goes with the flow it fakes, in [#533](https://github.com/snaha/swarm-id/pull/533).

## Two more things review turned up

- **The node has not seen the batch yet.** A batch bought straight from the contract exists on chain before Bee's chain sync reaches it, and stamping with it until then is rejected `400 invalid batch id` — so attaching the drive immediately made the next account sync fail for no visible reason. `createTestDrive` now waits for `/status` to pass the batch's block, best effort.
- **The mock ignored the size you picked.** It settled a fabricated batch at a hardcoded depth 20, so a mocked Add drive at 97.7 MB produced a 600 MB drive. The real widget chooses the depth itself, which is why no plain `depth` option exists; a mock-only `mockDepth` now carries the selection through.

## Verification

`pnpm check:all` green. Exercised by hand against a `--fresh --pull` bee-compose 0.2.0 cluster:

| Step | Result |
| --- | --- |
| Banner, public RPC | "GNOSIS MAINNET — these tools spend real funds" |
| Banner, local chain | "Local dev chain, nothing here is real" — correct despite chain id 100 |
| Settings, public RPC | "Connected to: Gnosis Chain" |
| Settings, local chain | "Connected to: Gnosis Chain (fake) — funds here are not real" — chain id 100, genesis says otherwise |
| Settings, nothing running | "Connected to: Not reachable", in the destructive tone |
| PostageStamp resolution | mainnet address `0x45a15023…` on localhost |
| Faucet | signer 0 → 0.05 xDAI / 1 BZZ; faucet 100 → 99.9499, 250 → 249 |
| Create drive to test with | batch `f91fd63d…`, depth 20 |
| On-chain owner | `0xe21393b4…58f` — the account's derived postage signer |
| Product UI | an ordinary drive, 600 MB |
| Drive lifetimes | 15.00 d default → `15 days left`; 1.00 d expiring → `Expires soon` |
| Genesis stub (chain id 100, genesis refused) | `No chain reachable` — was `Local dev chain, nothing here is real` |
| Dead RPC → Use local | reports the live chain; was stuck on the failure branch |
| Endpoints, production | `Cluster worker` row hidden; no dead `localhost:16331` |
| Mocked Add drive at 97.7 MB | a 97.7 MB drive |
| Batch visible to node | SOC upload accepted after the wait (`ed32ed15…`) |

A SOC upload stamped with the on-chain batch was accepted, so the drive is genuinely usable rather than merely listed.

Pre-existing `rejectAfter`/`Promise.race` timeout leaks found while reviewing this are filed separately as #546 — none of them are touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

